### PR TITLE
Fix: log-agent hooks read .agent_type instead of .agent_name

### DIFF
--- a/.claude/hooks/log-agent-stop.sh
+++ b/.claude/hooks/log-agent-stop.sh
@@ -2,16 +2,21 @@
 # Claude Code SubagentStop hook: Log agent completion for audit trail
 # Tracks when agents finish and their outcome
 #
-# Input schema (SubagentStop):
-# { "agent_id": "agent-abc123", "agent_name": "game-designer", ... }
+# Input schema (SubagentStop) — per Claude Code hooks reference:
+# { "session_id": "...", "agent_id": "agent-abc123", "agent_type": "Explore",
+#   "agent_transcript_path": "...", "last_assistant_message": "...", ... }
+#
+# The agent name is in `agent_type`, NOT `agent_name`. Reading `.agent_name`
+# returns null on every invocation, so the fallback "unknown" is always used
+# and the audit trail captures nothing useful.
 
 INPUT=$(cat)
 
 # Parse agent name -- use jq if available, fall back to grep
 if command -v jq >/dev/null 2>&1; then
-    AGENT_NAME=$(echo "$INPUT" | jq -r '.agent_name // "unknown"' 2>/dev/null)
+    AGENT_NAME=$(echo "$INPUT" | jq -r '.agent_type // "unknown"' 2>/dev/null)
 else
-    AGENT_NAME=$(echo "$INPUT" | grep -oE '"agent_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"agent_name"[[:space:]]*:[[:space:]]*"//;s/"$//')
+    AGENT_NAME=$(echo "$INPUT" | grep -oE '"agent_type"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"agent_type"[[:space:]]*:[[:space:]]*"//;s/"$//')
     [ -z "$AGENT_NAME" ] && AGENT_NAME="unknown"
 fi
 

--- a/.claude/hooks/log-agent.sh
+++ b/.claude/hooks/log-agent.sh
@@ -2,16 +2,20 @@
 # Claude Code SubagentStart hook: Log agent invocations for audit trail
 # Tracks which agents are being used and when
 #
-# Input schema (SubagentStart):
-# { "agent_id": "agent-abc123", "agent_name": "game-designer", ... }
+# Input schema (SubagentStart) — per Claude Code hooks reference:
+# { "session_id": "...", "agent_id": "agent-abc123", "agent_type": "Explore", ... }
+#
+# The agent name is in `agent_type`, NOT `agent_name`. Reading `.agent_name`
+# returns null on every invocation, so the fallback "unknown" is always used
+# and the audit trail captures nothing useful.
 
 INPUT=$(cat)
 
 # Parse agent name -- use jq if available, fall back to grep
 if command -v jq >/dev/null 2>&1; then
-    AGENT_NAME=$(echo "$INPUT" | jq -r '.agent_name // "unknown"' 2>/dev/null)
+    AGENT_NAME=$(echo "$INPUT" | jq -r '.agent_type // "unknown"' 2>/dev/null)
 else
-    AGENT_NAME=$(echo "$INPUT" | grep -oE '"agent_name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"agent_name"[[:space:]]*:[[:space:]]*"//;s/"$//')
+    AGENT_NAME=$(echo "$INPUT" | grep -oE '"agent_type"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/"agent_type"[[:space:]]*:[[:space:]]*"//;s/"$//')
     [ -z "$AGENT_NAME" ] && AGENT_NAME="unknown"
 fi
 


### PR DESCRIPTION
## Summary

- Fixes `.claude/hooks/log-agent.sh` and `.claude/hooks/log-agent-stop.sh` reading `.agent_name` from the hook payload — a field that doesn't exist on `SubagentStart`/`SubagentStop` events
- Claude Code emits the agent name in `agent_type`; the wrong field caused every audit log entry to fall through to `"unknown"`, making the entire audit trail useless
- Swapped `.agent_name` → `.agent_type` in both the jq path and grep/sed fallback; updated docstrings to reflect the real payload schema
- Log output format is **unchanged** — existing audit logs stay valid

Closes #20

Credit: bug report and fix originally authored by @bobloy in #20. Great catch.

## Test plan

- [x] Spawn any subagent (e.g. `Explore`) during a session
- [x] Check `production/session-logs/agent-audit.log` — entries should show the real agent name instead of `unknown`
- [x] Verify both jq path (systems with jq) and grep fallback (systems without) produce correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)