### PR TITLE
Fix missing allowed-tools in /architecture-decision and /story-done

### DIFF
--- a/.claude/skills/architecture-decision/SKILL.md
+++ b/.claude/skills/architecture-decision/SKILL.md
@@ -3,7 +3,7 @@ name: architecture-decision
 description: "Creates an Architecture Decision Record (ADR) documenting a significant technical decision, its context, alternatives considered, and consequences. Every major technical choice should have an ADR."
 argument-hint: "[title] [--review full|lean|solo]"
 user-invocable: true
-allowed-tools: Read, Glob, Grep, Write, Task, AskUserQuestion
+allowed-tools: Read, Glob, Grep, Write, Edit, Task, AskUserQuestion
 ---
 
 When this skill is invoked:

--- a/.claude/skills/story-done/SKILL.md
+++ b/.claude/skills/story-done/SKILL.md
@@ -3,7 +3,7 @@ name: story-done
 description: "End-of-story completion review. Reads the story file, verifies each acceptance criterion against the implementation, checks for GDD/ADR deviations, prompts code review, updates story status to Complete, and surfaces the next ready story from the sprint."
 argument-hint: "[story-file-path] [--review full|lean|solo]"
 user-invocable: true
-allowed-tools: Read, Glob, Grep, Bash, Edit, AskUserQuestion, Task
+allowed-tools: Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion, Task
 ---
 
 # Story Done


### PR DESCRIPTION
## Summary

- Adds `Edit` to `/architecture-decision` `allowed-tools` — retrofit mode and registry append both call `Edit` on existing files, causing a permission error on every `/architecture-decision retrofit` run
- Adds `Write` to `/story-done` `allowed-tools` — Phase 7 creates `active.md` on first run; missing `Write` caused silent failure and lost completion notes

Closes #33. Bug found and fix branches prepared by @xiaolai via [NLPM](https://github.com/xiaolai/nlpm-for-claude) audit. Great catch.

## Test plan

- [ ] Run `/architecture-decision retrofit <existing-adr>` — should complete without permission error
- [ ] Run `/story-done` on a fresh project (no `active.md`) — should create `active.md` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)