### PR TITLE
Fix: session-start preview shows most recent state instead of oldest

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -62,8 +62,8 @@ if [ -f "$STATE_FILE" ]; then
     echo "A previous session left state at: $STATE_FILE"
     echo "Read this file to recover context and continue where you left off."
     echo ""
-    echo "Quick summary:"
-    head -20 "$STATE_FILE" 2>/dev/null
+    echo "Quick summary (last 20 lines):"
+    tail -20 "$STATE_FILE" 2>/dev/null
     TOTAL_LINES=$(wc -l < "$STATE_FILE" 2>/dev/null)
     if [ "$TOTAL_LINES" -gt 20 ]; then
         echo "  ... ($TOTAL_LINES total lines — read the full file to continue)"


### PR DESCRIPTION
## Summary
- Replaces `head -20` with `tail -20` in `.claude/hooks/session-start.sh:66`
- The quick summary preview now shows the *last* 20 lines of `active.md`, where all skills append their `## Session Extract` blocks
- Updates the label from `"Quick summary:"` to `"Quick summary (last 20 lines):"` so the scope is unambiguous

## Why
All skills that write session state (`/review-all-gdds`, `/architecture-review`, `/dev-story`, etc.) **append** to `active.md`. `head` was reading from the top of the file — the oldest, stalest entries — causing Claude and the user to recover incorrect context on every new session.

## Test plan
- [x] Open a project where `active.md` has grown across multiple sessions
- [x] Start a new Claude Code session and confirm the preview shows the most recent extracts
- [x] Confirm the truncation message still appears when the file exceeds 20 lines

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)