### PR TITLE
Save/Load + Submission&Evaluation epics + UI Foundation services + reasoning-workspace data-layer

### DIFF
--- a/design/gdd/reasoning-workspace.md
+++ b/design/gdd/reasoning-workspace.md
@@ -1,0 +1,1218 @@
+# Reasoning Workspace
+
+> **Status**: Designed — 2nd Cascade Revision Applied (2026-05-07; design-review MAJOR REVISION NEEDED 2nd cycle → 22 BLOCKING + 50 IMPORTANT resolved via mechanical cascade; 3rd review cycle scheduled)
+> **Author**: kjuioqq8@gmail.com + game-designer + ux-designer + systems-designer + art-director + audio-director + qa-lead + godot-specialist + accessibility-specialist (review)
+> **Last Updated**: 2026-05-07 (2nd cascade)
+> **Decision Log**: `design/gdd/reviews/reasoning-workspace-decisions-2026-05-07.md` (3 gates, 1st cascade) + `design/gdd/reviews/reasoning-workspace-decisions-2026-05-07-cycle2.md` (2nd cascade — Pillar 2 / 인장빨강 lockdown / AccessKit floor / KB CitationDrop)
+> **Layer**: Feature
+> **Priority**: MVP
+> **Implements Pillar**: 1 (Truth Is Weighted) + 3 (Only Thought Pressures)
+> **Source Concept**: design/gdd/game-concept.md
+> **Position in Index**: #6 — 7th in design order (Feature Layer #1)
+> **Architectural Backing**: ADR-0007 (Submission Evaluation Algorithm) — chain_data 입력 계약 + freeze 스냅샷 forward-constraint; ADR-0004 (Korean Text Rendering) — Theme type variations + RichTextLabel scroll virtualization; **ADR-0008 (Workspace Layout — Proposed 2026-05-07)** — DeskPane Control hierarchy + CitationDrop hybrid signal topology + MemoPanel inline/fallback + Tree panning Camera2D + Gamepad two-step (Gate ③ 4 invariant + OQ-W5/W9/W10/W13 closure)
+> **Effort**: L (4+ sessions per systems-index)
+
+---
+
+## 1. Overview
+
+*Reasoning Workspace*는 플레이어가 한 케이스의 *추론을 구성하는 책상*이다 — 가설 트리, 자유 메모, Library에서 드래그한 evidence, 그리고 그 모든 것이 하나의 `chain_data` Dictionary로 export되는 freeze 스냅샷을 호스팅한다. Browser §3.6 `WorkspaceHandoff` 상태에서 DeskPane 통제권을 받으며, 케이스 lifecycle `InProgress` 동안 플레이어가 시간을 가장 길게 보내는 화면(Browser 다음 player-facing #2)이다. 데이터 측 책임은 — (a) `case.id` 단위 진행 Resource (가설 노드·메모·evidence·연결 그래프 보존), (b) `EvaluationService.submit()` 호출 시점의 불가변 `chain_data` 스냅샷 export (**ADR-0007 §3.2** freeze forward-constraint, 사후 정당화 방지 Pillar 1 가드), (c) Library `CitationDrop` 상태의 drop target 정책. 플레이어 측 경험은 Disco Elysium *Thought Cabinet* 결의 가설 트리 구성·재배치 + 노드별 자유 메모·evidence 첨부로, 본인의 *법리 직감*이 트리 깊이·인용 가중치로 정량화되는 자각을 만든다 — Pillar 1(*진실은 가중치다*)을 player-facing으로 시각화하는 핵심 시스템이며, Pillar 3(*사고 만이 압박이다*)이 시간 압박 0의 차분한 흐름으로 직접 구현되는 무대다. 시각·텍스트 렌더링은 **ADR-0004**(Theme type variations + RichTextLabel scroll virtualization)을 따르고, 위젯 트리 구체는 #2 UI Foundation 및 후속 *Workspace Layout ADR*에 위임된다 (본 GDD는 시각·인터랙션·데이터 계약 잠금에 집중).
+
+## 2. Player Fantasy
+
+1심·2심 판결문을 충분히 읽고 책상 앞에 앉으면, 가설 트리는 처음에 비어 있다. 후보 상고이유를 하나 적고, Library에서 끌어온 판시 단락을 그 아래 노드에 얹는다. 증거 카드 하나가 가설 노드 위에 얹히는 순간, 트리의 한 변이 굵어지는 게 보인다. 같은 판시 단락을 다른 가지에 옮겨붙이면 그쪽이 굵어진다. 어느 가지도 결정적이지 않다는 사실이, 손 끝에서 천천히 분명해진다 — 어느 인용이 더 무겁게 앉는가. 책상 위에서, 그 무게만으로 결론이 기운다.
+
+작업이 길어지면 어느 시점에 한 시간을 들여 키워둔 가지를 지우게 된다. 메모도, 인용도, 그 아래 달아둔 판례 세 건도 함께 사라진다. 처음 들였던 시간이 아깝다는 감각과, 이 가지로는 쟁점이 서지 않는다는 판단이 같은 무게로 놓인다. 누구도 재촉하지 않는다. 지울지 남길지를 정하는 일만 책상 위에 남아 있다 — 시간 압박이 아닌 *판단의 무게*가 곧 압박이다.
+
+제출 직전, 트리 전체가 한 번 더 눈에 들어온다. 어떤 노드는 인용이 두텁고, 어떤 노드는 메모만 길다. 누르면 모든 메모와 연결이 그대로 굳는다. 사후의 수정도, 더 나은 정리도 허락되지 않는다. 지금 놓인 가중치가 곧 제출되는 추론이라는 사실 앞에서, 한 번 더 읽고, 한 번 더 망설인다. 이 망설임 — 시간 압박 0의 게임에서 *유일하게 마련된 압박감* — 이 Reasoning Workspace가 만드는 핵심 감각이다.
+
+## 3. Detailed Design
+
+### 3.1 Core Rules
+
+**Rule 1 — HypothesisNode 모델**: 가설 트리는 *케이스 종속 multi-root tree (forest)* — 각 노드는 정확히 하나의 부모(또는 루트)와 0+ 자식을 보유. 루트가 복수 허용되어 forest of trees 구조 (다중 상고이유 병렬 표현). 각 노드는 다음 필드를 보유한다.
+
+| 필드 | 타입 | 의미 |
+|---|---|---|
+| `node_id` | String | 케이스 내 고유 — UUID v4 생성 (재정렬·삭제 후에도 chain_data 스냅샷 내 참조 안정) |
+| `label` | String | 플레이어 입력 가설 제목 — 최대 60자 |
+| `memo` | String | 자유 메모 — 최대 500자 (Rule 5) |
+| `evidence` | Array[String] | Library ID 배열 — 최대 5개 (Rule 4) |
+| `parent_id` | String | 부모 node_id — 루트는 빈 문자열 `""` |
+| `children` | Array[String] | 자식 node_id 목록 |
+
+시각: 200×48px 직사각형, border-radius 2px, 선택 2px 잉크블랙 / 미선택 0.5px 그레이 (Art Bible §3.1). **Label 표시 정책 (200×48px 물리 제약)**: Pretendard Regular 14pt 기준 카드 inner box(좌우 패딩 8px 차감 후 184px)에 단일 행 표시 가능 한국어 글자 수는 약 13–15자 (글자 폭 12–14px 평균). Rule 5의 60자 cap은 *입력·저장* 한계 — *표시* 시점에는 inner box width 초과분을 ellipsis(`…`) truncation. 전체 label은 (a) 노드 hover 또는 keyboard focus 시 tooltip / popover로 표시 (200ms hover delay), (b) 인라인 편집 진입 시 `TextEdit` 한 줄 전체 표시 (가로 스크롤 또는 자동 줄바꿈은 §9 ratify), (c) F2 list view (§9.4.2) — flat indented text 모드에서 full label 노출. Truncation 발생 시 시각 indicator: ellipsis 자체가 표지자 (Art Bible 인쇄 컨벤션 정합).
+
+**Rule 2 — Forest 구조 + MVP 깊이 제한**: 다중 루트 허용 (병렬 가설 — `parent_id == ""`인 노드 복수 OK; 본 GDD 전반에서 "tree"는 일반 명사이며 데이터 구조는 forest of trees). 깊이(depth) = 자기가 속한 root에서 해당 노드까지의 엣지 수. **MVP 깊이 ≤ 3** (루트=0 / 자식=1 / 손자=2 / 증손자=3) — "상고이유 → 쟁점 → 판례 근거" 3계층 표현 허용. 깊이 4+ 노드 추가 시도는 차단 + "이 가지는 더 깊이 나눌 수 없습니다" hint. 한국 상고심 4계층 추론(상고이유→쟁점→판례→학설/세부논거)에서 *학설/세부논거* 계층은 노드의 `memo` 본문(Rule 5)에 포함 — 트리 깊이 인플레이션 없이 추론 디테일 보존.
+
+**Rule 3 — 노드 추가/이동/삭제**:
+- **추가**: DeskPane 빈 공간 더블클릭 → 새 루트 노드. 기존 노드의 "+" 버튼 클릭 → 자식 노드 추가. 깊이 제한(Rule 2) 검사 후 허용.
+- **이동**: **Plain drag from node body** — modifier 키 없음 (macOS/Windows 플랫폼 컨벤션 정합; Ctrl+drag은 macOS에서 컨텍스트 메뉴, Windows Explorer에서 복사 의미로 충돌하여 폐기). Drop discrimination은 *드래그 source*로 결정 — 노드 본문 source = 이동 / LibraryPane 카드 source = evidence 첨부 (Rule 4). 다른 노드 위에 드롭 → drop target의 자식으로 재배치. 깊이 3 초과 유발 시 차단. 빈 공간 드롭 → 루트 승격 (`parent_id = ""`). **Discoverable surface 의무**: (a) 노드 호버 시 cursor `grab`(잡기) 변환, drag 시작 후 `grabbing` 변환 (CSS-equiv `cursor` 속성, Godot `Control.MOUSE_CURSOR_DRAG`); (b) 노드 우클릭 컨텍스트 메뉴에 "이동" 항목 — 선택 후 다음 클릭 위치로 이동 (KB+M 사용자에 명시 발견 경로 + 키보드 사용자에 fallback). Click vs drag 구별은 §7.2 `node_drag_threshold_px` (default 8px) 임계 적용.
+- **삭제**: 노드 선택 후 `Delete` 키 또는 컨텍스트 메뉴 "삭제". 자식·손자 포함 서브트리 전체 삭제. 삭제 전 *확인 다이얼로그* 의무 — "이 가지와 하위 [N]개 노드가 함께 삭제됩니다. 계속하시겠습니까?" (Pillar 3 — *cut* anchor 보존; 가벼운 삭제는 Section 2 판타지 침해).
+- **레이블 편집**: 노드 더블클릭 → 인라인 텍스트 입력 (60자 cap). Enter 또는 외부 클릭으로 확정.
+
+**Rule 4 — Evidence 첨부 (CitationDrop 정책)**:
+- **동일 ID 중복**: *같은 노드* 내 차단 / *다른 노드*에 동일 ID는 허용 (같은 판례가 두 가지를 모두 지지 가능).
+- **노드당 최대 evidence 수**: **5개** (MVP 초기값, Tuning Knob 노출). 6번째 거부 + "이 노드에는 인용을 5개까지만 첨부할 수 있습니다" hint.
+- **허용 Library ID 타입**: `law:...` (LibraryLawEntry) + `case:.../holding-N` (LibraryHolding). 판결 전체(`case:...` LibraryPrecedentEntry root) 드롭 거부 + "판시 단락(holding) 단위로 인용해주세요" 안내 (Library §3.1.2 합성 ID 정책 정합).
+- **드롭 타겟 인식**: §3.3 시그널 계약 참조.
+
+**Rule 5 — 노드별 자유 메모**: 노드 클릭 → DeskPane 메모 패널 (위치는 §9 UI Requirements 결정 위임 — OQ-W5)의 포커스 이동.
+- **표시**: `RichTextLabel scroll_active=true` (ADR-0004 forbidden_pattern `label_for_long_body_text` 정합 — 10+ 라인 본문 Label 금지).
+- **편집**: `TextEdit` 위젯.
+- **Theme**: `&"MemoLabel"` (표시) / `&"MemoEdit"` (편집) Theme type variation 의무 (ADR-0004 forbidden_pattern `inline_theme_override_without_type_variation` 정합).
+- **글자 수**: ≤ 500자.
+- **포맷**: Plain text MVP (마크다운 v1+ — OQ-W6 검토).
+
+**Rule 6 — chain_data Export 스키마**: `EvaluationService.submit()` 호출 시 Workspace는 다음 구조의 Dictionary를 `PlayerSubmission.chain_data`에 채운다.
+
+```python
+chain_data = {
+  "schema_version": 1,                # int — v1+ 구조 변경 시 마이그레이션 식별자
+  "nodes": [
+    {
+      "node_id": "uuid-string",
+      "label": "상고이유 1 — 법리 오해",
+      "depth": 0,                     # int — 0=루트, 최대 3
+      "parent_id": "",                # 루트는 ""
+      "evidence": [                   # Library ID 배열, 노드당 최대 5
+        "case:2019do1234/holding-1",
+        "law:criminal-act-art-250"
+      ],
+      "memo_length": 87,              # int — 메모 본문은 미포함 (Pillar 1 가드), 길이만
+      "child_count": 2                # int — 즉시 자식 수 (손자 포함 X)
+    }
+    # ... 추가 노드
+  ],
+  "edge_count": 4,                    # int — 전체 부모-자식 엣지 수
+  "max_depth_reached": 2,             # int — 트리 실제 최대 깊이
+  "total_evidence_count": 7           # int — 전체 노드 evidence 합산 (중복 ID 포함)
+}
+```
+
+MVP에서 `chain_data == {}` 빈 Dict 허용 (ADR-0007 §1 정합). v1+ chain_coherence subscore 알고리즘이 `nodes[].evidence`, `depth`, `edge_count`를 소비. **메모 본문은 chain_data에 미포함** (Pillar 1 가드 — 평가는 인용·구조 가중치, 글쓰기 실력 X). v1+ 메모 텍스트 분석 도입 시 schema_version=2 bump + `memo_text` 필드 추가 (OQ-W3).
+
+**Schema validation — dual-layer guard (Pillar 1 silent regression 방어)**:
+
+**단일 source of truth (godot-specialist Item 7 BLOCKING closure)**: schema_version=1 허용 필드 allow-list는 `src/data/chain_data_schema.gd`의 `const SCHEMA_V1_ALLOWED_FIELDS` (top-level: `["schema_version", "nodes", "edge_count", "max_depth_reached", "total_evidence_count"]`) + `const SCHEMA_V1_NODE_FIELDS` (노드별: `["node_id", "label", "depth", "parent_id", "evidence", "memo_length", "child_count"]`)에 정의. Workspace 빌더와 EvaluationService Pre-evaluation Gate가 *동일 const를 import*. 양쪽 inline 정의는 forbidden_pattern `chain_data_schema_allow_list_duplication` (architecture.yaml registry 등록 의무).
+
+1. **Builder-side allow-list** (본 GDD 책임): chain_data 빌더는 export Dict 생성 직후 import한 const 집합과 비교 검증. 비허용 필드 발견 시 `submission_rejected("schema_violation:[field_name]")` emit + `EvaluationService.submit()` *호출 자체 차단* (Pre-evaluation 도달 X). EC §5.6 fuzz test (AC-52) 커버.
+2. **EvaluationService Pre-evaluation Gate** (ADR-0007 §3.1.2 책임 — submission-evaluation §3.1.2 5번째 검증 step): submission-evaluation §3.1.2 Pre-evaluation Gate가 동일 const를 *독립적으로* 재검증 (2nd cycle BLOCKING #13 closure — 본 cascade revision 시 submission-evaluation §3.1.2에 5th check 추가 의무). 양쪽 const drift는 컴파일 타임 import 실패로 즉시 surface.
+
+**chain_data 빌드 normative (godot-specialist Item 8 BLOCKING closure)**: chain_data Dictionary는 *fully constructed new Dict*로 생성 — 라이브 `HypothesisNode` 그래프나 `WorkspaceData` 필드에 대한 reference 보유 금지. Godot Dictionary는 reference type이므로 freeze 후 라이브 데이터 mutation이 chain_data에 silent 반영될 수 있다. `WorkspaceData.build_chain_data()`는 모든 노드 dict를 `{"node_id": n.node_id, "label": n.label, ...}` 신규 dict literal로 채워 반환해야 하며, `nodes` 배열 또한 신규 Array — `WorkspaceData.nodes.duplicate()` 또는 등가. AC-24 deep-equality 검증의 step (1)이 이를 catch하나, 본 normative는 *구현 의무*로 명시.
+
+**nodes[] 배열 canonical ordering (systems-designer F3 BLOCKING closure)**: `chain_data.nodes` 배열은 다음 순서로 직렬화 — (1) 루트(`parent_id == ""`)를 `node_id` 사전식 순서로 정렬, (2) 각 루트에 대해 BFS 순회 (각 깊이 단계에서 자식을 `node_id` 사전식 정렬), (3) 결과 시퀀스를 `nodes` 배열로 출력. 이로써 동일 워크스페이스 상태의 두 chain_data 빌드는 동일 `nodes` 순서를 보장 — AC-24 JSON.stringify 비교가 결정적이다. 위반 시 AC-24 deep-equality 가 false negative를 생성한다.
+
+**Rule 7 — Freeze 동작** (ADR-0007 §3.2 forward-constraint 이행):
+- **Freeze 동기 트랜지션 (synchronous, single-frame)**: Submit 클릭 처리는 단일 프레임 내 다음 순서로 진행 — (a) `ACTIVE → FROZEN` 상태 전환, (b) chain_data Dictionary 빌드 + Schema validation (Rule 6 builder-side), (c) `PlayerSubmission.chain_data` 할당, (d) `EvaluationService.submit(submission)` 호출. (a)(b)(c)는 동일 frame에서 atomic. Workspace는 submit() 반환을 await하지 않는다 — fire-and-forget. UI 차단은 FROZEN 상태가 보장 (입력 무시 + 오버레이 배너).
+- **Freeze 범위**: 가설 트리 전체 (노드 구조·레이블·parent-child 관계) + 모든 노드의 evidence + 모든 노드의 memo. WorkspaceData Resource는 *불가변 스냅샷* — Write 경로 닫힘.
+- **Freeze 중 인터랙션**: 모든 입력 무시 + "제출이 처리 중입니다" 오버레이 배너. Submit 버튼은 `EvaluationService.current_state != IDLE` 동안 비활성 (ADR-0007 forbidden_pattern `submit_during_active_evaluation` 정합).
+- **Freeze 해제 (asynchronous via signal callbacks)**: Workspace는 EvaluationService 내부 진행을 polling 하지 않으며 시그널 콜백으로만 상태 복귀 — `submission_rejected` 시그널 수신 → FROZEN → ACTIVE 복귀 (재편집 허용); `evaluation_completed` 시그널 수신 → FROZEN → READ_ONLY (영구 아카이브).
+
+### 3.2 States and Transitions
+
+Workspace 자체 상태 머신 (case lifecycle / Browser screen state와 분리 — *작업 가능성* 측 상태):
+
+| State | 의미 | 진입 조건 | 종료 조건 |
+|---|---|---|---|
+| `INACTIVE` | DeskPane 비활성 — Browser CatalogIdle/BriefOpen/FactsOpen 동안 Workspace 미마운트 | 게임 시작 / 다른 케이스 진행 / 케이스 종결 후 | `workspace_handoff_started` 시그널 수신 → `ACTIVE` |
+| `ACTIVE` | 일반 작업 — 트리·메모·evidence 모두 편집 가능. 플레이어가 시간을 가장 길게 보내는 상태 | `workspace_handoff_started` 또는 `submission_rejected` | Submit 클릭 → `FROZEN` (**동기 single-frame 전이** — Rule 7 (a)→(d) atomic) / `workspace_handoff_ended(reason: "paused")` Browser emit → `INACTIVE` (재진입 가능) |
+| `FROZEN` | 평가 진행 중 — chain_data 스냅샷 export 후 모든 입력 무시. 오버레이 배너 표시 | Submit 클릭 시 동기 전이 (Rule 7 — chain_data 빌드 → submit() 호출 모두 동일 frame) | `submission_rejected` → `ACTIVE` 복귀 (async signal callback) / `evaluation_completed` → `READ_ONLY` (async signal callback) |
+| `READ_ONLY` | 평가 완료 후 영구 아카이브. #14 Retrospective Replay 열람 인터페이스의 데이터 소스 | `evaluation_completed` 수신 | `workspace_handoff_ended(reason: "submitted")` Browser emit → Browser `VerdictArrived` 진입 → 본 Workspace `INACTIVE` |
+
+**상태 전이 그래프**:
+
+```
+[INACTIVE]
+    │ workspace_handoff_started(case_id)
+    ▼
+[ACTIVE] ──Submit 클릭──▶ [FROZEN]
+    ▲                        │
+    │                        │ submission_rejected
+    └────────────────────────┘
+                             │ evaluation_completed
+                             ▼
+                        [READ_ONLY]
+                             │
+                             │ workspace_handoff_ended(reason: "submitted")
+                             ▼
+                        [INACTIVE]
+```
+
+ACTIVE → INACTIVE (`reason: "paused"`)는 플레이어가 다른 케이스로 이탈할 때 — 트리 상태는 `#3 Save/Load`가 직렬화하므로 재진입 시 동일 상태 복원 (Rule 8).
+
+### 3.3 Interactions with Other Systems
+
+#### WorkspaceHandoff 시그널 명세 (Browser §6 OQ-5 closure)
+
+| 시그널 | 발신자 | 수신자 | 발화 조건 | 페이로드 |
+|---|---|---|---|---|
+| `workspace_handoff_started(case_id)` | Browser (#5) | Workspace (#6) | "맡습니다" 클릭 → FactsOpen → WorkspaceHandoff 전이 | `case_id: String` |
+| `workspace_handoff_ended(case_id, reason)` | Workspace (#6) | Browser (#5) | Submit 완료 또는 플레이어 이탈 | `case_id: String, reason: String` (`"submitted"` \| `"paused"`) |
+
+`reason: "submitted"` → Browser `SubmissionPending` 전이. `reason: "paused"` → Browser `WorkspaceHandoff` 유지 (재진입 가능).
+
+#### CitationDrop 시그널 명세 (Library §3.2 ↔ Workspace)
+
+LibraryPane은 Browser가 통제하지만 drop target인 가설 노드는 DeskPane(Workspace)에 있다. 경계 시그널:
+
+| 시그널 의미 | 발신자 | 수신자 | 발화 조건 | 페이로드 |
+|---|---|---|---|---|
+| `citation_drag_started(library_id)` | Library Subsystem ¹ | Workspace | 플레이어가 LibraryPane 카드 드래그 시작 | `library_id: String` |
+| `citation_dropped(library_id, viewport_position)` | Library Subsystem ¹ | Workspace | 드롭 발생 (DeskPane 영역) | `library_id: String, viewport_position: Vector2` |
+
+¹ **발신자 구체 (autoload `LibraryService` vs scene node `LibraryPane`)와 전달 채널 (signal vs Godot 4.6 native drag-drop API `_get_drag_data`/`_can_drop_data`/`_drop_data` vs hybrid)는 Workspace Layout ADR (미작성)에 위임**. 본 GDD는 의미·페이로드·exactly-once delivery 계약만 잠근다 — Workspace 처리 로직은 emitter-agnostic. 위임 검증 invariant 4건은 `design/gdd/reviews/reasoning-workspace-decisions-2026-05-07.md` Gate ③ 참조.
+
+**Workspace 측 처리**:
+- `citation_drag_started` 수신 → DeskPane drop zone 하이라이트 활성 (workspace State == ACTIVE 시만).
+- `citation_dropped` 수신 → viewport_position을 DeskPane 로컬 좌표로 변환 → hit-test로 target node 결정 → Rule 4 정책 적용 (중복·cap·타입 검증). 유효 노드 미히트 시 drop 무시 + "노드 위에 드롭해주세요" hint.
+- Workspace State == FROZEN 또는 READ_ONLY 시 drop zone 하이라이트 비활성 + 드롭 자체 차단.
+
+#### 기타 시스템과의 인터랙션
+
+| 시스템 | 관계 | 인터페이스 |
+|---|---|---|
+| **#1 Case Data Schema** | Read-only | `CaseService.get_case(case_id) -> CaseFile`. correct_disposition / correct_citations / scoring_weights에 본 시스템 *접근 안 함* (평가는 #9 책임 — 정보 격리로 사후 정당화 방지). |
+| **#20 Legal Reference Library** | Read-only | `LibraryService.get_entry(id)` (evidence 카드 표시), `LibraryService.get_holding(synthesized_id)` (holding 단위 인용). CitationDrop 시그널 2종. |
+| **#3 Save/Load** | Read+Write 위임 | `workspace_state_changed` 시그널 emit → Save/Load가 직렬화 시점 결정. **저장 빈도 정책은 #3 GDD 위임** (OQ-W4). 게임 종료 시 마지막 emit 기준 저장 상태 복원. |
+| **#7 Brief Editor** | chain_data 입력 계약 제공 | Brief Editor가 `node.evidence` 배열에서 `{{cite:<library_id>}}` 토큰을 자동 생성 (Library `library_brief_cite_token` constant 정합). |
+| **#9 Submission & Evaluation** | chain_data export | `EvaluationService.submit(PlayerSubmission)` 호출 시 chain_data가 PlayerSubmission.chain_data로 전달 (ADR-0007 §1 정합). Freeze 행동 계약 (ADR-0007 §3.2 forward-constraint) 본 GDD가 이행. |
+| **#14 Retrospective Replay (Alpha)** | READ_ONLY 데이터 소스 | 결정문 도착 후 워크스페이스 아카이브 열람. *본 GDD scope 외* — #14 위임. |
+
+#### Persistence 정책 (Rule 8 — §3.1에서 인용)
+
+- **세션 간 저장**: `WorkspaceData` Resource는 케이스 `InProgress` 기간 동안 #3 Save/Load가 직렬화. Workspace 자체는 저장 호출 X — 상태 변경 시 `workspace_state_changed` 시그널만 emit.
+- **게임 종료 시**: `InProgress` 케이스의 Workspace는 마지막 emit 기준 저장 상태 복원. 미저장 변경(emit 사이)은 유실 허용 (MVP — 명시적 저장 버튼 v1+ 검토).
+- **Resolved 케이스 재플레이**: 새 `WorkspaceData` 인스턴스 생성 — 이전 트리·메모·evidence 초기화 (Browser §3.8 정합). 이전 인스턴스는 케이스 결과 아카이브의 일부로 #14가 보관 인터페이스 제공.
+
+## 4. Formulas
+
+### 4.1 chain_data Derivation Formulas (MVP — submission-time export)
+
+다음 5개 수식은 freeze 시점에 `chain_data` Dictionary의 각 파생 필드가 어떻게 계산되는지 정의한다. 모든 수식은 인메모리 `HypothesisNode` 그래프에 대해 작용하며, export Dictionary는 결과만 포함하고 중간 구조는 포함하지 않는다.
+
+---
+
+**depth(node)**
+
+The `depth` formula is defined as:
+
+`depth(n) = 0 if n.parent_id == "" else depth(parent(n)) + 1`
+
+**Variables:**
+
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `n` | n | node ref | — | The target HypothesisNode |
+| `n.parent_id` | pid | String | `""` or UUID | Empty string indicates a root node |
+| `depth(n)` | d | int | 0–3 | Edge distance from nearest ancestor with `parent_id == ""` |
+
+**Output Range:** 0 to MAX_DEPTH (=3, MVP). §4.2 Tree Structural Invariant이 ≤ 3 재귀 단계 내 종료를 보장 — depth > 3 노드는 ACTIVE 상태에서 존재 불가.
+
+**Example (4-node tree):** Root A (`parent_id=""`): depth=0. Child B (`parent_id=A`): depth=1. Grandchild C (`parent_id=B`): depth=2. Great-grandchild D (`parent_id=C`): depth=3.
+
+---
+
+**max_depth_reached**
+
+The `max_depth_reached` formula is defined as:
+
+`max_depth_reached = max(depth(n) for n in nodes)`
+
+**Variables:**
+
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `nodes` | N | Array[node] | size ≥ 0 | Freeze 시점의 모든 HypothesisNodes |
+| `depth(n)` | d_n | int | 0–3 | 노드별 깊이 (위 정의) |
+| `max_depth_reached` | D | int | 0–3 | 트리 실제 최대 깊이 |
+
+**Output Range:** 0 to 3. 트리가 루트만 있는 경우 0. 빈 워크스페이스(nodes=[])는 convention상 0 — 이 경우 chain_data는 `{}` (ADR-0007 §1 빈 Dict 허용).
+
+**Example:** 위 4-node 트리 (A·B·C·D): max(0, 1, 2, 3) = **3**.
+
+---
+
+**edge_count**
+
+The `edge_count` formula is defined as:
+
+`edge_count = |{n ∈ nodes : n.parent_id != ""}|`
+
+동등하게: 루트가 아닌 노드 수. 트리에서는 각 비루트 노드가 정확히 한 개의 부모 엣지에 기여한다.
+
+**Variables:**
+
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `nodes` | N | Array[node] | size ≥ 0 | Freeze 시점의 모든 HypothesisNodes |
+| `n.parent_id` | pid | String | `""` or UUID | 비빈값은 부모 엣지 보유 |
+| `edge_count` | E | int | 0–unbounded | 전체 forest의 부모-자식 엣지 총합 |
+
+**Output Range:** 0 to (node_count − root_count). 원리상 무제한이나 실용상 ≤ node_count − 1. 빈 워크스페이스는 0.
+
+**Example:** 4-node 트리 (A 루트, B/C/D 비루트): parent_id != "" 노드 = {B, C, D} → edge_count = **3**.
+
+---
+
+**total_evidence_count**
+
+The `total_evidence_count` formula is defined as:
+
+`total_evidence_count = Σ_{n ∈ nodes} len(n.evidence)`
+
+**Variables:**
+
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `nodes` | N | Array[node] | size ≥ 0 | Freeze 시점의 모든 HypothesisNodes |
+| `len(n.evidence)` | e_n | int | 0–5 | 노드 n의 evidence 배열 길이 (Rule 4 cap) |
+| `total_evidence_count` | T | int | 0–(5 × node_count) | 노드별 evidence 합산; 노드 간 중복 ID는 별개 카운트 |
+
+**Output Range:** 0 to 5 × node_count. 다른 노드에 첨부된 동일 Library ID는 각각 카운트 (단일 holding이 두 가지에 인용되면 = 2). ADR-0007 §1 평가 계약과 일치.
+
+**Example:** A(2 evidence), B(0), C(3), D(1) → total = 2+0+3+1 = **6**.
+
+---
+
+**child_count(node)**
+
+The `child_count` formula is defined as:
+
+`child_count(n) = len(n.children)`
+
+**Variables:**
+
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `n.children` | ch | Array[String] | size 0–unbounded | 즉시 자식 node_ids 배열 (재귀 X) |
+| `child_count(n)` | k | int | 0–unbounded | 직속 자식 수만; 손자 제외 |
+
+**Output Range:** 0 to unbounded (분기 인수에 MVP cap 없음). 리프 노드는 0.
+
+**Example:** A.children=[B], B.children=[C], C.children=[D], D.children=[] → child_count: A=1, B=1, C=1, D=**0**.
+
+---
+
+### 4.2 Tree Structural Invariants
+
+다음 4개 술어는 ACTIVE 상태에서 항상 참이어야 하며, freeze 빌드 단계에서 chain_data export 직전에 재검증된다. 어떤 mutation 시도가 invariant를 위반할 경우 *변경 적용 전* 거부 — 워크스페이스는 invalid 상태에 절대 진입하지 않는다.
+
+---
+
+**Invariant 1 — Parent-child symmetry**
+
+`∀ n ∈ nodes : n.parent_id == "" ∨ (∃ p ∈ nodes : n.node_id ∈ p.children)`
+
+비루트 노드는 모두 자신의 `node_id`가 부모의 `children` 배열에 포함되는 부모 노드를 가져야 한다. 이 양방향 정합성은 모든 add/move/delete 작업에서 유지된다.
+
+*위반 동작:* dangling parent_id 참조를 만들 add·move 시도는 silent 거부 + `push_error("HypothesisNode parent_id references non-existent node: %s")` 로깅. 워크스페이스 상태 불변.
+
+---
+
+**Invariant 2 — Depth bound**
+
+`∀ n ∈ nodes : depth(n) ≤ MAX_DEPTH (= 3, MVP)`
+
+깊이 4+ 노드는 존재 불가. 모든 add·move 작업에서 mutation 적용 *전* 검사.
+
+*위반 동작:* add·move 거부 + "이 가지는 더 깊이 나눌 수 없습니다" hint (Rule 2 지정 문구). 상태 불변.
+
+---
+
+**Invariant 3 — Acyclicity**
+
+`∀ n ∈ nodes : n에서 시작한 parent-walk는 ≤ MAX_DEPTH 단계 내 루트(parent_id == "")에 도달`
+
+MAX_DEPTH = 3이므로 최대 3 단계 parent-walk가 `parent_id == ""` 노드에 도달해야 한다. 도달하지 못하면 사이클 존재.
+
+*위반 동작:* 사이클 유발 move 시도(조상을 자기 후손의 자식으로 이동)는 mutation 전 거부. move-validation 단계에서 제안된 새 부모로부터 위로 walk하면서 대상 노드의 `node_id`가 walk에 출현하면 거부 + `push_error("Cycle detected: cannot reparent node %s under its own descendant")`.
+
+---
+
+**Invariant 4 — Evidence count bound**
+
+`∀ n ∈ nodes : len(n.evidence) ≤ EVIDENCE_PER_NODE_CAP (= 5, MVP)`
+
+노드당 evidence는 최대 5개. 모든 CitationDrop에서 검사.
+
+*위반 동작:* 6번째 드롭 거부 + "이 노드에는 인용을 5개까지만 첨부할 수 있습니다" hint (Rule 4 지정 문구). evidence 배열 불변.
+
+---
+
+**Invariant 5 — Evidence move atomicity (systems-designer F8 IMPORTANT closure)**
+
+evidence 노드 간 *이동* (decisions-2026-05-07 Gate ① 재해석 — "옮겨붙이면": source 노드 evidence 배열에서 제거 + target 노드 배열에 추가)은 `WorkspaceData` 레이어에서 *원자적*으로 실행. `WorkspaceData.move_evidence(library_id, source_node_id, target_node_id) -> bool`은 두 step 모두 success 시에만 commit, 어느 한 step 실패 시 source 배열 rollback. 두 step 사이에 외부 코드(시그널 핸들러·crash·integrity sweep)가 진입해도 evidence는 source 또는 target 중 한 곳에 *반드시* 존재 — 양쪽 부재 상태 도달 불가. 위반 시 `push_error("Evidence move atomicity violated: evidence %s lost in transit between %s and %s")` + WorkspaceData rollback. EC §5.3 evidence drop 정책 정합 (CitationDrop은 add only — move는 별도 API).
+
+---
+
+**Invariant 6 — Tuning resource validation (systems-designer F7 IMPORTANT closure)**
+
+`assets/data/workspace/tuning.tres` 로드 시점에 다음 invariant 검증 — 위반 시 default value 대체 + `push_error`:
+
+`evidence_hit_test_tolerance_px ≥ node_drag_threshold_px` (§7.6 부등식)
+
+이 부등식이 무너지면 드롭 히트 테스트가 등록되기 전에 드래그가 시작되어 evidence 첨부가 항상 차단된다. `WorkspaceData._validate_tuning(tuning: WorkspaceTuning) -> WorkspaceTuning` 메소드가 로드 시점 검증 + 위반 knob을 default value로 silent 보정.
+
+---
+
+### 4.3 v1+ chain_coherence Subscore — Forward Declaration
+
+ADR-0007 §1 + submission-evaluation GDD §4.4는 chain_data로부터 `nodes[].evidence`, `depth`, `edge_count`를 소비할 미래 `chain_coherence` subscore를 예약한다. 이 subscore는 모든 MVP 케이스에서 weight 0.0 잠금 (`scoring_weights.chain_coherence = 0`) — MVP 평가에서 제외된다. 아래 수식은 **v1+ 잠정 초안일 뿐 — MVP 명세 아님**.
+
+```
+chain_coherence(submission) = α · normalized_depth
+                            + β · normalized_breadth
+                            + γ · evidence_distribution_entropy
+```
+
+후보 항 (v1+ 잠정 — boundary case 명시 필수):
+
+| Term | Candidate formula | Notes |
+|------|------------------|-------|
+| `normalized_depth` | `max_depth_reached / MAX_DEPTH` | [0, 1]; 추론 체인 깊이. node_count==0 시 0 (빈 워크스페이스 EC §5.1) |
+| `normalized_breadth_v2` | `1 − (leaf_count / node_count)` (leaf_count = `\|{n : n.children == []}\|`) — **단 `node_count == 0` 시 div-zero 보호: §4.3 Boundary policy 강제 short-circuit (chain_coherence = 0 즉시 반환, 본 항 미실행)** | [0, 1]; 단일 노드(node_count=1, leaf=1) → 0; 선형 체인 4-node(leaf=1) → 0.75; star tree 4-node(leaf=3) → 0.25; balanced binary 7-node(leaf=4) → ≈0.43. *"비-리프 비율"이 분기성의 proxy* — 선형/star/balanced를 구분 (기존 `edge_count/(node_count−1)` 폐기 — 모든 forest에서 1 고정 → discrimination 0). **Forest semantic 한계 (systems-designer F4 IMPORTANT)**: 2-root forest (leaf=2, node=2) → 0 — 단일 노드와 동일 score. v1+ formula round에서 forest-aware 변형 검토 필요 |
+| `evidence_distribution_entropy` | 노드별 evidence 분포의 normalized Shannon entropy. `p_i = len(n_i.evidence) / total_evidence_count`. `H = −Σ p_i · log2(p_i)`. `H_max = log2(node_count)`. 정규화: `H / H_max` (단 boundary 적용). **Convention `0 · log2(0) := 0`** (systems-designer F2 BLOCKING closure — Shannon entropy 표준 limit p→0+. GDScript 구현은 zero-evidence 노드의 항을 0으로 명시 단축, `log(0) → -inf` 후 multiplication NaN 전파 방지) | [0, 1]; **Boundary cases**: node_count == 1 → 0 (단일 노드는 entropy 의미 없음); total_evidence_count == 0 → 0 (evidence 없음 — entropy 미정, lowest score 처리); H_max == 0 (node_count == 1) → 0 (분모 보호); 개별 노드의 `len(n.evidence) == 0` 시 해당 항만 0 단축 (전체 entropy 계속 계산) |
+
+**Boundary policy (v1+ 알고리즘 구현 의무, systems-designer F1 BLOCKING closure)**: 모든 chain_coherence 항은 `node_count == 0 ∨ chain_data == {}` 시 항 전체를 0으로 단축평가 — 본 short-circuit은 *각 항 formula row 인라인에 명시* (위 표 참조), Implementor가 표를 코드로 추출 시 보호 누락 방지. 단일 노드(node_count == 1)는 chain_coherence = 0 (linear chain 하한 + breadth/entropy 미정). Submission-evaluation §4 산출 시 이 short-circuit이 div-by-zero · NaN 전파를 방지한다. 또한 `0·log2(0) := 0` convention은 entropy 계산 시점에 *코드 레벨 guard*로 진입 (GDScript: `if p_i == 0.0: continue` 또는 `term = 0.0 if p_i == 0.0 else -p_i * log(p_i) / log(2.0)`).
+
+가중치 α, β, γ는 **TBD — v1+ formula round로 위임** (자문가 검수 + playtest data 대기). Output range [0, 1].
+
+**Note:** MVP submission-evaluation §4는 chain_data를 소비하지 않음. 이 수식은 v1+ ship 시 #6 GDD amendment를 피하기 위한 forward declaration. schema_version=1 export 계약(§3.1 Rule 6)은 이 수식이 요구하는 모든 필드를 이미 포함. v1+ 진입 시 자문가/playtest 결과로 가중치 튜닝 + 이 boundary policy 재검토 의무 (특히 `normalized_breadth_v2`의 한국 상고심 추론 패턴 적합성).
+
+---
+
+### 4.4 evidence_density (per-node informational metric — NOT exported)
+
+The `evidence_density` formula is defined as:
+
+`evidence_density(n) = len(n.evidence) / EVIDENCE_PER_NODE_CAP`
+
+**Variables:**
+
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `len(n.evidence)` | e | int | 0–5 | 노드 n의 현재 evidence 수 |
+| `EVIDENCE_PER_NODE_CAP` | CAP | int | 5 (MVP) | Rule 4 tuning knob; denominator |
+| `evidence_density(n)` | ρ_n | float | 0.0–1.0 | 채워진 evidence 슬롯 비율 |
+
+**Output Range:** [0.0, 1.0]. 0.0 = evidence 없음; 1.0 = 5개 슬롯 모두 채움.
+
+**chain_data에 포함 X.** DeskPane이 render 시 계산하는 local UI hint. **bottom evidence rule** 시각 채널의 길이 결정에 사용 (§8.1.1) — 노드 카드 하단의 가로 잉크블랙 룰(underline mark)이 `ρ × node_width` 길이로 표시. 한국 법조 문서의 *밑줄 강조* 관례를 차용한 Pillar 1 가시화 채널이며, **selection state (border 두께)와 visual channel 분리** — 두 신호가 동시 발화해도 충돌 없음 (decisions-2026-05-07 Gate ② 참조). 원시 카운트를 노출하지 않고 즉각적인 밀도 피드백 제공.
+
+**Discretization:** MVP cap=5에서 ρ는 6개 이산 값 — `{0.0, 0.2, 0.4, 0.6, 0.8, 1.0}`. 이는 node_width 200px 기준 0/40/80/120/160/200px 길이의 룰 — 1080p 1:1 매핑에서 모든 단계가 인지 가능 (40px ≫ subpixel 임계). **Discretization step count는 `evidence_per_node_cap` knob 종속** (systems-designer F5 IMPORTANT closure — knob 변경 시 step 수 재산출: cap=3 → 4 step, cap=8 → 9 step). 본 6단계 시각 spec(§8.1.1.b) + AC-37 픽셀 수치(40/120/200px ±2px)는 `evidence_per_node_cap = 5` MVP 기본값 종속. cap 변경 시 §8.1.1.b 픽셀 표 + AC-37 수치 동시 갱신 의무.
+
+**Pillar 2 도메인 한계 명시 (game-designer Pillar 2 IMPORTANT — MVP 수용 결정 2026-05-07 cycle 2)**: `evidence_density`는 *count-based* proxy — 한국 상고심에서 인용 weight는 *court grade* (전합 > 부 > 하급심) + *판례 recency* + *doctrinal alignment*에 의해 결정되는 다차원 신호. MVP는 count proxy를 *수용된 단순화*로 채택 (Bottom Evidence Rule 시각 채널 인지 가능성 우선). v1+ ADR-0007 amendment를 통해 `precedent_seniority_bonus` subscore (현재 weight 0.0 잠금) 활성 + `evidence_density` weighted 변형(`weighted_density(n) = Σ_i court_grade_weight(evidence_i) / EVIDENCE_PER_NODE_CAP_WEIGHTED`) 도입을 v1+ formula round에 위임. *MVP는 count-based 시각 신호로 ship — 본 한계는 design/gdd/reviews/reasoning-workspace-decisions-2026-05-07-cycle2.md Decision 1에 명시.*
+
+**Example:** evidence 3개 노드: ρ = 3/5 = **0.6**; bottom rule 길이 = 0.6 × 200px = **120px**.
+
+## 5. Edge Cases
+
+### 5.1 Empty / minimum tree
+
+- **If 플레이어가 노드 0개로 Submit 클릭**: `submit()` 호출이 `FROZEN` 전이 *전* 차단 — Workspace가 즉시 `submission_rejected("empty_tree")` emit (`EvaluationService` 도달 X); 워크스페이스 `ACTIVE` 유지; DeskPane 인라인 hint "가설 트리에 노드가 없습니다. 하나 이상의 가설을 추가해주세요." 1차 방어선은 Submit 버튼이 node count == 0 동안 비활성 — 클릭 자체 차단. ADR-0007 §1은 `chain_data == {}`를 허용하나 본 UI 레이어 사전 차단으로 빈 submission이 EvaluationService에 전달되지 않음.
+
+- **If 플레이어가 단일 루트 노드(evidence 0)로 Submit**: Submit 허용 (Rule 4는 최솟값 0 미금지). `chain_data.nodes`에 `evidence: [], memo_length: 0, child_count: 0` 단일 노드 포함된 채 전달. 결과 subscore의 `chain_coherence`·`citation_score`가 낮게 산출되는 것은 *평가 시스템의 의도된 동작* — 에디터 레이어 추가 차단 없음. *v1+ chain_coherence boundary policy* (§4.3): `node_count == 1` 또는 `total_evidence_count == 0` 시 chain_coherence = 0 short-circuit — div-zero · NaN 전파 방지.
+
+- **If 노드가 레이블만 있음 (memo·evidence·children 모두 없음)**: 차단 없음 (Rule 4·5 위반 아님). `memo_length: 0, evidence: [], child_count: 0`으로 직렬화되어 `chain_data` 포함. 평가 가중치 산출 시 낮은 contribution 반영은 설계 의도.
+
+### 5.2 Tree-structural violations
+
+- **If plain drag으로 깊이 4 위치에 노드 배치 시도** (Rule 2 cap 위반): 드롭 직전 깊이 검증 실패 → 드롭 거부, 노드 원위치 애니메이션 복귀, DeskPane 하단 "이 가지는 더 깊이 나눌 수 없습니다" hint (Rule 2 지정). 부모 노드 visual drop zone 하이라이트는 드래그 중 실시간 비활성 — depth-3 노드의 drop target 자격 없음을 즉시 시각화 (커서 변경).
+
+- **If plain drag으로 사이클 생성 시도** (조상을 후손 위 드롭): `parent_id` 체인 재귀 검사 → 사이클 감지 시 드롭 거부 + 원위치 복귀 + "노드를 자신의 하위 노드로 이동할 수 없습니다" hint. `chain_data` forest 계약 보유 — 사이클 허용 시 직렬화 루프. 검증은 드롭 완료 *전* 동기 실행 의무.
+
+- **If 동시 drag 두 건 발화** (multi-select 제스처 또는 rapid input): Workspace는 동시 drag context 1건만 보유 (first-drag-wins). 두 번째 드래그 시작 신호 무시. 첫 드래그 완료(드롭 또는 취소) 후 두 번째 드래그를 새로 시작해야 한다. 추가 에러 표시 없이 silent — 복잡한 multi-drag UX는 MVP scope 외.
+
+- **If `parent_id`가 존재하지 않는 `node_id` 참조** (Save/Load 역직렬화 시 손상된 데이터): `WorkspaceData` 로드 시점에 integrity sweep 실행 — 미존재 `parent_id` 노드는 `parent_id = ""`로 보정(루트 승격) + 부모 노드의 `children`에서 해당 node_id 제거. 플레이어에게 silent repair. `workspace_state_changed` emit 후 `#3 Save/Load`가 정합 상태 재저장. 손상 발생 시 에디터 콘솔 `push_warning("WorkspaceData integrity: orphan node [id] promoted to root")` 기록.
+
+### 5.3 Evidence drop edge cases
+
+- **If 플레이어가 Library precedent 루트(`case:2019do1234` — `/holding-N` 미포함) 드롭**: Rule 4 타입 검증 실패 → 드롭 거부 + 카드 원위치 튕김 애니메이션 + "판시 단락(holding) 단위로 인용해주세요" hint (Rule 4 지정). 시각: 대상 노드 drop zone brief red flash (150ms) 후 원래 색 복귀 — 허용 불가 명시.
+
+- **If 드롭한 Library entry의 `library_id`가 LibraryService에 미존재** (드래그 시점·평가 시점 사이 캐시 불일치): (a) 드래그 중 `citation_drag_started(library_id)` 수신 시 Workspace는 ID 유효성 검사를 하지 않음 — 검사 책임은 LibraryService. (b) `EvaluationService.submit()` Validating 단계에서 `LibraryService.validate_citations(player_citations)` 호출 시 미존재 ID 감지 → `submission_rejected("invalid_citation:[library_id]")` emit → Workspace `FROZEN` → `ACTIVE` 복귀. DeskPane "존재하지 않는 인용 항목이 포함되어 있습니다. 인용을 확인해주세요." 메시지. 해당 evidence는 노드에서 *수동 제거* 의무 (자동 제거 X — 플레이어 의도적 확인 필요).
+
+- **If 동일 `library_id`를 같은 노드에 재드롭** (Rule 4 중복 차단): 두 번째 드롭 거부 + 카드 원위치 즉시 복귀(애니메이션 없음 — silent drop cancel) + 대상 노드의 이미 첨부된 동일 evidence 항목이 250ms yellow flash (중복 항목을 시각적으로 지시). hint 텍스트 없음 — flash가 충분한 피드백.
+
+- **If 노드 evidence count가 정확히 5이고 6번째 드래그**: 드래그 중 노드 위 커서 진입 시 drop zone 하이라이트 비활성 + 커서 "금지" 심볼 변경 (드롭 불가 선행 피드백). 드롭 발생 시 카드 원위치 복귀 + "이 노드에는 인용을 5개까지만 첨부할 수 있습니다" hint (Rule 4 지정). 실시간 커서 피드백이 hint보다 우선.
+
+- **If 드롭한 Library 카드가 노드 사이에 떨어짐** (no hit-test target — Rule 4 §3.3): hit-test 결과 유효 노드 없음 → 카드가 드롭 위치에서 원본 LibraryPane 위치로 ease-back 애니메이션 복귀 (0.25s ease-out) + "노드 위에 드롭해주세요" hint. 카드는 LibraryPane `ItemView`에서 사라지지 않음 — 동일 카드 재드래그 가능.
+
+### 5.4 Lifecycle / state transitions
+
+- **If `submission_rejected`가 Workspace `INACTIVE` 중 도착** (평가 중 플레이어 이탈 — 경쟁 조건): `INACTIVE` 상태 수신은 무시. Workspace `INACTIVE` 유지. 플레이어가 해당 케이스로 재진입(`workspace_handoff_started`) 시 `ACTIVE` 전환되며 거부 사유는 `WorkspaceData`에 임시 보관 → DeskPane 상단 배너 "이전 제출이 거부되었습니다: [reason]".
+
+- **If `evaluation_completed` 도착했으나 `case_id` 불일치** (케이스 전환 중 평가 완료): Workspace는 수신된 `result.case_id`가 현재 `active_case_id`와 다르면 시그널 무시. `EvaluationResult`는 #11 Career Progression이 독립 수신·영속화 — 데이터 손실 없음. Browser Catalog의 해당 케이스 봉투는 `Resolved`로 갱신 (Browser가 `evaluation_completed` 직접 수신). Workspace는 현재 케이스 상태 유지.
+
+- **If 플레이어가 FROZEN 중 ANY 입력 시도**: 트리 편집(추가/이동/삭제/레이블), evidence 드롭, 메모 편집, Submit 재클릭 모두 무시. 입력 이벤트 consumed 처리 — UI 위젯 자체 disable. "제출이 처리 중입니다" 오버레이 배너 계속 표시. **예외**: `Escape` 키 + 메인 메뉴 접근은 무시 대상에서 제외 — FROZEN 중에도 메뉴 탐색 허용 (Pillar 3 — 어떤 UX 압박도 플레이어 이탈 자유 침해 X). 메뉴 이탈은 5.4 첫 항목의 INACTIVE 경쟁 조건으로 처리.
+
+- **If 게임이 FROZEN 중 크래시·종료** (chain_data export 후 평가 미반환): 재시작 시 `WorkspaceData`는 `FROZEN` 상태로 직렬화됐으나 `EvaluationService`는 `IDLE` 초기화. Workspace는 기동 시 저장 상태가 `FROZEN`임을 감지 → 자동으로 `ACTIVE` 복구 + "이전 세션에서 제출이 완료되지 않았습니다. 다시 제출해주세요." 배너. `chain_data` 스냅샷은 `WorkspaceData`에 보존 → 재제출 시 *동일 스냅샷 재사용* (사후 편집 없이 동일 내용 재전달 — Pillar 1 가드 유지).
+
+- **If `workspace_handoff_started`가 이전 케이스 Workspace `ACTIVE` 중 도착** (Browser §3 코너): `workspace_handoff_started(case_id_B)` 수신 시 현재 ACTIVE case_A에 대해 `workspace_handoff_ended(case_id_A, "paused")` 자동 emit 후 case_B 전환. case_A `WorkspaceData`는 #3 Save/Load가 직렬화 (`workspace_state_changed` emit 포함). case_B Workspace `INACTIVE` → `ACTIVE`. 플레이어 경고 없음 — "paused" 이탈은 정상 흐름.
+
+### 5.5 Memo edge cases
+
+- **If memo가 정확히 500자에서 추가 입력 시도** (Rule 5 cap): `TextEdit.max_length=500` 하드 캡 → 501번째 키 입력 자체 차단 (입력 무시). 별도 에러 메시지 없음 — 글자 수 카운터 "500/500" 실시간 표시가 cap 도달 인지 제공. 붙여넣기 시 500자 초과분 잘림 (truncate-on-paste).
+
+- **If memo가 공백·이모지 only**: 허용. Rule 5 내용 형식 제약 없음 (plain text MVP). 저장·직렬화·`memo_length` 계산은 실제 character count 그대로. `chain_data`에는 `memo_length`(공백·이모지 포함 character count)만 포함, 본문 미포함 (Pillar 1 가드 — 공백 메모도 평가 미반영).
+
+- **If 5000자 클립보드를 메모에 붙여넣기** (MVP plain text): `TextEdit.max_length=500` 적용 → 첫 500자만 삽입, 이후 잘림. 잘림 발생 시 카운터 "500/500"으로 즉시 갱신 — 시각 피드백. 경고 다이얼로그 없음.
+
+### 5.6 Pillar 1 guard violations (silent regressions)
+
+- **If 미래 코드 변경이 `chain_data`에 `memo_text`를 포함시키려 시도**: `chain_data` Dictionary는 `schema_version: 1` 하에서 허용 필드 집합을 `schema_version`, `nodes`, `edge_count`, `max_depth_reached`, `total_evidence_count`로 잠금. `submit()` 호출 직전 chain_data 빌더는 allow-list 검증 — `memo_text` 또는 비허용 필드 포함 시 `push_error("chain_data schema_version=1 violation: forbidden field [field_name]")` + `submission_rejected("schema_violation")` emit. 빌더가 자기 생성 dict를 자기 검증 — unit test AC 항목 커버 의무.
+
+- **If Library entry의 `hanja_terms`(또는 미래 확장 필드)가 `library_id` 형식 변경 시도**: `library_id` 계약은 `LibraryEntry.id` 단일 소스이며 런타임 합성 ID(`case:.../holding-N`)는 `<file.id> + "/holding-" + N` 고정 패턴 외 변형 불허. `hanja_terms` 등 확장 필드는 검색·표시 전용 — evidence 배열 저장 또는 citation 검증 경로에 투영 X. LibraryService `get_entry(id)` 인터페이스는 합성 완료 ID만 입력으로 받도록 타입 계약 유지. 향후 ID 형식 변경 시 별도 migration + `schema_version` bump 의무 (Library ADR-0001 amendment 절차 mirror).
+
+### 5.7 Workspace-Browser boundary
+
+- **If 플레이어가 case A WorkspaceHandoff 후 mid-edit으로 case B WorkspaceHandoff 발화** (case A 미제출): 5.4 마지막 항목 처리 경로 적용. case A는 `workspace_handoff_ended(case_id_A, "paused")` auto-emit → `INACTIVE`. 삭제 확인 다이얼로그 없음 — case A 트리·메모·evidence는 `WorkspaceData`에 보존되며 재진입 시 복원 (Rule 8 §3.3 persistence 정합, Browser §AC-20 post-WorkspaceHandoff tree+memo PERSISTENT 보장). case B Workspace `ACTIVE` 진입.
+
+- **If `workspace_handoff_ended(reason: "paused")`가 Workspace `FROZEN` 중 emit 시도**: 상태 머신상 불가능 — `FROZEN` 진입 조건은 Submit 클릭이고 `workspace_handoff_ended` emit 조건은 ACTIVE 이탈 또는 READ_ONLY 후 Browser VerdictArrived 완료. 그러나 방어적 guard로: `workspace_handoff_ended` 수신 시 Workspace가 `FROZEN`이면 시그널 무시 + `push_warning("workspace_handoff_ended received during FROZEN — ignored; evaluation in progress")`. Browser는 이 거부를 관찰 불가하므로 Browser `WorkspaceHandoff` 상태가 교착 가능 — 이 경우 Browser측 타임아웃 가드 필요 (**OQ-W8** Browser 위임).
+
+## 6. Dependencies
+
+본 GDD가 의존하는 시스템·ADR 인터페이스를 양방향(상류·하류·아키텍처) 명시. 각 행은 §3.3에서 잠근 시그널/API 계약을 응축하고, 후속 ADR 또는 GDD가 변경 시 본 GDD 갱신 트리거를 발동시키는 traceability hook 역할.
+
+### 6.1 시스템 의존성 (양방향)
+
+| # | 시스템 | 방향 | 강도 | 인터페이스 | 본 GDD 측 책임 | 상대 측 책임 |
+|---|---|---|---|---|---|---|
+| **#1** | Case Data Schema | 상류 (Read-only) | Hard | `CaseService.get_case(case_id) -> CaseFile` | `case_id`로 케이스 메타 조회. **`correct_disposition` / `correct_citations` / `scoring_weights` 접근 금지** (정보 격리 — 사후 정당화 방지 Pillar 1 가드) | Case Resource를 Library 참조 ID로 직렬화 (#1 GDD §3 정합) |
+| **#20** | Legal Reference Library | 상류 (Read-only) | Hard | `LibraryService.get_entry(id)`, `LibraryService.get_holding(synthesized_id)`, `LibraryService.validate_citations(ids)`; CitationDrop 시그널 2종 (`citation_drag_started`, `citation_dropped`) | Evidence 카드 표시·드롭 처리·invalid_citation EC §5.3 처리 | Holding 합성 ID 일관성 (Library §3.1.2), 드래그 시그널 emit (Library §3.2 CitationDrop state) |
+| **#3** | Save/Load | 하류 (Read+Write 위임) | Hard | Workspace `workspace_state_changed` emit; #3가 직렬화 시점 결정 | 상태 변경 시 시그널 emit; 직접 파일 I/O 금지 | `WorkspaceData` Resource를 케이스 lifecycle 동안 직렬화/역직렬화. **저장 빈도 정책 #3 GDD 위임 (OQ-W4)**; integrity sweep 대상 (orphan node EC §5.2 처리) |
+| **#7** | Brief Editor | 하류 (chain_data 입력 계약 제공) | Soft | `node.evidence` 배열에서 `{{cite:<library_id>}}` 토큰 자동 생성 (Library `library_brief_cite_token` constant 정합) | Evidence ID array를 Brief Editor에 노출 | Brief Editor가 워크스페이스 evidence를 인용 토큰으로 변환 |
+| **#9** | Submission & Evaluation | 하류 (chain_data export) | Hard | `EvaluationService.submit(PlayerSubmission)`; `chain_data` Dictionary export (ADR-0007 §1); `submission_rejected` / `evaluation_completed` 시그널 수신 | Freeze 행동 계약 (ADR-0007 §3.2 forward-constraint) 이행; chain_data schema_version=1 빌드·검증; FROZEN/READ_ONLY 상태 머신 | EvaluationService autoload (ADR-0007 §2); 평가 결과 evaluation_completed emit |
+| **#14** | Retrospective Replay (Alpha) | 하류 (READ_ONLY 데이터 소스) | Soft | READ_ONLY 상태의 `WorkspaceData` 인스턴스 | 결정문 도착 후 워크스페이스 아카이브 보존 (불가변) | 아카이브 열람 인터페이스 — *본 GDD scope 외* (#14 위임) |
+
+**의존성 그래프 (compact)**:
+
+```
+#1 Case Data Schema  ──read──┐
+#20 Legal Library    ──read──┤── #6 Reasoning Workspace ──emit──> #3 Save/Load
+                              │                          ──read──> #7 Brief Editor
+                              └────chain_data export────> #9 Submission & Evaluation
+                                                          │
+                                                          └──submission_rejected/
+                                                             evaluation_completed
+                                                             └────> #6 (back to ACTIVE/READ_ONLY)
+                                                                    └──READ_ONLY──> #14 Retrospective Replay
+```
+
+### 6.2 아키텍처 의존성 (ADR)
+
+| ADR | Status | 본 GDD 의존 사항 | 변경 트리거 |
+|---|---|---|---|
+| **ADR-0001** (Library Storage Format) + Amendment 1 + 1.1 | Accepted | `LibraryEntry` / `LibraryLawEntry` / `LibraryPrecedentEntry` / `LibraryHolding` 클래스 트리. Evidence ID 형식 (`law:...`, `case:.../holding-N`) 계약. | Library ID 형식 변경 시 Rule 4 evidence 타입 검증·EC §5.6 forward-defense 갱신 의무 |
+| **ADR-0004** (Korean Text Rendering MSDF Font) | Proposed (verification 대기) | Theme type variations (`&"BodyLabel"`, `&"CommentLabel"`, `&"MemoLabel"`, `&"MemoEdit"`, `&"CourtHeadline"`, `&"CaptionLabel"`); `RichTextLabel + scroll_active=true` 가상화 (메모 본문); `inline_theme_override_without_type_variation` forbidden_pattern; `text_server/backend = "TextServerAdvanced"` 의존 | Theme key 추가/변경 시 §3.1 Rule 5 + §8.1.6 + §9.4 갱신 |
+| **ADR-0007** (Submission Evaluation Algorithm) | Proposed (verification 대기) | §1 chain_data Dictionary 입력 계약 (schema_version=1); §3.2 freeze 스냅샷 forward-constraint (submit() 시점 workspace 메모 불가변); EvaluationService autoload + `submission_rejected` / `evaluation_completed` 시그널 | chain_data 스키마 변경 시 ADR amendment + GDD §3.1 Rule 6 + §4 Formulas + §7 schema_version knob 동시 갱신 |
+| **Workspace Layout ADR** (provisional — 미작성) | Pending | 3-Pane 레이아웃 내 DeskPane 위치/크기, 메모 패널 OQ-W5 ratify, 트리 캔버스 panning OQ-W10, gamepad CitationDrop OQ-W9, **CitationDrop signal topology** (`citation_drag_started`/`citation_dropped` 발신자 + Godot 4.6 native drag-drop API 채택 vs autoload signal 선택 — OQ-W13), 노드 카드 inner padding (effective text box 200×46px — bottom evidence rule 영역 예약) | 본 GDD §9 PROVISIONAL → LOCKED 전환의 prerequisite. §3.3 시그널 contract만 본 GDD에서 잠금; emitter 구체는 본 ADR 책임 (decisions-2026-05-07 Gate ③ 위임 검증 invariant 4건 준수). UI Foundation epic 진입 시 작성 의무 |
+
+### 6.3 GDD 횡단 의존성 (정합 요건)
+
+| 상대 GDD | 잠금 사항 | 본 GDD 측 이행 |
+|---|---|---|
+| **#5 Case File Browser §3.6 WorkspaceHandoff** | Browser가 FactsOpen → WorkspaceHandoff 전이 시 통제권 위임. `workspace_handoff_started(case_id)` emit | §3.3 시그널 명세 closure (Browser §6 OQ-5 해소) |
+| **#5 Case File Browser §AC-20** | Pre-WorkspaceHandoff 메모 *VOLATILE* / Post-WorkspaceHandoff 워크스페이스 트리 + 메모 *PERSISTENT* | §3.3 Persistence 정책 (Rule 8) — `WorkspaceData`는 케이스 InProgress 동안 #3가 직렬화. 본 GDD가 *영속 메모* 정책 책임 |
+| **#20 Library §3.1.2** | Holding ID 합성 규칙 `<file.id> + "/holding-" + N` 단일 source | §3.1 Rule 4 evidence 타입 검증 (precedent root 거부 — holding 단위만) |
+| **#20 Library §3.2 CitationDrop state** | Library가 드래그 시작 시 `citation_drag_started(library_id)` emit; Workspace가 drop target 정책 책임 | §3.3 CitationDrop 시그널 명세 + Rule 4 정책 (cap·중복·타입) |
+| **#9 Submission & Evaluation §3.1.1** | PlayerSubmission Resource의 `chain_data: Dictionary` 필드 | §3.1 Rule 6 + §4.1 chain_data 빌드 책임 본 GDD |
+| **#2 UI Foundation** (미설계) | Workspace UI Control 노드 구체 | §9 PROVISIONAL — Control class 선택 위임. UI Foundation 작성 후 본 §9 LOCKED 전환 |
+
+### 6.4 의존성 강도 분류
+
+- **Hard (시스템 미존재 시 본 GDD 기능 중단)**: #1, #20, #3, #9, ADR-0001/0004/0007
+- **Soft (선택적 enhancement)**: #7 (Brief Editor 없어도 Workspace 작동), #14 (Alpha 시스템 — MVP 외)
+- **Pending hard-gate (미설계 의존, MVP QA 진입 차단 의무 — 2026-05-07 cycle 2 강화)**:
+  - **#4 Settings & Accessibility GDD** — accessibility I-9 IMPORTANT closure: Workspace MVP는 #4가 최소 3 API (`reduced_motion: bool`, `text_scale: float [1.0, 2.0]`, `keyboard_shortcut_remap: Dict[String, String]`) 제공 시점까지 QA 진입 차단. AC-40·AC-41·§9.6 keyboard configurable 모두 #4 의존.
+  - **#2 UI Foundation** — §9 PROVISIONAL 잠금만; Control class 구체는 Workspace Layout ADR 위임 (UI Foundation epic 시작 전제).
+  - **Workspace Layout ADR** — 메모 패널 OQ-W5 fallback ratify + gamepad OQ-W9 + panning OQ-W10 + signal topology OQ-W13. **§8.1.1.b inner padding spec은 본 GDD 2026-05-07 cycle 2에서 잠금 (위임 폐기)** — Workspace Layout ADR scope 축소.
+
+## 7. Tuning Knobs
+
+### 7.1 Structural Caps
+
+| Knob | Type | Default (MVP) | Safe Range | Affects | Extreme Behavior |
+|---|---|---|---|---|---|
+| `max_tree_depth` | int | 3 | 2 – 5 | §3.1 Rule 2 트리 깊이 제한; chain_data `max_depth_reached` 상한 | <2: 루트+자식 2계층만 — "상고이유 → 쟁점" 표현만 허용, 판례 근거 계층 소실, Pillar 1 가중치 신호 빈약; >5: 트리가 다단계 프레임으로 분기 — `total_evidence_count` 상한이 depth × evidence_per_node_cap으로 선형 확대, 인지 과부하 |
+| `evidence_per_node_cap` | int | 5 | 3 – 8 | §3.1 Rule 4 노드당 첨부 evidence 최대 수; chain_data `total_evidence_count` 공동 상한 | <3: 노드 하나가 판례 2건 이하 — 인용 전략 폭 협소, 중요 판결 선택 압박 과다; >8: 인용 희석 — 핵심 판시 단락이 잡음에 묻혀 Pillar 1 가중치 신호 저하 |
+| `node_label_char_limit` | int | 60 | 30 – 120 | §3.1 Rule 3 레이블 *입력·저장* cap (display는 ellipsis truncation 정책 — Rule 1 참조; 200×48px 카드 inner box 단일 행 표시 ~13–15자, 그 이상은 hover tooltip + 편집 진입 + F2 list view에서 노출) | <30: 가설 문장 절단 불가피 (저장 자체 cap), 플레이어 좌절; >120: 입력 길이 부담 + ellipsis 빈도 증가로 시각 노이즈; 카드 자체 높이는 영향 없음 (truncation으로 안전) |
+| `node_memo_char_limit` | int | 500 | 200 – 2000 | §3.1 Rule 5 메모 TextEdit 입력 cap; `RichTextLabel scroll_active` 활성화 시점 압박 | <200: 메모 공간이 너무 협소 — 사고 보조 기능 무력화; >2000: 단일 노드 메모가 단문 준비서면 수준이 되어 §7 Brief Editor 역할 침범, chain_data `memo_length` 집계 불균형 |
+| `max_root_count` | int | unlimited | 1 – 20 | 병렬 가설(다중 루트) 최대 수 — v1+ 플래그 | <1: 병렬 가설 불가 — 게임 플레이 근본 제약; =1: 단일 루트 강제, 다양한 상고이유 탐색 불가; >20: DeskPane 수평 오버플로 — 레이아웃 UX 파탄, §9 요건 범위 초과 |
+
+### 7.2 Interaction Tuning
+
+| Knob | Type | Default (MVP) | Safe Range | Affects | Extreme Behavior |
+|---|---|---|---|---|---|
+| `node_drag_threshold_px` | float | 8.0 | 4 – 16 | §3.1 Rule 3 이동 의도 인식 — plain drag 시작 감지 픽셀 (click vs drag 구별 임계) | <4: 미세 움직임에도 드래그 시작 → 클릭 중 의도치 않은 노드 이동 다수; >16: 드래그 시작이 느껴질 만큼 지연 — 이동 의도 인식 불량, `evidence_hit_test_tolerance` 부등식 위반 리스크 |
+| `evidence_hit_test_tolerance_px` | float | 16.0 | 8 – 32 | §3.1 Rule 4 CitationDrop — 드롭 타겟 노드 히트박스 확장 | <8: 소형 노드 위 드롭 정확도 요구 과다 — 정밀 조작 스트레스; >32: 인접 노드 히트박스 중첩 → 잘못된 노드에 evidence 첨부 빈발 |
+| `node_double_click_window_ms` | int | 350 | 200 – 500 | §3.1 Rule 3 레이블 인라인 편집 진입 / Rule 3 루트 노드 추가 더블클릭 인식 | <200: 빠른 단순 클릭이 편집 진입 오발동; >500: 더블클릭 의도가 두 번의 단일 클릭으로 오판 → 편집 진입 불가, 선택 중복 토글 |
+
+### 7.3 Visual Feedback Intensity (§9 Prep)
+
+| Knob | Type | Default (MVP) | Safe Range | Affects | Extreme Behavior |
+|---|---|---|---|---|---|
+| `selected_border_thickness_px` | float | 2.0 | 1.0 – 3.0 | §3.1 Rule 1 선택 노드 보더 — Art Bible §3.1 정합 | <1.0: 선택 상태 인식 불량 — 어떤 노드에 메모 패널이 연결됐는지 불명확; >3.0: 보더가 카드 내 텍스트 영역 침범, 200×48px 레이아웃 압박 |
+| `unselected_border_thickness_px` | float | 0.5 | 0.25 – 1.0 | §3.1 Rule 1 미선택 노드 보더 — Art Bible §3.1 정합 | <0.25: 노드 경계 소실 — 카드 식별 불가; ≥ `selected_border_thickness_px`: 선택/미선택 구분 신호 소실 (항상 unselected < selected 유지 필요) |
+| `evidence_rule_visible` | bool | true | true \| false | §8.1.1.b bottom evidence rule (Channel B) 표시 여부 — Pillar 1 가시화 메인 채널 | =false: bottom rule 미표시 — Pillar 1 "무게가 보인다" 판타지 소실. *Selection signal(Channel A)만으로는 evidence weight 미가시 — 디버그 외 사용 금지* |
+| `evidence_rule_thickness_px` | float | 2.0 | 1.5 – 3.0 | §8.1.1.b bottom evidence rule 두께 — 길이는 ρ에 종속 (튜닝 X), 두께만 조정 | <1.5: 인지 임계 근접; >3.0: 카드 inner box (effective 200×46px) text vertical center 압박 — Layout 의존 |
+| `freeze_overlay_fade_ms` | int | 250 | 150 – 500 | §3.1 Rule 7 FROZEN 상태 진입 시 오버레이 배너 페이드인 속도 | <150: 배너가 즉각 등장 — 플레이어 깜짝 놀람, 전환 폭력적; >500: 오버레이가 느리게 떠서 플레이어가 FROZEN 상태임을 인지하기 전에 입력 시도 → UX 혼란 |
+
+### 7.4 Confirmation Thresholds (Pillar 3 — *cut* anchor)
+
+| Knob | Type | Default (MVP) | Safe Range | Affects | Extreme Behavior |
+|---|---|---|---|---|---|
+| `delete_confirmation_subtree_threshold` | int | 0 | 0 – 5 | §3.1 Rule 3 삭제 확인 다이얼로그 발동 조건 — 서브트리 총 노드 수 N 이상일 때 확인. Default 0 = 항상 확인 | =0: 항상 확인 — Pillar 3 "삭제 무게" 판타지 완전 보존; =1: 단일 리프 삭제는 확인 없이 진행 — 경량화 UX이나 Pillar 3 약화; >5: 깊은 서브트리 삭제도 즉시 실행 — 판타지 침해, §2 Player Fantasy "아깝다는 감각" 소실 |
+
+### 7.5 chain_data Export
+
+| Knob | Type | Default (MVP) | Safe Range | Affects | Extreme Behavior |
+|---|---|---|---|---|---|
+| `chain_data_schema_version` | int | 1 | locked | §3.1 Rule 6 chain_data Dictionary 구조 식별자 — ADR-0007 §3.2 마이그레이션 계약 | 임의 변경 금지. 스키마 변경은 ADR-0007 Amendment로만 처리. 변경 없이 버전 번호만 올리면 `EvaluationService` 파싱 오류 |
+
+### 7.6 Tuning Interaction Warnings
+
+세 가지 위험한 조합을 주의해야 한다.
+
+**구조 상한 공동 효과.** `max_tree_depth`와 `evidence_per_node_cap`은 chain_data `total_evidence_count` 상한을 공동으로 결정한다. MVP 기본값 기준 이론적 최대는 `(4^0 + 4^1 + 4^2 + 4^3) × 5 = 425`이나 실제 `max_root_count`와 분기 패턴에 따라 달라진다. 두 값을 동시에 올릴 경우 chain_data 직렬화 크기와 v1+ `EvaluationService` chain_coherence 연산 비용이 배수로 증가한다.
+
+**드래그 vs 히트 테스트 부등식.** `node_drag_threshold_px`와 `evidence_hit_test_tolerance_px`는 반드시 `evidence_hit_test_tolerance_px ≥ node_drag_threshold_px` 관계를 유지해야 한다. 이 부등식이 무너지면 드롭 히트 테스트가 등록되기 전에 드래그가 시작되어 evidence 첨부가 항상 차단된다.
+
+**Pillar 3 약화 플래그.** `delete_confirmation_subtree_threshold > 0` 으로 높이면 Pillar 3 "삭제 무게" 앵커가 약화된다. 이 값을 변경하기 전에 game-designer 검토를 받아야 한다 — §2 Player Fantasy의 "누구도 재촉하지 않는다" 경험은 시간 압박이 없는 환경에서 확인 다이얼로그가 유일한 마찰 포인트이기 때문이다.
+
+### 7.7 Knob 저장 위치
+
+| 범주 | 값 | 저장 위치 |
+|---|---|---|
+| 구조 상한 (§7.1) | `max_tree_depth`, `evidence_per_node_cap`, `node_label_char_limit`, `node_memo_char_limit`, `max_root_count` | `design/registry/entities.yaml` constants 섹션 (cross-system 등록 대상) |
+| Pillar 3 임계값 (§7.4) | `delete_confirmation_subtree_threshold` | `design/registry/entities.yaml` constants 섹션 |
+| 인터랙션·시각 피드백 (§7.2, §7.3) | drag threshold, hit-test tolerance, double-click window, border thickness, modulation strength, fade duration | `assets/data/workspace/tuning.tres` (Workspace 전용 튜닝 Resource) |
+| chain_data 스키마 버전 (§7.5) | `chain_data_schema_version` | ADR-0007에 잠금 — 별도 파일 저장 불필요 |
+
+구조 상한은 EvaluationService(ADR-0007), §7 Brief Editor, §10 Verdict Reveal이 동일 값을 참조하므로 레지스트리 등록 필수. 인터랙션·시각 튜닝은 Workspace 내부 전용이므로 ADR-0001/0004 관례를 따라 theme resource 또는 전용 tuning resource로 격리.
+
+## 8. Visual/Audio Requirements
+
+본 섹션은 Reasoning Workspace의 시각·오디오 요건을 정의한다. 모든 시각 결정은 Art Bible의 인쇄 미학을 따르며 — *법정 기록* 톤의 잉크블랙·판결지·인장빨강 팔레트, 0.5px·2px 두 단계 보더, 외부 그림자 없음 — Pillar 1(가중치 시각화)와 Pillar 3(시간 압박 0의 침묵)을 직접 구현한다. 모든 오디오 결정은 *물리적 책상의 종이·펜·법정 atmosphere*를 차용하며 게임 컨벤션의 긴장 자극·시간 압박 큐를 명시 금지한다. 시각·오디오는 1:1 중복(audio 단독 정보 전달 금지) 의무 — 접근성 요건(§9.6) 정합.
+
+### 8.1 Visual Requirements
+
+**8.1.1 Node visual states**
+
+모든 spec은 Art Bible §3 (Shape Language), §4 (Color System), §7 (Motion Style) 정합. Visual signal은 **두 직교 채널**로 분리 (Gate ② decisions-2026-05-07 참조):
+- **Channel A (Selection)**: 외곽 보더 두께 — binary (0.5px 미선택 / 2px 선택).
+- **Channel B (Evidence weight)**: 노드 하단 *bottom evidence rule* 길이 — continuous 6단계 ρ ∈ {0.0, 0.2, 0.4, 0.6, 0.8, 1.0} (§4.4 evidence_density · §8.1.1.b 명세).
+
+두 채널은 동시 발화해도 충돌 없음 — 본 결정은 0.125px subpixel 인지 임계 미달 + selection signal과의 신호 압도 문제(2026-05-07 review BLOCKING #6/#7) 해소.
+
+| State | Border (Channel A) | Background | Text color | Shadow | Notes |
+|---|---|---|---|---|---|
+| `default unselected` | 0.5px **미드그레이 `#8C8C8C`** (Art Bible §3 라인 무게 표 + WCAG 1.4.11 non-text contrast 3.0:1 충족 — accessibility BLOCKING #3 closure; 기존 `#D9D6CF` 1.3:1 ratio 폐기) | 판결지 `#F5F2EC` | 잉크블랙 `#1A1A1A` | 없음 (Art Bible §3 "외부 그림자 없음") | 기준선 — bottom rule(Channel B)이 별개로 발화 |
+| `selected` | 2px 잉크블랙 `#1A1A1A` (Art Bible §3 "활성·선택 강조 2px") | 판결지 `#F5F2EC` — 배경색 변화 없음 (Art Bible §3 "배경색 변화 없음") | 잉크블랙 `#1A1A1A` | 없음 | 테두리 두께 전환만 — 0.05초 (Art Bible §7 클릭 피드백). bottom rule(Channel B) 길이 영향 없음 |
+| `drop target hover (CitationDrop 중)` | 1px 잉크블랙 `#1A1A1A` — 미선택에서 0.5px→1px 상승. 선택은 2px 유지 | 판결지 `#F5F2EC` — 배경 변화 없음 (Art Bible §3 원칙) | 잉크블랙 `#1A1A1A` | 없음 | 드래그 진입 즉시 전환. 이탈 즉시 복원. 0.08초 (Art Bible §7 호버 속도) |
+| `drop target REJECTED flash (shape-only, 인장빨강 폐기)` | 1.5px **미드그레이 `#8C8C8C` 점선** (`StyleBoxFlat` border_dash 또는 등가) | 판결지 `#F5F2EC` — 배경 변화 없음 (인장빨강 5% 투명 폐기 — art-director B-NEW-1 BLOCKING closure: 인장빨강 단독 시맨틱 결정문 전용 lockdown 정합) | 잉크블랙 `#1A1A1A` | 없음 | 150ms 후 원래 상태로 선형 페이드. 거부 신호는 *shape cue (점선)* + 카드 원위치 ease-back으로 전달 — 색 채널 사용 X. 색맹 가드: spatial+motion 채널 다중 |
+| `evidence duplicate flash (subtle grey tint)` | 기존 보더 유지 | 미드그레이 10% 투명도 `#8C8C8C1A` (Art Bible §4 팔레트 준수 — 색맹 가드: 색 단독 의존 금지; flash는 spatial 위치 cue 보완) | 잉크블랙 `#1A1A1A` | 없음 | 250ms 후 페이드. 경고가 아닌 *지시* — 이미 있는 항목을 조용히 가리킨다. bottom rule 영향 없음. *(art-director I-1 IMPORTANT closure: state name "yellow" → "subtle grey tint" — 실제 색과 일치)* |
+
+**Pillar 3 (시간 압박 0)**: 플래시 두 종 모두 단기 시각 후 즉시 소멸 — 상태가 남지 않고 화면이 정적으로 복귀.
+
+**8.1.1.b Bottom evidence rule (Channel B — Pillar 1 가시화 채널)**
+
+각 노드 카드 하단에 가로 *evidence rule* (밑줄 강조 mark)이 evidence 수에 비례한 길이로 표시 — 한국 법조 문서의 *중요 부분 밑줄* 관례 직접 차용.
+
+| 변수 | 값 |
+|---|---|
+| 위치 | 노드 카드 하단 edge — 카드 외곽 보더의 *내측* (보더가 룰을 시각적으로 감싸지 않음). 좌측 정렬 |
+| 두께 | 2.0px (고정 — `evidence_rule_thickness_px` knob §7.3) |
+| 색상 | 잉크블랙 `#1A1A1A` (Art Bible §3 line weight 표 — 활성 line) |
+| 길이 | `ρ × node_inner_width` — `ρ = len(n.evidence) / EVIDENCE_PER_NODE_CAP` (§4.4). MVP cap=5 기준 6단계 0%·20%·40%·60%·80%·100% |
+| 가시 조건 | `ρ > 0` 시 표시; `ρ == 0` 시 미표시 (룰 자체 없음 — 카드 하단 빈 공간) |
+| 추가 (evidence add) | 0.15초 linear width tween 좌→우 grow (Art Bible §7 "문서 간 전환 0.15초 페이드" 정합) |
+| 제거 (evidence remove) | 0.15초 linear width tween 우→좌 shrink |
+| Reduced-motion 모드 | tween 비활성, snap to final width (AC-40 정합) |
+
+**Layout — inner padding spec (art-director B-NEW-5 BLOCKING closure 2026-05-07 cycle 2)**: 200×48px 카드 기준 inner padding 명세를 본 GDD에서 잠금 (Workspace Layout ADR 위임 폐기 — Gate ② tradeoff (a) 직접 이행):
+
+| 영역 | 값 |
+|---|---|
+| Top padding | 6px |
+| Left padding | 8px |
+| Right padding | 8px |
+| Bottom padding | 4px (`evidence_rule_visible == false` 시) / 2px text + 2px rule 영역 (`evidence_rule_visible == true` 시) |
+| Effective text box (rule 부재) | 184×38px |
+| Effective text box (rule 활성) | 184×40px (수직 정렬은 위쪽 6px + 아래 2px text padding + 2px rule 영역 = 본문 높이 40px) |
+| Label 폰트 | Pretendard Regular 14pt (line-height 18px — 단일 행 수용) |
+
+이 padding은 Art Bible §3.1 200×48px hero shape 명세 *확장* (Art Bible amendment 트리거 — art-director가 Art Bible §3.1에 본 padding spec 등재 의무). Bottom rule은 inner padding 영역 내부 좌측 정렬, 좌측 padding 8px 시작점에서 grow → 200px node 좌측 edge에서 inset 되어 표시되지 않는다 (rule은 효과 영역 좌측 8px 시작 → ρ × 184px 길이 → 카드 내측 우측 padding까지). 즉 ρ=1.0 시 룰은 184px (200px 카드 inner 가로) 가득 차고, 카드 외곽 padding 영역은 룰이 침범 X. AC-37 픽셀 수치 정합 갱신 의무 (40/120/200px → 36.8/110.4/184px ±2px).
+
+**Pillar 1 (가중치 시각화) 직접 구현**: bottom evidence rule 길이가 인용 수에 비례 — 인용이 쌓일수록 *밑줄이 길어진다*. 6 단계 이산 길이 (40px 단위)는 1080p에서 모두 명확히 구분 (subpixel 임계 ≫). `evidence_rule_visible == false` 또는 cap=0인 극단 케이스에서도 selection signal(Channel A)과 독립 — Pillar 1 메인 신호 채널 유지.
+
+**색맹 가드**: 길이는 spatial cue 단독 — 색 단독 신호 의존 없음 (Art Bible §4 정합).
+
+**8.1.2 Tree edges**
+
+- **스타일**: 직선 (Art Bible §3 "선은 항상 직선이다"). 실선. 굵기 0.5px (Art Bible §3 "보조 정보 구분"). *art-director I-4 IMPORTANT 지적: parent-child 관계는 "단락 구분"보다 강한 의미이므로 1px 후보도 검토 가능. 본 cycle은 0.5px 유지 + Art Bible §3 amendment 시 재검토.*
+- **색상**: **미드그레이 `#8C8C8C`** (기존 라이트그레이 `#D9D6CF` 폐기 — WCAG 1.4.11 non-text contrast 3:1 충족, accessibility BLOCKING #3 closure). 엣지는 구조의 보조 기록 — 결정 아님.
+- **라우팅**: 직각 절곡 오서거널 (L-라우트). 트리 레이아웃이 판결문 번호 위계(I. 1. 가. ①.)와 시각적 일치.
+- **추가**: 새 자식 노드 연결 시 0.2초 리니어 드로 — 라인이 부모→자식 방향 진행 (Art Bible §7 "노드 연결 생성 0.2초 리니어 드로. 잉크가 선 위를 천천히 지나가는 느낌"). Pillar 3 — 연결이 가볍지 않음을 모션으로 전달.
+- **삭제**: 엣지 0.15초 페이드 아웃 (Art Bible §7 "문서 간 전환 0.15초 페이드").
+- **이동**: 원위치 엣지 0.15초 페이드 → 새 위치 0.2초 드로. 순차.
+
+**8.1.3 DeskPane background**
+
+- **배경**: 판결지 `#F5F2EC` 단색 + 종이 텍스처 오버레이 (Art Bible §3 "봉투 질감 오프화이트 종이 텍스처"; 에셋 `tex_paper_aged_01.png` 1024×1024px BC7, Art Bible §8). 텍스처 채도 5% 이하 — 패턴 인지 안 되는 grain. 격자·선분 패턴 금지. Art Bible §1 "꾸밈 없고 구조만 있다".
+- **여백**: 콘텐츠 영역 기준 Art Bible §3 페이지 그리드. DeskPane 내부 패딩 ≥24px — 트리 노드가 패널 경계에 붙지 않아 판결문 여백감 유지.
+- **드롭존 힌트 (`citation_drag_started` 수신 시)**: DeskPane 전체에 **미드그레이 `#8C8C8C`** 1px 점선 border (border-radius 2px) — 기존 라이트그레이 폐기 (WCAG 1.4.11 정합). 내부 배경 변화 없음. "끌어오세요" 텍스트 금지 — Pillar 3 침묵. 드래그 종료 즉시 소멸. *(art-director I-6 IMPORTANT: Art Bible §3 "플레이어 인터랙션 힌트용 점선: 허용" 1줄 amendment 의무.)*
+
+**8.1.4 Freeze overlay banner (§3.1 Rule 7) — "조용히 정지한다" 연출 (art-director B-NEW-2/B-NEW-3 BLOCKING closure 2026-05-07 cycle 2)**
+
+- **오버레이**: DeskPane 전체 덮는 판결지 `#F5F2EC` **80% 불투명** (기존 60% → 80% 상향. art-director B-NEW-2 closure: 60%는 "흐릿"이 아닌 "뚜렷"; 80%에서 트리가 20% visibility — "아직 거기 있음" 암시 + 입력 차단 명확). 배경 트리가 흐릿하게 비치며 "아직 거기 있음" 암시 — 완전 차단 아님.
+- **배너**: 수평 잉크블랙 `#1A1A1A` 바 (높이 64px), 오버레이 수직 중앙. 내부 텍스트 `&"CourtHeadline"` type variation (본명조 SemiBold 16pt — ADR-0004 §4. 인라인 theme override 금지). 문구: **"제출이 처리 중입니다"**. 텍스트 색: 판결지 `#F5F2EC` (반전 — 이 순간만 배경·전경이 뒤집힘 — Art Bible §2 상태 5 결정문 시퀀스 반전 패턴 *준비*; 결정적 반전은 #10 Verdict Reveal 전용으로 보존).
+- **~~인장 모티프~~** **폐기 (art-director B-NEW-3 BLOCKING closure)**: 32px 인장은 Art Bible §3 히어로 셰이프 minimum (120px 캔본 + 내부 大法院 14pt) 위반 + Art Bible §1 원칙 4 ("결정문 도착 시퀀스 이외에 나타나지 않는다") 직접 충돌. **인장 모티프 제거** — 배너 텍스트 단독 처리. 결정성 신호는 배너 64px 두께 + 색 반전 + `weight-stamp-deep` 오디오로 전달 (인장빨강 lockdown — 인장은 #10 Verdict Reveal 전용).
+- **연출 두 단계**: (1) 0–250ms 오버레이 페이드인 (`freeze_overlay_fade_ms` knob §7.3) — 배경 트리가 서서히 흐려진다. (2) 250ms 시점 배너 단독이 scale(1.0 유지) + opacity(0→1) 0.15초 페이드인 (Art Bible §7 "문서 간 전환 0.15초 페이드" 정합). 스케일 변화 폐기 — 인장 부재 시 *부드러운 등장*이 더 정합. ~~Art Bible §7 인장 도장 찍힘 1:1 정합~~ 폐기 (인장 자체가 부재).
+- **해제**: 오버레이 + 배너 0.15초 페이드 아웃 후 트리 인터랙션 재활성.
+
+**8.1.5 READ_ONLY post-evaluation visual**
+
+- **표시**: DeskPane 전체에 `CanvasItem.modulate` 채도 감쇠 — **15% 감쇠 (기존 5% → 15% 상향. art-director I-3 IMPORTANT closure: 5%는 1080p 육안 인지 임계 ~10-15% 미달; 15%는 임계 통과 + 30% 워터마크와 보완 신호로 작동)**. 완전 그레이스케일 금지 — 트리 구조가 판독 가능해야 한다 (#14 Retrospective Replay 데이터 소스).
+- **워터마크**: DeskPane 전체에 판결지 배경색 30% 불투명 오버레이 (FROZEN 60%보다 옅게 — 아카이브 상태 조용히 알림). 배너 없음 — READ_ONLY는 조용한 종결이지 FROZEN의 적극적 차단 아님. Art Bible §2 상태 6(회고) "낮은 에너지. 마무리의 고요."
+- **노드 테두리**: 전체 노드 border를 **미드그레이 `#8C8C8C`** 0.5px 고정 (라이트그레이 `#D9D6CF` 폐기 — WCAG 1.4.11 정합; 선택/비선택 구분 소실 — 더 이상 편집 가능한 작업 공간 아님).
+- FROZEN(배너 + 60% 오버레이)과 READ_ONLY(워터마크 30% + 채도 감쇠)는 오버레이 강도와 배너 유무로 명확히 구분.
+
+**8.1.6 Memo panel (provisional — §9 의존)**
+
+- **접힌 상태**: 패널 숨김. 노드 선택 해제 시 패널 사라짐. 패널 존재 암시 아이콘 불필요 — Pillar 3 침묵.
+- **펼친 상태**:
+  - 표시 위젯: `RichTextLabel`, `theme_type_variation = &"MemoLabel"` (ADR-0004 §4 type variation 의무; `inline_theme_override_without_type_variation` forbidden_pattern 위반 금지). 폰트 Pretendard Regular 14pt `&"BodyLabel"` 계열.
+  - 편집 위젯: `TextEdit`, `theme_type_variation = &"MemoEdit"`. 동일 폰트 계열.
+  - 배경: 판결지 `#F5F2EC`. 경계: 0.5px **미드그레이 `#8C8C8C`** (라이트그레이 `#D9D6CF` 폐기 — WCAG 1.4.11 정합; Art Bible §3 0.5px 보조 구분선).
+- **글자 수 카운터 ("500/500") (art-director B-NEW-4 BLOCKING closure 2026-05-07 cycle 2 — 인장빨강 lockdown)**: `&"CaptionLabel"` type variation (Pretendard Regular 11pt 미드그레이 `#8C8C8C`). cap 도달 시 **글꼴 무게 Medium 상승 단독 처리** (기존 인장빨강 `#C8102E` 전환 폐기 — Art Bible §4 인장빨강은 *결정적·돌이킬 수 없다·대법원 공식 행위* lockdown — 메모 cap은 *편집 중 경계 알림*으로 결정성 부재; 인장빨강 사용은 #10 Verdict Reveal 단독). 신호 채널: 위치(우측 정렬 고정) + 수치(500/500) + 글꼴 무게 (Regular → Medium). 색 단독 의존 없음 (Art Bible §4 색맹 가드 정합).
+
+**8.1.7 Asset Spec 트리거**
+
+후속 `/asset-spec system:reasoning-workspace` 실행 시 생성 대상:
+
+- ~~`vfx_freeze_banner_stamp_01.png`~~ **폐기** (art-director B-NEW-3 BLOCKING closure — 인장 모티프 §8.1.4에서 제거).
+- `tex_paper_aged_01.png` — DeskPane 배경 종이 텍스처 (1024×1024px BC7, 채도 5% 이하). **art-director I-2 IMPORTANT closure: Art Bible §8 do 예시의 canonical 명 사용. 기존 `tex_desk_paper_base_01.png` 명명 폐기 — 단일 명명 통일.**
+- **Reject flash 색 토큰 폐기 + 점선 토큰 추가**: ~~인장빨강 5% 투명 `#C8102E0D`~~ 폐기 (인장빨강 lockdown). `evidence_duplicate_subtle_grey_tint = #8C8C8C1A` (10% 투명 미드그레이) 토큰 + `dropzone_hint_dashed_grey = #8C8C8C` (점선 1px) 토큰을 `assets/data/themes/default.tres` 등록.
+- `ui_dropzone_hint_dashed.svg` — DeskPane 드롭존 1px 점선 보더 (32×32px 타일 가능 SVG 또는 StyleBox).
+- Tree edge 라인 스타일 스펙시먼 — 0.5px **미드그레이 `#8C8C8C` (WCAG 1.4.11 정합 — 라이트그레이 `#D9D6CF` 폐기)** 오서거널 L-라우트 + 0.2초 드로 (수직 segment 0–0.1초 → 수평 segment 0.1–0.2초 *순차*; art-director N-2 NICE-TO-HAVE closure: Art Bible §7 "잉크가 선 위를 천천히 지나가는 느낌" 정합). godot-shader-specialist와 구현 가능성 (Line2D vs shader) 확인.
+
+> **📌 Asset Spec** — Visual/Audio 요건이 정의됨. Art Bible 승인 후 `/asset-spec system:reasoning-workspace` 실행하여 per-asset visual descriptions·dimensions·generation prompts 생성 권장.
+
+### 8.2 Audio Requirements
+
+**8.2.1 Audio philosophy / tone**
+
+Workspace는 변호사가 사고하는 *조용한 방*이다. 모든 사운드는 종이·잉크·나무라는 물리 세계에서 차용 — 게임 컨벤션의 긴장 큐 차용 금지. 오디오는 *정보전달*이지 *판단평가* 아님 — 행동이 등록됐음을 확인할 뿐, 행동의 좋고 나쁨을 평가하지 않는다. 긴장 sting·카운트다운 톤·"오답" 부저·서두름 시사 큐는 절대 도입 금지. 감정적 무게는 두 순간에만 허용 — evidence가 노드에 부착될 때 (Pillar 1 — 인용이 안착하는 무게감) + Submit 누를 때 (Pillar 3 — 결정 전 숨을 들이마시는 sonic 등가물). 그 외 모든 인터랙션은 책장을 넘기는 정도의 정적이다.
+
+**weight-stamp / weight-stamp-deep 제작 측 measurable 제약 (audio-director #1 IMPORTANT closure)** — 위 "tension 금지" 원칙을 sound-designer 위임 시 모호함 없이 전달하기 위한 객관 spec:
+- **No pitch rise**: 음높이 상승 (rising pitch contour) 금지 — *압력*은 정적 sonic 사건이지 *증가하는 긴박*이 아님.
+- **No BPM-suggestive rhythm**: 리듬 패턴 또는 반복 attack 금지 — 단발 hit only.
+- **Attack transient ≤ 30ms**: 빠른 attack — 긴 buildup 금지.
+- **Reverb tail ≤ 200ms** (`weight-stamp`) / **≤ 600ms** (`weight-stamp-deep`): tail은 결정성 인지에 충분, urgency 부여 길이 X.
+- **No harmonic content above 4kHz**: 고주파 발사음(=긴장 trigger 컨벤션) 금지. 본 spec 위반 시 sound-designer 측 deliverable 거부.
+
+**8.2.2 Sound event catalog**
+
+| Event | §3 Ref | Cue family | Duration | Volume layer | Tone description |
+|---|---|---|---|---|---|
+| Node added (root) | Rule 3 | `paper-place` | ~150 ms | UI-low | 빈 책상 위에 종이 한 장을 내려놓는 소리 — 무게감 있고 조용 |
+| Node added (child) | Rule 3 | `paper-place-soft` | ~100 ms | UI-low | 루트보다 가볍게, 같은 결이되 안쪽 거리감 |
+| Node selected | Rule 1 | `paper-settle` | ~80 ms | UI-low | 종이가 살짝 당겨지는 느낌 — 클릭이 아니라 집어올리는 결 |
+| Node deselected | Rule 1 | *(silence)* | — | — | 다음 선택의 소리가 맡는다 |
+| Label edit start (double-click) | Rule 3 | `pen-arrive` | ~60 ms | UI-low | 펜촉이 종이 위에 닿는 순간 — 짧고 건조 |
+| Label edit confirm (Enter) | Rule 3 | `pen-lift` | ~80 ms | UI-low | 펜이 종이에서 떨어지는 결 — 작은 종결감 |
+| Node move start (plain drag) | Rule 3 | `paper-drag` | ~120 ms | UI-low | 종이 표면을 끌어당기는 결 — 마찰감, 천천히 |
+| Node move drop (success) | Rule 3 | `paper-place` | ~130 ms | UI-low | 추가와 동일 패밀리지만 약간 묵직 — 배치 결정감 |
+| Node move drop (rejected — depth/cycle) | EC §5.2 | `paper-return` | ~100 ms | UI-low | 종이가 원위치로 미끄러짐 — 조용히 돌아온다 |
+| Node delete confirm | Rule 3 | `paper-set-aside` | ~200 ms | UI-mid | 종이 묶음을 책상 귀퉁이로 — **Pillar 3 *cut* 앵커**: 삭제의 무게를 폭력 없이 |
+| Node delete cancel | Rule 3 | *(silence)* | — | — | 다이얼로그 닫힘은 시각이 충분 |
+| Memo focus | Rule 5 | `pen-arrive-soft` | ~50 ms | UI-low | 더 조용한 변형 — 필기 준비 진입 |
+| Memo char-cap reached (500/500) | EC §5.5 | *(silence)* | — | — | 시각 카운터가 충분 |
+| CitationDrop hover (drag over valid target) | Rule 4 | `paper-hover` | ~60 ms | UI-low | 종이가 목적지 위 정지한 느낌 — 단발성 진입 톤, barely there |
+| CitationDrop accept (evidence attached) | Rule 4 | `weight-stamp` | ~180 ms | UI-mid | **Pillar 1 weight cue** — 인장 도장 직전 압력감: 짧고, 둔하고, 분명. 의사결정의 무게를 sonic으로 표현하는 유일한 큐 |
+| CitationDrop reject (root / cap / duplicate) | Rule 4 | `paper-return` | ~100 ms | UI-low | depth 거부와 동일 패밀리, 약간 더 건조 — quiet, 책망 X |
+| CitationDrop miss (no hit-test) | EC §5.3 | *(silence)* | — | — | 시각 ease-back 충분 |
+| Submit click | Rule 7 | `weight-breath` | ~400 ms | UI-mid | 숨을 한 번 들이마시는 짧고 낮은 톤 — Pillar 3 망설임의 sonic 등가 |
+| FROZEN overlay appears | Rule 7 | `hush-down` (atmosphere bus) + `weight-stamp-deep` (**UI-mid bus**) | ~250 ms | mixed | 방의 소리가 한 겹 물러나고 (`hush-down`은 atmosphere -18 dB), 인장이 찍히는 묵직한 임팩트 1회 (`weight-stamp-deep`은 UI bus 0 dB — audio-director #4 BLOCKING closure: 기존 atmosphere 분류는 "게임 전체에서 이 소리만이 분명" 의도와 모순; UI bus 배정으로 명료성 확보) — 게임 전체에서 이 소리만이 분명 |
+| evaluation_completed received | Rule 7 / §3.2 | `paper-release` | ~200 ms | atmosphere | 오버레이가 걷히는 소리 — 앰비언트가 다시 살아남, 축하 X |
+| submission_rejected (validation error) | EC §5.3, §5.4 | `paper-return-soft` | ~150 ms | UI-low | 조용한 정지 — 오버레이 걷힘, 꾸중·안도 모두 X |
+
+**8.2.3 Atmosphere / ambience**
+
+**권장: 앰비언트 베드 있음.** Pillar 3(시간 압박 0)는 무음을 요구하지 않는다 — 완전 무음은 플레이어를 경계 상태로 두어 사운드 이벤트 하나하나를 과도하게 인지하게 만든다. 앰비언트 베드는 UI 이벤트 사이의 침묵을 자연스럽게 채우고, 한국 대법원 인근 사무실의 물리적 존재감을 부여한다.
+
+- **구성 요소**: 로우-레벨 룸 톤(공기 느낌), 먼 곳 종이 넘기는 소리 (15-30초마다 무작위), 건물 하층의 희미한 나무 바닥 발소리·엘리베이터 소리(불규칙·드물게), 창밖 먼 도심 저음(선택 — 너무 주의 끌면 제거).
+- **루프 전략**: 메인 룸 톤 90-120초 루프 + 랜덤 단발 레이어(Godot `AudioStreamRandomizer`). 단일 루프 반복 피로 방지. 루프 경계 크로스페이드 2초.
+- **볼륨**: UI 이벤트 대비 **-18 dB 이하, -24 dB 이상** (audio-director #3 IMPORTANT closure — floor 명시; "들릴 때가 아니라 *없어졌을 때* 느껴지는 수준"의 의도는 보존하되 `hush-down` anchor가 무의미해질 정도의 불가청 mix 차단; sound-designer는 본 범위 내 player listening level 70 dB SPL 기준 perceptible at ~46-52 dB SPL 보장).
+
+**8.2.4 Music**
+
+**MVP: 음악 없음.** Workspace에서 음악은 감정을 유도한다 — 이 게임은 플레이어 자신의 추론이 감정의 원천. BGM이 그 자리를 선점해서는 안 된다. 앰비언트 베드(§8.2.3)가 충분한 질감을 제공.
+
+**단일 예외 — FROZEN**: **앰비언트 조작만 허용 — 음악 트랙 도입 절대 금지** (audio-director #5 IMPORTANT closure). FROZEN 진입 시 (a) 룸 톤 amplitude fade-out (`hush-down` envelope), (b) `weight-stamp-deep` 단발 hit 1회. 신규 tonal content (피치 element, 멜로디, 화성 패드) 도입 X — 기존 ambient 룸 톤의 *amplitude·spectral filter manipulation*으로 한정. 본 제약은 기존 "음악적 처리" 모호 표현 폐기 — sound-designer 위임 spec.
+
+장시간 세션 BGM 도입 검토 트리거 (**OQ-W11**, audio-director #6 IMPORTANT closure — trigger criterion 명시): "v1+ playtest data에서 *median active-workspace session time ≥ 10분* AND *팀 외 playtest 응답자의 30% 이상이 voluntarily report audio fatigue* 시 audio-director가 BGM prototype 시작". 두 조건 모두 충족 전까지 OQ-W11 deferred 유지. 도입 시 무드 드리프트 없는 단선율 드론 또는 피아노 한 음만 허용.
+
+**MVP 정의: 앰비언트 베드만, 음악 트랙 없음.**
+
+**8.2.5 Mix / accessibility**
+
+| 버스 | 용도 | 기본 레벨 |
+|---|---|---|
+| `UI` | 모든 `sfx_*` 이벤트 | 0 dB (기준) |
+| `Atmosphere` | 앰비언트 베드, `hush-down`, `paper-release` | -18 dB (UI 기준) |
+| `Music` | 예약 — MVP 미사용 | muted |
+| `Master` | 마스터 믹스 | LUFS -14 통합 타깃 |
+
+**플레이어 슬라이더**: `UI Sound`, `Atmosphere`, `Master Volume` 세 개. Music 슬라이더는 v1+ 도입 전까지 숨김. **Dialogue 슬라이더는 본 화면 미사용** — 향후 voice content 도입 화면이 추가되면 그 시점에 Dialogue bus 도입 (accessibility N-1 NICE-TO-HAVE closure: 본 GDD는 Workspace 화면 한정 audio architecture, *전체 게임 audio 글로벌 spec 아님*).
+
+**접근성 (audio-director #7 IMPORTANT closure — OQ-W12 ↔ §8.2.5 모순 해소)**: 음성 대화 없음. 모든 *information-bearing* 오디오 이벤트는 시각 피드백과 1:1 중복 — 어떤 정보-전달 이벤트도 소리만으로 정보 전달 X. §8.2.2 `*(silence)*` row (Node deselected, Memo char-cap, Node delete cancel, CitationDrop miss)는 *information-bearing 분류 외* — 별도 시각 보완 불요. `weight-stamp`는 시각 보더 강화·evidence 카드 안착 애니메이션과 쌍 + bottom rule 길이 grow tween (§8.1.1.b). FROZEN 오버레이는 시각 배너가 오디오와 동시 진입. **OQ-W12 closed**: §8.2.5 absolute rule "1:1 중복 (information-bearing only)"이 정책. 추후 playtest accessibility round는 *implementation 검증* (정책 결정 X — 정책은 본 lock으로 종결).
+
+**8.2.6 Asset Spec 트리거**
+
+GDD 승인 후 sound-designer 위임. 각 패밀리는 단일 샘플 반복 피로 방지를 위해 3-5개 변형 요구.
+
+| 큐 패밀리 | 변형 수 | 비고 |
+|---|---|---|
+| `paper-place` / `paper-place-soft` | 4 each | 핵심 노드 인터랙션 — 최다 노출 |
+| `paper-settle` | 3 | 선택 피드백 |
+| `pen-arrive` / `pen-arrive-soft` | 3 each | 편집 진입 |
+| `pen-lift` | 3 | 편집 확정 |
+| `paper-drag` | 3 | 이동 시작 |
+| `paper-return` / `paper-return-soft` | 3 each | 거부/취소 |
+| `paper-set-aside` | 3 | 삭제 확정 — Pillar 3 앵커, 가장 신중한 디자인 |
+| `paper-hover` | 2 | CitationDrop 진입 |
+| `weight-stamp` | **5** | **최우선** — Pillar 1 핵심 큐. **fire rate 65 fires/session 가능 (5 evidence × 30 nodes 상한) → 3 변형은 identifiability fatigue 확정** (audio-director #2 BLOCKING closure). 5 변형 + 즉시 반복 회피 randomizer 정책 (last-played variant 다음 fire에서 가중치 0). |
+| `weight-stamp-deep` | 2 | FROZEN 임팩트 — `weight-stamp` 확장 (UI bus 0 dB — §8.2.2 mix 정합) |
+| `weight-breath` | 2 | Submit 망설임 |
+| `hush-down` | 1 | FROZEN 앰비언트 페이드 — 처리 기반, 변형 불요 |
+| `paper-release` | 2 | evaluation_completed / 오버레이 해제 |
+| 앰비언트 룸 톤 루프 | 1 (90-120s) | 크로스페이드 지점 마킹 필수 |
+| 앰비언트 랜덤 단발 레이어 | 6-8개 종류 | 종이 넘김·발소리·건물 소리 풀 |
+
+## 9. UI Requirements
+
+> **Status**: PROVISIONAL contract — Control 노드 구체는 후속 *Workspace Layout ADR* + #2 UI Foundation epic 위임. 본 섹션은 정보 아키텍처·인터랙션 패턴·접근성 요건·screen state·핵심 인터랙션을 잠그지만 Godot Control class 선택은 잠그지 않는다.
+
+### 9.1 Information Architecture
+
+**DeskPane ownership.** DeskPane은 Workspace의 유일한 렌더링 surface — Browser §3.6 `WorkspaceHandoff`로부터 위임받음. DeskPane 내부에서 Workspace가 소유:
+
+- **Tree canvas** — 가설 노드 그래프 (add / move / delete / label-edit)
+- **Memo panel** — per-node 자유 메모; 위치는 **PROPOSED** (§9.3)
+- **Submit affordance** — full-width submit button + character cap counter
+- **Freeze overlay** — "제출이 처리 중입니다" 배너, FROZEN state 한정
+- **READ_ONLY indicator** — 영구 배너, READ_ONLY state 한정
+
+DeskPane이 **소유하지 않는 것**: LibraryPane 콘텐츠/검색, CatalogPane 상태, verdict display (Browser 통해 #10에 위임).
+
+**Sub-zone priority (z-order, front to back):**
+
+1. Freeze overlay / READ_ONLY indicator (최상단 — FROZEN 중 모든 인터랙션 차단)
+2. Confirmation dialogs (delete, submit)
+3. Memo panel (트리 캔버스 위 — 펼친 상태 오버랩 허용)
+4. Tree canvas + Submit affordance (base layer)
+
+**인접 pane과의 책임 분담:**
+
+| 책임 | 소유자 |
+|---|---|
+| Citation drag source | LibraryPane / LibraryService |
+| Drop target hit-test | DeskPane (Workspace) |
+| Node visual + label | DeskPane |
+| Memo content | DeskPane |
+| Pane width / resizing | 후속 Workspace Layout ADR + Browser §6 OQ-8 |
+
+### 9.2 Screen States
+
+| State | Rendered | Hidden / Disabled | Modified |
+|---|---|---|---|
+| `INACTIVE` | 없음 — DeskPane 미마운트 | 모든 Workspace sub-zone | — |
+| `ACTIVE` | Tree canvas, memo panel, submit button, progress counters | Freeze overlay, READ_ONLY indicator | 모든 편집 가능 (트리·메모·evidence) |
+| `FROZEN` | Tree canvas (read-only), freeze overlay banner | Submit button (disabled), memo edit input | Evidence drop zone 비활성; 모든 인터랙티브 위젯 disable |
+| `READ_ONLY` | Tree canvas (read-only), 모든 노드 메모 (display only), READ_ONLY indicator | Submit button (hidden), memo edit input, add/delete 컨트롤 | Write 경로 없음 — 아카이브 뷰 |
+
+**Prose snapshots:**
+
+- **INACTIVE**: DeskPane은 Browser-owned 콘텐츠(placeholder 또는 case brief) 표시. Workspace 미렌더링.
+- **ACTIVE**: 트리 캔버스가 DeskPane 상단을 채우고 가설 노드 200×48px. 선택 노드는 메모 패널 표시 (위치는 §9.3). full-width submit button이 하단 anchor. Evidence count 배지가 각 노드에 visible.
+- **FROZEN**: 모든 노드가 시각적으로 존재하나 non-interactive. 배너 오버레이가 트리 캔버스 위 페이드인 ("제출이 처리 중입니다") at `freeze_overlay_fade_ms` = 250ms. submit button visible but grayed. 호버 응답 없음.
+- **READ_ONLY**: 트리 전체 visible, 모든 evidence·메모 콘텐츠 읽기 접근. DeskPane 상단 sticky 배너 ("제출 완료 — 열람 전용") — ACTIVE와 구별. 메모 패널 display-only (`RichTextLabel`, `TextEdit` 없음). #14 Retrospective Replay 데이터 소스.
+
+### 9.3 Memo Panel Position — OQ-W5 Resolution Proposal
+
+**Status: PROPOSED — UI Foundation epic에서 ratify**
+
+세 후보:
+
+**(A) Inline next to selected node (recommended)**
+선택 노드의 우측 가장자리 또는 하단에 side-car로 펼침.
+- Pros: 노드와 메모의 공간 결합이 "메모는 노드에 *속한다*"는 mental model 강화 (Gibson affordance — co-location signals ownership). Pillar 3 contemplative 톤 지원 — 트리에서 시야를 잃지 않고 읽고 편집.
+- Cons: 메모 길이 시 레이아웃 압박 (500자, ~8 lines at 13pt `CommentLabel`); DeskPane 우측 가장자리 근처 노드는 truncation 또는 패널 오버플로우 필요. 동적 재배치 로직 필요.
+
+**(B) Fixed bottom-right of DeskPane**
+메모 패널이 우하단 고정 사각형 차지, 어떤 노드를 선택해도 동일 좌표.
+- Pros: 예측 가능한 영역 — 레이아웃 reflow 없음; 구현 단순; 명확한 시각 위계 (트리 위, 메모 아래).
+- Cons: 선택 노드와 공간 단절. 4-deep 트리 + 다중 루트 시 선택 노드가 메모 패널과 멀어 mental model 끊김. 마우스 사용자가 DeskPane 양분된 주의 필요.
+
+**(C) Modal on demand**
+메모 패널이 modal 오버레이로 열림 (DeskPane 전체 dim) — 명시 호출 (전용 키 또는 버튼) 시.
+- Pros: 메모 편집 풀 포커스; 레이아웃 압박 없음.
+- Cons: 메모 편집 중 트리 가시성 상실 — 형제 노드·evidence count 교차 참조 불가. Pillar 3 contemplative flow 침해 — 단일 가지 의심 시 전체 논리 동시 인식이 필요한 경험.
+
+**Recommendation: (A), (B)는 UI Foundation 스프린트 레이아웃 복잡도가 차단할 경우 fallback.**
+근거: Pillar 1 ("진실은 가중치다")는 메모 작성 중에도 evidence 밀도와 트리 구조가 보여야 한다. Pillar 3의 *판단 무게*는 단일 가지를 의심하는 동안 전체 주장을 볼 수 있을 때만 효과적. (C)는 그 동시 인식을 완전히 제거. (B)는 공간 거리로 약화. (A)는 동적 위치 계산 비용으로 보존.
+
+**OQ-W5 open 유지.** UI Foundation epic이 4-deep tree + `max_root_count` ≥ 3에서 prototype 측정 후 (A) 또는 (B) 확정.
+
+### 9.4 Interaction Patterns
+
+#### 9.4.1 Pointer (KB+M primary)
+
+| Gesture | Effect | Feedback |
+|---|---|---|
+| Click node | 노드 선택; 메모 패널이 해당 노드로 포커스 이동 | Selected border → 2px 잉크블랙; 메모 패널 콘텐츠 갱신 |
+| Double-click empty canvas | cursor 위치에 새 루트 노드 생성 | 새 노드 cursor 위치 등장, 레이블 필드 활성 |
+| Double-click node | 인라인 레이블 편집 진입 (60자 cap) | 레이블 필드 열림; cursor 텍스트 표시; 글자수 카운터 visible |
+| Hover node body | Cursor `grab`(잡기) 변환 — 이동 가능성 명시 | `Control.MOUSE_CURSOR_DRAG` 적용 (Godot 4.6). **drop-shadow 도입 X** — Art Bible §3 "외부 그림자 없음" + §8.1.1 Shadow=없음 정합 (ux-designer + game-designer + art-director 2nd cycle BLOCKING closure: 기존 §9.5 "미세 drop-shadow 증가" 폐기) |
+| Drag node (plain, no modifier) | 노드 이동 (재부모화 또는 루트 승격) — Rule 3 | Cursor `grabbing`, **노드 ghost 70% opacity + 좌측 상단 6×6px 잉크블랙 grip dot indicator** (ux-designer ghost discrimination IMPORTANT closure: library-source ghost는 좌측 상단 indicator 부재 — 두 drag mode를 visual differentiation); 유효 drop target 하이라이트; 무효 dim. drop discrimination by source (node-source = 이동 / library-source = evidence) |
+| Drop on node (node-source) | 드래그 노드를 target의 자식으로 reparent | Ghost snap, 트리 reflow |
+| Drop on empty canvas (node-source) | 루트 승격 (`parent_id = ""`) | 부모로부터 detach, 트리 reflow |
+| Right-click node | Context menu: 자식 추가 / 레이블 편집 / **이동** / 삭제 | Cursor 위치 menu — 이동은 다음 클릭으로 target 지정 (KB+M discoverable + KB fallback). **이동 modal 동작 (ux-designer IMPORTANT closure)**: (a) 이동 모드 진입 시 cursor crosshair + 화면 하단 status bar "이동 위치를 클릭하세요. (Esc: 취소)" 표시; (b) 무효 target 클릭(자기 후손, depth 4 위반) 시 brief 점선 red flash + status bar "이동 불가: [reason]" + modal *유지* (재선택 허용); (c) Esc 또는 우클릭 dismiss → modal 종료 + cursor 복원 |
+| Drag from LibraryPane to node | Evidence citation 첨부 (CitationDrop) | 노드 drop zone 하이라이트; 카드 ghost 70% opacity |
+| Delete key (node selected) | 노드 + 서브트리 삭제 (확인 다이얼로그) | "이 가지와 하위 [N]개 노드가 함께 삭제됩니다" |
+| Enter (label edit active) | 레이블 확정 | 레이블 필드 닫힘 |
+| Escape (label edit active) | 레이블 편집 취소 | 이전 값으로 복귀 |
+
+#### 9.4.2 Keyboard Alternatives (accessibility floor)
+
+| Key | Action | Notes |
+|---|---|---|
+| Tab | 노드 간 포커스 traversal (breadth-first) | Focus ring은 selected와 구별 (§9.6) |
+| Shift+Tab | 역방향 traversal | — |
+| Arrow Up/Down | 부모 / 첫 자식으로 포커스 이동 | 트리 탐색 |
+| Arrow Left/Right | 이전 / 다음 형제로 포커스 이동 | 트리 탐색 |
+| Enter | 선택 노드 펼침 (자식 표시) 또는 이미 펼쳐진 경우 레이블 편집 진입 | — |
+| Delete | 선택 노드 + 서브트리 삭제; 확인 다이얼로그 의무 | Pointer 경로와 동일 |
+| Ctrl+Arrow Up/Down | 선택 노드 reparent (KB-only drag 등가): Ctrl+Up = 루트 승격; Ctrl+Down = 이전 형제의 자식으로 | Depth + cycle invariant 검사. KB modifier는 KB-only 경로 한정 — pointer drag와 무관 (pointer는 plain drag, §3.1 Rule 3) |
+| **Ctrl+Arrow Left/Right** | **선택 노드 형제 reorder (좌 = 앞으로 / 우 = 뒤로) — ux-designer IMPORTANT closure 2026-05-07 cycle 2** | 한국 상고심에서 *상고이유 순서* (가장 강한 이유 first) 표현. 형제가 없으면 no-op + status bar "형제 노드가 없어 순서를 바꿀 수 없습니다" |
+| **Space (LibraryPane card focused)** | **KB CitationDrop 시작 — 카드를 "pending citation" 상태로 마크. status bar "[library_id] 인용 대기 중. 노드 포커스 후 Space로 첨부" + 좌상단 floating 배지 표시** | **ux-designer + accessibility BLOCKING closure 2026-05-07 cycle 2 — AC-45 KB-only workflow 가능. OQ-W9 gamepad 두 단계 패턴과 mirror.** Pending 상태는 application-level — Tab으로 DeskPane 진입 가능 |
+| **Space (DeskPane node focused, pending citation 활성)** | **pending library_id를 포커스 노드에 첨부 (Rule 4 정책 적용 — cap·중복·타입 검증)** | 성공 시 `weight-stamp` audio + bottom rule 길이 갱신 + pending 상태 해제. 거부 시 §5.3 정책 mirror (depth/cap hint) + pending 상태 *유지* (다른 노드 재선택 허용) |
+| **Esc (pending citation 활성)** | **pending citation 취소** | 좌상단 배지 사라짐 + status bar "인용 대기 취소" |
+| Ctrl+Enter | Submit (트리가 비어있으면 §5.1 mirror — 버튼 비활성과 동일 silent no-op + status bar "노드를 추가해주세요"; 비어있지 않으면 확인 다이얼로그 진입) | ux-designer NICE-TO-HAVE closure: 빈 트리 동작 명시 |
+| Ctrl+S | **No-op** — 자동 저장 (§3.3 Rule 8). Ctrl+S는 효과 없음, false "saved" toast 금지 | 수동 저장 잘못 광고 X |
+| F2 | 접근성 list view 토글 (flat indented text tree) | §9.6. **F2 discoverability 의무 (accessibility BLOCKING #2 closure)**: DeskPane 진입 시 status bar 일회성 toast "F2: 텍스트 목록 보기" 3초 표시 (세션 첫 진입 시만; `WorkspaceData.f2_hint_seen: bool` 영속). AccessKit 측면은 §9.6 참조 |
+| Escape | 진행 중인 작업 취소 (label edit / drag / dialog / pending citation) | FROZEN 중 메인 메뉴 이탈 포함 항상 사용 가능 |
+
+#### 9.4.3 Gamepad (critical paths required)
+
+| Input | Action | Notes |
+|---|---|---|
+| D-pad / Left stick | 노드 간 포커스 traversal | Tab과 동일 breadth-first |
+| A button | Confirm / 포커스 노드 선택; context에서 레이블 편집 진입 | — |
+| B button | Back / cancel; context menu 닫기; 레이블 편집 취소 | — |
+| X button | 포커스 노드의 context menu 열기 | add-child, delete 발견 경로 |
+| Y button | 포커스 노드 레이블 편집 시작 | Context menu 우회 단축 |
+| Right stick | 트리 캔버스 panning (가시 영역 초과 시) | Provisional — UI Foundation에서 ratify; §9.8 OQ-W10 |
+| Left trigger + D-pad Up | 포커스 노드 루트 승격 (Ctrl+Up 등가) | Trigger combo for reparent |
+| Left trigger + D-pad Down | 포커스 노드를 이전 형제의 자식으로 (Ctrl+Down 등가) | — |
+| Right bumper | 다음 노드 (fast traversal) | — |
+| Left bumper | 이전 노드 | — |
+| Start / Menu | pause / settings | FROZEN 포함 항상 사용 가능 |
+
+**Gamepad CitationDrop — provisional discrete 대안 (OQ-W9):**
+드래그-from-Library는 가장 어려운 gamepad 인터랙션. 두 단계 대안 제안: (1) LibraryPane에서 카드 포커스 후 A 누르면 "인용 대기 중" 상태; (2) DeskPane 가설 노드 포커스 후 A 누르면 부착. 아날로그 드래그 없이 cross-pane citation workflow 보존. 정확한 버튼 할당 + 시각 핸드셰이크 (예: floating "인용 대기 중" 배지) + 취소 경로는 **provisional — UI Foundation epic ratify.**
+
+### 9.5 Feedback Patterns
+
+| Interaction | Visual | Audio | Reference |
+|---|---|---|---|
+| Node hover | 커서 → grab(잡기) 변환 (drop-shadow 도입 X — Art Bible §3 정합); 노드 visual 변화 없음 | — | §8.1.1 + §3.1 Rule 3 |
+| Node selected | Border → 2px 잉크블랙; 메모 패널 갱신 | `paper-settle` (§8.2.2) | — |
+| Valid drop target (CitationDrop) | Drop zone 하이라이트 active | `paper-hover` | §8.1.1 |
+| Invalid drop (cap reached) | Drop zone 하이라이트 부재; "금지" 커서; post-drop hint | `paper-return` | §3.1 Rule 4 |
+| Duplicate evidence drop | 250ms yellow flash on existing badge | (silent) | §5.3 |
+| Invalid type drop (precedent root) | 150ms red flash; 카드 origin 복귀 | `paper-return` | §5.3 |
+| Label char counter | 레이블 필드 *편집 모드* 한정 (인라인 편집 진입 시에만 표시); cap 도달 시 글꼴 무게 Medium 전환 (game-designer I-8 IMPORTANT closure: 60/60 도달이 *유일한 신호* — 표시 시점은 ellipsis truncation으로 이미 달라진 화면이므로 mid-threshold 신호 무의미) | — | §3.1 Rule 3 |
+| Memo char counter | 메모 필드 아래 인라인; cap 도달 시 글꼴 무게 Medium 전환 (인장빨강 폐기 — art-director B-NEW-4 BLOCKING 정합 §8.1.6) | — | §5.5 |
+| Freeze overlay | `freeze_overlay_fade_ms` 250ms 페이드인; 모든 위젯 dim | `hush-down` + `weight-stamp-deep` | §3.1 Rule 7; §7.3 |
+| Error tooltip | 영향 노드 아래 인라인 hint; ~3s 자동 dismiss | — | §3.1 Rules 2–4 |
+| Subtree delete | 노드 수 표시 확인 다이얼로그; 파괴적 액션 | `paper-set-aside` | §3.1 Rule 3 |
+
+모든 오디오 큐는 §9.6 접근성 요건에 따라 visual redundancy 의무. 오디오 에셋 할당은 §8.2 위임.
+
+### 9.6 Accessibility Requirements
+
+Floor 요건 — 풀 audit은 OQ-W7 + accessibility-specialist 위임. **본 cycle (2026-05-07 cycle 2)에서 AccessKit role floor + KB CitationDrop + WCAG 1.4.11 contrast + F2 discoverability 잠금 (4 BLOCKING closure).**
+
+- **색 대비 — WCAG AA + 1.4.11 non-text contrast**: 본문 텍스트 잉크블랙 `#1A1A1A` on 판결지 `#F5F2EC` ≈ 14:1 (AAA pass). **Non-text UI components (border·tree edge·icon)는 SC 1.4.11 3:1 minimum 의무** — 미드그레이 `#8C8C8C` on `#F5F2EC` ≈ 3.0:1 충족 (accessibility BLOCKING #3 closure: 기존 `#D9D6CF` 1.3:1 폐기, §8.1.1·§8.1.2·§8.1.3 모두 미드그레이로 통일). 피드백 상태(selected, error, frozen)는 색 단독 의존 X — border 두께·텍스트 레이블·spatial cue가 non-color 채널.
+- **AccessKit role floor (accessibility BLOCKING #1 closure 2026-05-07 cycle 2 — OQ-W7 부분 종결)**: Tree canvas의 root Control은 `accessibility_role = AccessibilityRole.ROLE_TREE`, 각 HypothesisNode Control은 `ROLE_TREE_ITEM`. 각 노드의 `accessibility_name = node.label` (full 60자, ellipsis 미적용 — 스크린 리더는 시각적 truncation 무관), `accessibility_description = "depth %d, evidence %d개 첨부됨, 자식 %d개" % [depth, len(evidence), child_count]`. Canvas root의 `accessibility_description = "가설 트리 캔버스. F2를 눌러 텍스트 목록 보기로 전환. Space로 인용 첨부 (LibraryPane → DeskPane 두 단계)."` *— 본 floor는 정상 path (full audit 종결 X) — OQ-W7 잔여 audit은 verification 작업으로 reframe.*
+- **오디오 redundancy**: §8.2.5 정합 — *information-bearing* 오디오 큐는 동시 시각 카운터파트 의무 (§8.2.2 silence row 제외).
+- **키보드 단축키**: §9.4.2 모든 단축키는 Settings 통해 configurable (#4 Settings & Accessibility GDD 위임). **#4 GDD blocking gate (accessibility I-9 IMPORTANT closure)**: Workspace MVP는 #4 Settings GDD가 최소 3 API (`reduced_motion: bool`, `text_scale: float [1.0, 2.0]`, `keyboard_shortcut_remap: Dict[String, String]`) 제공 시점까지 *QA 진입 차단*. §6.4 Pending dependency에 #4 hard-gate 명시 갱신.
+- **KB CitationDrop (accessibility BLOCKING #8 closure 2026-05-07 cycle 2)**: §9.4.2 Space-on-LibraryPane → Space-on-Node 두 단계 패턴 + Esc 취소 + 좌상단 floating 배지 + status bar 안내. AC-45 KB-only workflow 통과 가능.
+- **스크린 리더**: AccessKit는 Godot 4.6 default. Tree canvas traversal AccessKit 검증은 위 role floor에 *기반*하여 verification — non-standard widget이지만 explicit role assignment로 표준 widget 등가 traversal 가능. RichTextLabel 메모 본문은 AccessKit 자동 노출 미보장 (Godot 4.6 알려진 한계) — `accessibility_name`을 underlying memo 문자열로 programmatically 설정 의무 (godot-specialist Item 9 IMPORTANT — ADR-0004 amendment 검토 항목).
+- **Focus indicator (AC-47 lockdown)**: visible focus ring이 "selected" 상태와 구별 의무. **Spec lock**: 1px 잉크블랙 `#1A1A1A` 점선 + 외부 inset 2px (카드 외곽 border 바깥쪽 2px offset, *내부 inset 폐기* — accessibility I-5 IMPORTANT closure: selected 2px 보더 occlusion 방지). Selected = 카드 외곽 2px solid; Focused = 카드 외곽 +2px offset의 점선 ring; 두 상태 동시 공존 시 outer 점선 ring + inner solid 모두 visible.
+- **Reduced motion**: 모든 drag/drop 애니메이션 + freeze overlay fade + **bottom evidence rule grow/shrink tween (§8.1.1.b — accessibility I-4 IMPORTANT closure)**은 "Reduced Motion" 설정 존중 (easing 비활성, 즉시 final 상태 snap). #4 Settings configurable.
+- **텍스트 스케일링**: `&"BodyLabel"` (Pretendard 14pt) + `&"CommentLabel"` (본명조 13pt) + `&"MemoLabel"` (Pretendard 14pt) + `&"MemoEdit"` (Pretendard 14pt TextEdit variation)은 Settings text-scale 슬라이더 100%–200%로 스케일 (ADR-0004 Theme type variations). 200% scale에서 horizontal overflow 또는 text truncation 없이 레이아웃 수용.
+- **F2 list view (accessibility BLOCKING #2 closure 2026-05-07 cycle 2)**: 가설 트리의 flat indented text 표현이 F2로 접근 가능. **Discoverability 의무**: (a) DeskPane 진입 시 일회성 status bar toast (§9.4.2 mirror), (b) Canvas root AccessKit `accessibility_description`에 F2 단축키 안내 포함 (위 role floor 참조), (c) `#4 Settings & Accessibility GDD` 첫 진입 가이드에서 F2 발견 경로 등재 (#4 위임 항목).
+- **No flashing content**: 3–50 Hz 플래시 금지. 150ms red flash (§5.3) → ~~150ms 인장빨강 flash~~ 폐기 (인장빨강 lockdown — §8.1.1 REJECTED flash가 미드그레이 점선으로 대체); rapid-rejection 시나리오에서 반복되지 않도록 검증.
+
+### 9.7 Layout Constraints (provisional)
+
+- **Baseline 해상도**: 1920×1080. Baseline DeskPane width ≈ 870px (Browser §3.1: 1920 − 480 CatalogPane − 470 LibraryPane − 8 margin).
+- **Floor 해상도**: 1366×768 최소 지원 윈도우 사이즈 (제안). 1366px에서 DeskPane ≈ 566px (1366 − 480 − 320 LibraryPane clamp − 0 margin). 4-deep tree + 3+ root at 566px DeskPane width는 horizontal scroll 필요 가능 — Workspace Layout ADR ratify 의무.
+- **DeskPane minimum width for tree rendering**: 4-deep linear chain (4 노드 × 200px wide + spacing) horizontal 렌더링 시 ~900px 요구. Vertical 레이아웃은 ~48px × 4 + spacing ≈ 230px 高. 트리 캔버스 default는 **top-down vertical** — multi-root horizontal capacity 최대화. Horizontal extent는 root count로 결정, depth로 결정 X. Layout direction provisional — Workspace Layout ADR가 최종 결정.
+- **Ultrawide (21:9)**: DeskPane 확장; 트리 캔버스 노드 사이즈 stretch X — 캔버스가 whitespace + scroll range 획득. Layout 목적 maximum DeskPane width는 Workspace Layout ADR TBD.
+- **4:3 aspect ratio**: 미지원 타깃. 레거시 4:3는 <1280px viewport과 동급 — EC-8 / #2 UI Foundation v1+.
+- **3-pane resizing**: 본 GDD scope X. Browser Layout ADR (Browser §6 OQ-8) 위임.
+
+### 9.8 Open UX Questions Surfaced
+
+| ID | Question | Status |
+|---|---|---|
+| OQ-W5 | Memo panel position — (A) inline vs. (B) fixed bottom-right vs. (C) modal. **Fallback (A) → (B) trigger threshold**: ux-designer IMPORTANT closure 2026-05-07 cycle 2 — DeskPane width < 720px 또는 선택 노드 우측 inline panel 영역(330px = 메모 패널 + 16px gap)이 DeskPane 우측 edge를 초과하면 (B) 자동 fallback. 본 threshold는 prototype 측정 후 ratify (UI Foundation epic). | Proposed (A) + threshold spec, ratify at UI Foundation epic |
+| OQ-W7 | AccessKit verification for non-standard tree canvas widget — *role floor § 9.6에서 잠금 (2026-05-07 cycle 2)*; OQ-W7 잔여는 verification 작업 (RichTextLabel 메모 본문 AccessKit 노출 검증 + UI Foundation prototype에서 actual screen reader 출력 측정) | Floor locked, verification deferred — accessibility-specialist 위임 |
+| OQ-W9 (new) | Gamepad CitationDrop 두 단계 discrete 대안 — 버튼 할당, 시각 핸드셰이크 ("인용 대기 중" 배지), 취소 경로. **KB pattern은 §9.4.2에서 잠금** — gamepad가 동일 패턴(A=mark, A=attach, B=cancel) mirror | UI Foundation epic 프로토타입 의무. **2026-05-07 cycle 2 escalation trigger (qa-lead AC-46 IMPORTANT closure)**: UI Foundation epic sign-off 시점에 OQ-W9 ratify 의무 — 미해결 시 AC-46 ADVISORY → BLOCKING 전환 |
+| OQ-W10 (new) | Tree canvas panning behavior: right-stick analog pan vs. D-pad scroll vs. auto-center on focused node; 4-deep + 3+ roots at 566px DeskPane floor 시 동작 | UX validation — floor 해상도 ratify에 종속 |
+
+## 10. Acceptance Criteria
+
+각 기준은 Given-When-Then 형식으로 표기되며 GDD를 읽지 않은 QA tester가 독립 검증 가능해야 한다. 끝부분 태그 **(Logic / Integration / Visual / UI / Manual)**가 테스트 분류를 명시. 총 56 ACs + 2 untestable OQs.
+
+### 10.1 chain_data Export
+
+**AC-1 — depth root node**: GIVEN a HypothesisNode with `parent_id == ""`, WHEN `chain_data` is built at freeze time, THEN that node's exported `depth` field == 0. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_depth_root_is_zero`
+
+**AC-2 — depth recursive computation**: GIVEN a 4-node linear chain (A root → B → C → D), WHEN chain_data is built, THEN exported `depth` values are A=0, B=1, C=2, D=3. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_depth_recursive_four_node_chain`
+
+**AC-3 — max_depth_reached single root only**: GIVEN a workspace with one root node and no children, WHEN chain_data is built, THEN `max_depth_reached == 0`. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_max_depth_reached_root_only`
+
+**AC-4 — max_depth_reached full tree**: GIVEN a tree reaching depth 3 (A→B→C→D), WHEN chain_data is built, THEN `max_depth_reached == 3`. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_max_depth_reached_four_level_tree`
+
+**AC-5 — edge_count non-root nodes**: GIVEN the 4-node chain (A root, B/C/D non-root), WHEN chain_data is built, THEN `edge_count == 3`. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_edge_count_equals_non_root_count`
+
+**AC-6 — total_evidence_count summed across nodes**: GIVEN nodes A(2 evidence), B(0), C(3), D(1), WHEN chain_data is built, THEN `total_evidence_count == 6`. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_total_evidence_count_sum`
+
+**AC-7 — child_count immediate children only**: GIVEN node A with children [B, C] and B with children [D], WHEN chain_data is built, THEN A's `child_count == 2`, B's `child_count == 1`, D's `child_count == 0`. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_child_count_immediate_only`
+
+**AC-8 — schema_version locked to 1**: GIVEN any non-empty workspace, WHEN chain_data is built, THEN `chain_data["schema_version"] == 1`. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_schema_version_locked_one`
+
+**AC-9 — memo_length is UTF-8 codepoint count not byte count**: GIVEN a node memo containing 4 Korean codepoints "법리오해", WHEN chain_data is built, THEN `memo_length == 4` (codepoint count, NOT byte length). 구현은 `String.length()` 사용 의무. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_memo_length_codepoint_not_byte`
+
+**AC-10 — memo body excluded from chain_data (Pillar 1 guard)**: GIVEN a node with memo text "test content", WHEN chain_data is built and the allow-list validator runs, THEN no `memo_text` 또는 비허용 필드가 노드 dict에 출현하지 않으며; `memo_text` 인젝션 시도는 `push_error("chain_data schema_version=1 violation: forbidden field memo_text")` + `submission_rejected("schema_violation")` 트리거. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_memo_body_absent_fuzz_schema_validator`
+
+**AC-11 — empty workspace exports empty dict**: GIVEN a workspace with zero nodes, WHEN chain_data is requested, THEN the returned Dictionary is `{}` (ADR-0007 §1). **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_empty_workspace_exports_empty_dict`
+
+### 10.2 Tree Structural Invariants
+
+**AC-12 — depth bound rejection**: GIVEN a node at depth 3, WHEN player attempts to add a child (would be depth 4), THEN the add is rejected, workspace state unchanged, and "이 가지는 더 깊이 나눌 수 없습니다" hint displayed. **(Logic)** `tests/unit/workspace/tree_invariants_test.gd::test_depth_bound_add_rejected_at_four`
+
+**AC-13 — cycle detection rejection (qa-lead IMPORTANT closure 2026-05-07 cycle 2 — Logic vs Integration 분리)**: GIVEN node A is parent of node B, WHEN `WorkspaceData.reparent(node_a_id, under=node_b_id)` is called directly on the data model, THEN the move is rejected pre-mutation, state unchanged, `push_error("Cycle detected: cannot reparent node %s under its own descendant")` logged, return value indicates rejection. UI gesture path (drag from A body → drop on B) covered by separate Integration AC `AC-13b`. **(Logic)** `tests/unit/workspace/tree_invariants_test.gd::test_cycle_detection_ancestor_under_descendant`
+
+**AC-13b — cycle detection UI integration**: GIVEN node A is parent of node B in DeskPane, WHEN player plain drags A's body and drops on B, THEN drag controller calls `reparent()` (which rejects per AC-13), workspace UI shows ease-back animation + "노드를 자신의 하위 노드로 이동할 수 없습니다" hint. **(Integration)** `tests/integration/workspace/tree_invariants_test.gd::test_cycle_detection_ui_path`
+
+**AC-14 — evidence cap rejection**: GIVEN a node holding 5 evidence items, WHEN a 6th CitationDrop is received, THEN the drop is rejected, evidence array unchanged (still 5), and "이 노드에는 인용을 5개까지만 첨부할 수 있습니다" hint displayed. **(Logic)** `tests/unit/workspace/tree_invariants_test.gd::test_evidence_cap_sixth_drop_rejected`
+
+**AC-15 — parent-child symmetry on add**: GIVEN node A exists, WHEN child node B is added under A, THEN `B.parent_id == A.node_id` AND `A.children` contains B's node_id (bidirectional symmetry). **(Logic)** `tests/unit/workspace/tree_invariants_test.gd::test_parent_child_symmetry_on_add`
+
+**AC-16 — parent-child symmetry preserved on delete**: GIVEN nodes A→B→C, WHEN B is deleted (with subtree confirmation), THEN A.children no longer contains B's node_id, and C is also removed (full subtree deletion). **(Logic)** `tests/unit/workspace/tree_invariants_test.gd::test_parent_child_symmetry_on_subtree_delete`
+
+### 10.3 State Machine
+
+**AC-17 — INACTIVE to ACTIVE on handoff**: GIVEN Workspace is INACTIVE, WHEN `workspace_handoff_started(case_id)` is received, THEN Workspace transitions to ACTIVE and DeskPane tree canvas becomes interactive. **(Integration)** `tests/integration/workspace/state_machine_test.gd`
+
+**AC-18 — ACTIVE to FROZEN on Submit**: GIVEN Workspace is ACTIVE with at least one node, WHEN Submit is triggered, THEN Workspace transitions to FROZEN, chain_data is built and assigned to PlayerSubmission, and `EvaluationService.submit()` is called. **(Integration)** `tests/integration/workspace/state_machine_test.gd`
+
+**AC-19 — FROZEN to ACTIVE on submission_rejected**: GIVEN Workspace is FROZEN, WHEN `submission_rejected(reason)` is received, THEN Workspace transitions back to ACTIVE, freeze overlay removed, tree editing re-enabled. **(Integration)** `tests/integration/workspace/state_machine_test.gd`
+
+**AC-20 — FROZEN to READ_ONLY on evaluation_completed**: GIVEN Workspace is FROZEN, WHEN `evaluation_completed(result)` is received, THEN Workspace transitions to READ_ONLY, all write paths closed, READ_ONLY indicator visible. **(Integration)** `tests/integration/workspace/state_machine_test.gd`
+
+**AC-21 — READ_ONLY to INACTIVE on handoff_ended submitted**: GIVEN Workspace is READ_ONLY, WHEN `workspace_handoff_ended(case_id, "submitted")` is emitted, THEN Workspace transitions to INACTIVE. **(Integration)** `tests/integration/workspace/state_machine_test.gd`
+
+**AC-22 — ACTIVE to INACTIVE on handoff_ended paused**: GIVEN Workspace is ACTIVE, WHEN `workspace_handoff_ended(case_id, "paused")` is emitted, THEN Workspace transitions to INACTIVE while WorkspaceData is preserved. **(Integration)** `tests/integration/workspace/state_machine_test.gd`
+
+**AC-22b — submission_rejected received during INACTIVE (qa-lead §5.4 IMPORTANT closure 2026-05-07 cycle 2)**: GIVEN Workspace is INACTIVE (player navigated away after submit), WHEN `submission_rejected(reason)` arrives, THEN signal is consumed, `WorkspaceData.last_rejection_reason = reason` 임시 보관 + `WorkspaceData.last_rejection_case_id` 기록. WHEN player re-enters that case via `workspace_handoff_started(case_id)`, THEN Workspace transitions ACTIVE + DeskPane top sticky banner "이전 제출이 거부되었습니다: [reason]" shown + reason cleared after dismissal. **(Integration)** `tests/integration/workspace/state_machine_test.gd::test_inactive_rejection_temp_storage`
+
+**AC-23 — forbidden transition blocked with push_warning**: GIVEN Workspace is in READ_ONLY state, WHEN any direct-edit input event is processed, THEN the event is consumed (silently blocked); submit() from READ_ONLY logs `push_warning` and is rejected. **(Logic)** `tests/unit/workspace/state_machine_test.gd::test_forbidden_transition_read_only_no_edit`
+
+### 10.4 Freeze Forward-Constraint
+
+**AC-24 — chain_data immutable post-freeze (deep-equality verification + 신규 instance distinctness step — qa-lead IMPORTANT closure 2026-05-07 cycle 2)**: GIVEN chain_data was built and assigned at freeze, WHEN any post-freeze tree mutation is attempted, THEN mutation blocked, and `PlayerSubmission.chain_data` 내용이 freeze 스냅샷과 동일. **검증 방법 (Godot Dictionary reference type 고려)**: byte-identical 비교는 Godot Dictionary가 reference type이므로 직접 적용 불가. 대신 다음 4-step verification: (1) **Deep-equality**: `JSON.stringify(snapshot, "  ", true)` 와 `JSON.stringify(PlayerSubmission.chain_data, "  ", true)` 문자열 동등 비교 (Godot 4.6 signature: `JSON.stringify(data, indent, sort_keys, full_precision)` — 3rd arg=sort_keys=true, key 정렬 포함; nodes[] 배열 순서는 §3.1 Rule 6 canonical ordering이 보장); (2) **Reference identity option**: `snapshot == PlayerSubmission.chain_data` (Godot Dictionary `==` 연산자 — value 비교; 같은 reference면 자명 true, 별도 reference면 deep value 비교); (3) **Mutation attempt blocking**: freeze 후 `workspace_data.add_node(...)` / `node.evidence.append(...)` 호출 시 push_error + 상태 변경 없음 검증; (4) **Instance distinctness**: `PlayerSubmission.chain_data` 와 `WorkspaceData` 내부 노드 reference가 *별도 instance* 임을 검증 — 라이브 노드 mutation을 시도하고(예: `workspace_data._test_force_mutate_node(node_id)` 헬퍼) `PlayerSubmission.chain_data["nodes"][i]` 가 변경되지 않음 확인. (4)는 §3.1 Rule 6 "fully constructed new Dict" normative 위반을 catch. 4 step 모두 PASS 시 AC-24 충족. **(Logic)** `tests/unit/workspace/freeze_contract_test.gd::test_chain_data_immutable_post_freeze`
+
+**AC-25 — memo edits during FROZEN ignored**: GIVEN Workspace is FROZEN, WHEN a TextEdit input event fires on a memo field, THEN memo content unchanged; `memo_length` in frozen snapshot unchanged. **(Logic)** `tests/unit/workspace/freeze_contract_test.gd::test_memo_edit_during_frozen_ignored`
+
+**AC-26 — evidence drop during FROZEN ignored**: GIVEN Workspace is FROZEN, WHEN `citation_dropped(library_id, position)` is received, THEN no node's evidence array modified; drop zone highlight inactive. **(Logic)** `tests/unit/workspace/freeze_contract_test.gd::test_evidence_drop_during_frozen_ignored`
+
+**AC-27 — crash recovery during FROZEN restores ACTIVE with banner**: GIVEN WorkspaceData was serialized FROZEN (game crash mid-evaluation), WHEN game restarts and loads, THEN Workspace auto-recovers to ACTIVE (NOT FROZEN), banner "이전 세션에서 제출이 완료되지 않았습니다. 다시 제출해주세요." shown, preserved chain_data snapshot reused on re-submit. **(Integration)** `tests/integration/workspace/freeze_recovery_test.gd`
+
+### 10.5 CitationDrop
+
+**AC-28 — precedent root drop rejected with hint**: GIVEN a `LibraryPrecedentEntry` (root, no `/holding-N` suffix), WHEN dropped on a hypothesis node, THEN the drop is rejected, card returns to LibraryPane, and "판시 단락(holding) 단위로 인용해주세요" hint displayed. **(Integration)** `tests/integration/workspace/citation_drop_test.gd`
+
+**AC-29 — duplicate drop on same node triggers yellow flash**: GIVEN a node already holding `case:2019do1234/holding-1`, WHEN same ID dropped on same node again, THEN drop silently rejected, card returns instantly, existing evidence badge flashes yellow 250ms. **(Integration)** `tests/integration/workspace/citation_drop_test.gd`
+
+**AC-30 — evidence cap reached, 6th drop rejected with hint**: GIVEN a node with exactly 5 evidence items, WHEN a 6th drop attempted, THEN drop rejected and "이 노드에는 인용을 5개까지만 첨부할 수 있습니다" hint shown (UI path mirror of AC-14). **(Integration)** `tests/integration/workspace/citation_drop_test.gd`
+
+**AC-31 — miss drop ease-back, no state change**: GIVEN no hypothesis node under drop position (no hit-test target), WHEN `citation_dropped` fires, THEN no node's evidence array changes, card animates back to LibraryPane over 0.25s ease-out, "노드 위에 드롭해주세요" hint shown. **(Integration)** `tests/integration/workspace/citation_drop_test.gd`
+
+**AC-32 — invalid_citation at submit triggers submission_rejected**: GIVEN a node holds a Library ID that was valid at drop but no longer in LibraryService at submit, WHEN `EvaluationService.submit()` called, THEN `submission_rejected("invalid_citation:[id]")` emitted, Workspace returns to ACTIVE from FROZEN, "존재하지 않는 인용 항목이 포함되어 있습니다" 배너. **(Integration)** `tests/integration/workspace/citation_drop_test.gd`
+
+### 10.6 Persistence
+
+**AC-33 — WorkspaceData survives game restart**: GIVEN a case InProgress with workspace tree (3 nodes, memos, evidence), WHEN game closed and reopened, THEN same tree structure, labels, memos, evidence arrays present in loaded WorkspaceData. **(Integration)** `tests/integration/workspace/persistence_test.gd`
+
+**AC-34 — ACTIVE → INACTIVE → ACTIVE roundtrip preserves full state**: GIVEN Workspace ACTIVE with tree and memos, WHEN paused INACTIVE then resumed ACTIVE, THEN tree structure, memo contents, evidence arrays, labels identical to pre-pause. **(Integration)** `tests/integration/workspace/persistence_test.gd`
+
+**AC-35 — orphan node integrity sweep on load**: GIVEN WorkspaceData contains a node with `parent_id` referencing non-existent node_id (corruption), WHEN workspace loads, THEN orphan's `parent_id` set to `""` (root promotion), missing parent's children list cleaned up, `push_warning("WorkspaceData integrity: orphan node [id] promoted to root")` logged, `workspace_state_changed` emitted. **(Integration)** `tests/integration/workspace/persistence_test.gd`
+
+### 10.7 UI Visual / Interaction
+
+**AC-36 — selected node border 2px ink-black**: GIVEN a node selected, WHEN rendered at 1920×1080, THEN border visually 2px and 잉크블랙 `#1A1A1A` (Art Bible §3.1), distinct from unselected 0.5px. Screenshot evidence. **(Visual)** `production/qa/evidence/workspace-node-selected-border.md`
+
+**AC-37 — bottom evidence rule length matches evidence count**: GIVEN nodes with evidence count = {0, 1, 3, 5} (ρ = {0.0, 0.2, 0.6, 1.0}) at default `evidence_rule_thickness_px = 2.0`, WHEN rendered at 1920×1080 1:1 zoom and **node_inner_width = 184px (= 200px card − 8px×2 padding, §8.1.1.b inner padding spec)**, THEN bottom rule lengths measured at {0px (none), 36.8px ±2px, 110.4px ±2px, 184px ±2px} respectively (qa-lead + systems-designer IMPORTANT closure 2026-05-07 cycle 2: 픽셀 수치는 §8.1.1.b inner padding spec lockdown에 따라 갱신; `evidence_per_node_cap` 변경 시 본 수치 재산출 의무). Measurement protocol: screenshot capture + pixel-ruler overlay (`tools/qa/pixel-ruler.gd` 또는 동등 manual measurement); ρ=0 node 룰 부재 검증 (보더 only); ρ=1.0 룰이 노드 inner padding 좌측 8px 시작 → 우측 8px 끝 가득 채움 검증. Lead sign-off + screenshot evidence. **(Visual)** `production/qa/evidence/workspace-bottom-evidence-rule.md`
+
+**AC-38 — freeze overlay banner 250ms fade-in with banner appear (art-director B-NEW-3 BLOCKING closure 2026-05-07 cycle 2 — 인장 모티프 폐기)**: GIVEN Workspace transitions to FROZEN, WHEN 250ms elapses, THEN **80% opacity 판결지 오버레이** fades in over 250ms; THEN ink-black banner alone (인장 stamp 부재 — Art Bible §1 원칙 4 "결정문 도착 시퀀스 이외에 나타나지 않는다" 정합) opacity(0→1) **0.15s linear fade-in** (Art Bible §7 "문서 간 전환 0.15초 페이드" 정합). 스케일 변화 X. **(Visual)** `production/qa/evidence/workspace-freeze-overlay-banner.md`
+
+**AC-39 — READ_ONLY indicator distinct from FROZEN**: GIVEN Workspace READ_ONLY, WHEN rendered, THEN 30% 워터마크 + 15% modulate 채도 감쇠 (NOT 80% FROZEN 오버레이; 5% → 15% 갱신 — art-director I-3 IMPORTANT closure), 잉크블랙 배너 부재, "제출 완료 — 열람 전용" sticky indicator at DeskPane top. **(Visual)** `production/qa/evidence/workspace-readonly-vs-frozen.md`
+
+**AC-40 — reduced-motion disables all easing/tween animations (accessibility I-4 IMPORTANT closure 2026-05-07 cycle 2)**: GIVEN "Reduced Motion" 설정 enabled, WHEN any of (a) node drag-drop, (b) FROZEN entry overlay fade, (c) **bottom evidence rule grow/shrink (§8.1.1.b)**, (d) tree edge draw on add/move, (e) red flash / grey-tint duplicate flash, THEN 애니메이션 즉시 final 상태 snap (no interpolation), tween 비활성. 모든 5 path 검증. **(UI)** `production/qa/evidence/workspace-reduced-motion.md`
+
+**AC-41 — text scaling 100%–200% without horizontal overflow**: GIVEN text scale 200%, WHEN 4-level tree + memos rendered, THEN no `BodyLabel` or `MemoLabel` text truncated/overflow horizontally. **(UI)** `production/qa/evidence/workspace-text-scale-200.md`
+
+**AC-42 — F2 list view renders all nodes in indented text**: GIVEN workspace with 5 nodes across 2 depth, WHEN F2 pressed, THEN flat indented text representation displayed, child indented relative to parent, all labels readable. **(UI)** `production/qa/evidence/workspace-f2-list-view.md`
+
+### 10.8 Accessibility
+
+**AC-43 — body text color contrast WCAG AA**: GIVEN default theme (잉크블랙 `#1A1A1A` on 판결지 `#F5F2EC`), WHEN automated WCAG check, THEN ratio ≥ 4.5:1 for all `BodyLabel` and `MemoLabel`. **(Logic)** `tests/unit/workspace/accessibility_test.gd::test_body_text_contrast_aa`
+
+**AC-44 — information-bearing audio cues have visual counterpart (qa-lead IMPORTANT closure 2026-05-07 cycle 2 — silence row 명시 제외)**: GIVEN sound event catalog (§8.2.2) **filtered to non-`*(silence)*` rows = 11 information-bearing cues** (Node added × 2 + Node selected + Label edit start/confirm + Node move start/drop success/drop rejected + Node delete confirm + Memo focus + CitationDrop hover/accept/reject + Submit click + FROZEN overlay + evaluation_completed + submission_rejected; 수치 §8.2.2 row 합산 검증 의무), WHEN each event fires during manual walkthrough, THEN every information-bearing cue (weight-stamp, paper-return, FROZEN banner, etc.)는 동시 시각 피드백 (border 변화, card 애니메이션, overlay, status bar) 보유. **AT-mode validation (accessibility I-6 IMPORTANT closure)**: 별도 run with screen reader active + F2 list view enabled — list view text reflects evidence count change on CitationDrop accept (spatial canvas 대체 신호). Checklist enumerable per §8.2.2 (silence row 4건 제외). **(Manual)** `production/qa/evidence/workspace-audio-visual-parity.md`
+
+**AC-45 — keyboard-only full workflow completion (ux-designer + accessibility BLOCKING closure 2026-05-07 cycle 2)**: GIVEN keyboard input only, WHEN player executes the complete sequence: (1) Tab to LibraryPane, focus a holding card; (2) Press Space → "pending citation" 상태 활성화 (좌상단 배지 표시); (3) Tab to DeskPane, navigate to target HypothesisNode via Arrow keys; (4) Press Space → evidence attached (`weight-stamp` 오디오 + bottom rule 길이 갱신); (5) Add new root via Tab to "+" button + Enter; (6) Edit label via F2 + type + Enter; (7) Open memo panel via selecting node (Space on focused node), focus moves to memo TextEdit, type memo; (8) Ctrl+Enter to Submit + confirm dialog. THEN 모든 8 step pointer 없이 완료, focus ring visible throughout, status bar guidance present. **(Manual)** `production/qa/evidence/workspace-keyboard-only-workflow.md`
+
+**AC-46 — gamepad full workflow (escalation trigger 명시 — qa-lead IMPORTANT closure 2026-05-07 cycle 2)**: GIVEN gamepad only + OQ-W9 두 단계 discrete 대안 구현됨, WHEN player completes add tree → drop evidence → submit, THEN critical path 모두 KB/Mouse 없이 완료. **ADVISORY until UI Foundation epic sign-off** — UI Foundation epic sign-off 시점에 OQ-W9 ratify 의무, 미해결 시 본 AC ADVISORY → BLOCKING 자동 전환. **(Manual — Advisory with sunset)** `production/qa/evidence/workspace-gamepad-workflow.md`
+
+**AC-47 — focus ring visually distinct from selected state (qa-lead BLOCKING closure 2026-05-07 cycle 2 — "권장" 언어 폐기, spec lockdown)**: GIVEN node keyboard-focused but not gameplay-selected (Tab 또는 Arrow key 도달 후 click 부재), WHEN rendered at 1920×1080 1:1 zoom, THEN focus ring **렌더링 명세 (LOCKED, not 권장)**: `1px 점선 잉크블랙 #1A1A1A 외부 offset 2px` (선택 2px solid 보더 *바깥쪽* 2px offset에 점선 ring — accessibility I-5 IMPORTANT closure: 기존 inset 2px는 selected solid 보더 occlusion + card text content 영역 침범). 두 상태 동시 발생 (focused + selected) 시 outer 점선 ring + inner solid 모두 visible → 두 신호 readable coexist. **측정 protocol**: focus state + selected state 동시 캡처 + 색맹 시뮬레이터(Stark, Sim Daltonism, 또는 Color Oracle 중 1) 적용 시에도 두 상태 구분 가능 검증. **Floor resolution 검증**: 1366×768에서도 1px 점선이 인지 가능 — 미달 시 thickness 1.5px 폴백 (Workspace Layout ADR amendment 트리거). Lead sign-off + screenshot 3종 (focused only / selected only / both). **(Visual)** `production/qa/evidence/workspace-focus-vs-selected.md`
+
+### 10.9 Performance
+
+**AC-48 — chain_data build time ≤ 16ms at MVP cap (godot-specialist Item 2 BLOCKING closure 2026-05-07 cycle 2 — 50ms → 16ms 정정 + Time API 갱신)**: GIVEN worst-case MVP (~30 nodes: depth=3 fully branched, evidence=5 per node), WHEN chain_data built and measured via gdunit4 timer, THEN elapsed ≤ **16ms** (60fps frame budget — Rule 7 single-frame atomic 정합; 기존 50ms는 ADR-0007 §3.3 full evaluation 예산 — chain_data build alone은 dict assembly로 << 1ms 예상). 측정 프로토콜: seeded fixture + **`Time.get_ticks_msec()`** start/end (godot-specialist Item 4 IMPORTANT closure: `OS.get_ticks_msec()` deprecated since Godot 4.0) + N=100 averaged. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_chain_data_build_time_worst_case`
+
+**AC-49 — tree render with 30 nodes sustains 60fps (qa-lead IMPORTANT closure 2026-05-07 cycle 2 — stub test 의무화)**: GIVEN 30-node workspace rendered in headless gdunit4 scene, WHEN 100 consecutive frames measured, THEN no frame > 16.6ms (60fps budget). **Blocked**: Workspace Layout ADR가 Control class를 ratify하기 전까지 hard gate 불가 (OQ-QA-2 참조). **Stub test 의무**: `tests/unit/workspace/performance_test.gd::test_tree_render_30_nodes_60fps` 는 항상 존재하되 unblock 전까지는 `assert_skip("Blocked on Workspace Layout ADR — Control class TBD")`로 명시 skip — CI 차단 X, 그러나 sprint review에서 "AC-49 done" 주장 차단 (test가 skip으로 자명 표시). Workspace Layout ADR ratify 시 본 stub을 actual test로 교체. **(Logic)** `tests/unit/workspace/performance_test.gd::test_tree_render_30_nodes_60fps`
+
+**AC-50 — memo TextEdit input lag ≤ 100ms perceived (godot-specialist Item 5 BLOCKING closure 2026-05-07 cycle 2 — phantom API 폐기)**: GIVEN node memo TextEdit focused at default `MemoEdit` Theme variation (ADR-0004), WHEN key pressed and character appears on screen, THEN delay between key-down event timestamp and frame containing the new character ≤ 100ms. Measurement protocol (선택지 — 동일 결과 보장 시 어느 쪽이든 허용): (a) **고속 카메라 측정** — 240fps phone camera로 키보드 + 화면 동시 촬영, key-press frame과 character-appears frame 사이 frame 수 × 4.16ms 환산; (b) **인스트루멘트 measurement** — `_unhandled_input(event: InputEvent)` 콜백에서 `event is InputEventKey and event.pressed` 시 `Time.get_ticks_usec()` 캡처를 t0로 기록 + 다음 `RenderingServer.frame_post_draw` 시그널 콜백에서 `Time.get_ticks_usec()` 캡처를 t1로 기록 + frame buffer 내 새 character 존재 시 `delta = (t1 − t0) / 1000.0` ms 산출, N=20 sample 평균. (기존 `Input.get_action_press_timestamp()` API는 Godot 4.6에 미존재 — 폐기). 측정 환경: target hardware (Steam Deck 또는 동등 GTX 1060+ desktop) at 1080p Forward+; vsync on; 30-node tree fully populated (worst case); 5분 워밍업 후 측정. **(Manual)** `production/qa/evidence/workspace-memo-input-lag.md`
+
+### 10.10 Pillar Compliance Verification
+
+**AC-51 — Pillar 1 evidence count visible without raw numbers (game-designer + qa-lead + ux-designer BLOCKING closure 2026-05-07 cycle 2 — Gate ② cascade 누락 정정)**: GIVEN node with ρ=0.6 (3/5), WHEN rendered, THEN **bottom evidence rule visible at correct length** (§4.4 + §8.1.1.b: ρ × 184px = 110.4px ±2px) WITHOUT 노드 face 위 숫자 evidence count 라벨 (density는 *bottom rule length로만* 전달, counter 아님 — Channel B per Gate ②). 기존 "border modulation" 채널은 Gate ② 결정으로 폐기 — 본 AC는 새 채널 검증. Lead sign-off + screenshot at ρ ∈ {0.0, 0.2, 0.4, 0.6, 0.8, 1.0}. **(Visual)** `production/qa/evidence/workspace-pillar1-density-no-raw-count.md`
+
+**AC-52 — Pillar 1 guard: memo text never reaches chain_data (fuzz test)**: GIVEN schema validator on chain_data dict injected with `memo_text` field at node level, WHEN validator runs (regression simulation), THEN dict rejected + `submission_rejected("schema_violation")` emitted, NO EvaluationService call. Fuzz: 5 distinct forbidden field names, all caught. **(Logic)** `tests/unit/workspace/chain_data_test.gd::test_memo_body_absent_fuzz_schema_validator`
+
+**AC-53 — Pillar 3: no time-pressure cues in workspace (manual audit — qa-lead IMPORTANT closure 2026-05-07 cycle 2 — boundary 명시)**: GIVEN full workspace running ACTIVE, WHEN QA tester runs 5분 세션 + 모든 audio events·visual elements 감사, THEN no countdown timer, ticking cue, urgency animation, pace-increasing signal present. **명시 inclusion (urgency cue 정의)**: countdown timer; progress bar with shrinking quantity; clock display; flashing element with persist > 250ms; BPM-escalating audio; rising pitch contour; alert color (인장빨강 단독으로 *결정* context 외 사용). **명시 exclusion (urgency 외)**: `weight-stamp` audio (180ms, no pitch rise, no rhythm — §8.2.1 measurable spec 정합); FROZEN banner fade-in 0.15s (single transition, finality not urgency); evidence rule grow 0.15s (single transition, value increment not pace). Checklist는 inclusion 8항목 모두 absent + exclusion 3항목 explicitly permitted. **(Manual)** `production/qa/evidence/workspace-pillar3-no-time-pressure.md`
+
+**AC-54 — Pillar 3 cut anchor: delete confirmation always shown for non-empty subtree**: GIVEN `delete_confirmation_subtree_threshold == 0` (default), WHEN any node with ≥ 1 child deleted via Delete key or context menu, THEN "이 가지와 하위 [N]개 노드가 함께 삭제됩니다. 계속하시겠습니까?" 다이얼로그가 모든 상태 변경 *전* 출현, cancel 시 트리 변경 없음. **(Logic)** `tests/unit/workspace/tree_invariants_test.gd::test_delete_confirmation_always_shown_nonempty_subtree`
+
+### 10.11 Cross-System Interaction
+
+**AC-55 — Workspace ↔ EvaluationService: chain_data delivered correctly on submit**: GIVEN workspace with 2 노드 (depth 1, one evidence each), WHEN submit triggered, THEN PlayerSubmission received by EvaluationService has `chain_data.nodes.size() == 2`, `chain_data.edge_count == 1`, `chain_data.total_evidence_count == 2`, `chain_data.schema_version == 1`. **(Integration)** `tests/integration/workspace/citation_drop_test.gd` (fixture shared with EvaluationService stub)
+
+**AC-56 — Workspace ↔ Library: drop from Library accepted and evidence list updated**: GIVEN valid holding-level Library ID (`case:2024da12345/holding-1`) dragged from LibraryPane and dropped on hypothesis node with < 5 evidence, WHEN drop completes, THEN `LibraryService.get_holding(id)` resolves without error, node's evidence array contains the ID, `weight-stamp` 오디오 큐 발화. **(Integration)** `tests/integration/workspace/citation_drop_test.gd`
+
+### 10.12 Untestable AC Open Questions
+
+- **OQ-QA-1**: AC-46 (gamepad CitationDrop workflow) is ADVISORY because OQ-W9 (두 단계 gamepad discrete 대안) is unresolved — 버튼 할당, 시각 핸드셰이크, 취소 경로 미명세. **2026-05-07 cycle 2 escalation trigger added**: UI Foundation epic sign-off 시점 OQ-W9 미해결 시 BLOCKING 자동 전환.
+- **OQ-QA-2**: AC-49 (60fps with 30 nodes)는 headless Godot 4.6 scene with DeskPane Control tree 인스턴스화 필요. Tree canvas 정확한 Control class는 Workspace Layout ADR 위임 (§9 PROVISIONAL). Control class 결정 + gdunit4 headless 인스턴스화 가능 시까지 hard gate 불가. **2026-05-07 cycle 2: stub test 의무 추가** (assert_skip + 명시 reason — sprint review에서 false-claim 차단).
+
+### 10.13 Smoke-Check Baseline (qa-lead IMPORTANT closure 2026-05-07 cycle 2)
+
+`/smoke-check` 실행 시 다음 ACs를 baseline regression suite로 사용:
+
+**Logic ACs (모두 PASS 의무 — BLOCKING gate)**:
+- AC-1 ~ AC-11 (chain_data export 11건)
+- AC-12 ~ AC-16 (tree invariants 5건)
+- AC-23 (forbidden transition)
+- AC-24 (chain_data immutable post-freeze 4-step)
+- AC-25, AC-26 (FROZEN input 차단 2건)
+- AC-43 (text contrast)
+- AC-48 (chain_data build time ≤ 16ms)
+- AC-52 (Pillar 1 fuzz schema validator)
+- AC-54 (Pillar 3 cut anchor)
+
+**Integration ACs (전체 PASS 의무 — BLOCKING gate)**:
+- AC-17 ~ AC-22, AC-22b (state machine 7건)
+- AC-27 (crash recovery)
+- AC-28 ~ AC-32 (CitationDrop 5건)
+- AC-33 ~ AC-35 (persistence 3건)
+- AC-55, AC-56 (cross-system 2건)
+
+**Visual / Manual / UI ACs**: 본 baseline에서 제외 (lead sign-off + manual evidence 별도 trigger). Smoke-check는 자동화 가능 ACs로 한정.
+
+## Open Questions
+
+본 GDD 디자인 사이클에서 surface된 미해결 질문 + 위임 항목. 각 항목은 owner와 ratify 시점이 명시된다.
+
+### Resolved (in-session)
+
+- **OQ-W1 ✅ resolved (2026-05-06)**: 트리 깊이 cap. **Decision**: depth = 3 (MVP). §3.1 Rule 2 + §7.1 `max_tree_depth` knob.
+- **OQ-W2 ✅ resolved (2026-05-06)**: 노드당 evidence cap. **Decision**: 5 (MVP). §3.1 Rule 4 + §7.1 `evidence_per_node_cap` knob.
+
+### Resolved (2026-05-07 cycle 2 — 22 BLOCKING + 50 IMPORTANT closure)
+
+2nd cycle `/design-review` 결과 (8 specialist + creative-director synthesis): MAJOR REVISION NEEDED, 22 BLOCKING + ~50 IMPORTANT. 결정 근거 + 응답 cascade는 `design/gdd/reviews/reasoning-workspace-decisions-2026-05-07-cycle2.md`. 5 design decisions binding for cascade (Pillar 2 MVP 단순화 수용 / 인장빨강 #10 lockdown / AccessKit role floor lock / KB CitationDrop spec / Inner padding direct lock).
+
+**22 BLOCKING (요약 — 상세는 cycle2 decisions 문서 참조)**:
+- (cascade discipline 5건) AC-51 stale, §9.5 hover drop-shadow, REJECTED flash 인장빨강, 메모 카운터 인장빨강, 인장 32px → 모두 mechanical cascade revision 적용 (§8.1.1·§8.1.4·§8.1.6·§9.4.1·§9.5 갱신)
+- (Pillar 1 silent regression 2건) submission-evaluation §3.1.2 dual-layer guard 미이행 → submission-evaluation §3.1.2에 5th check 추가 의무 (cascade revision 동시 진행), §3.1 Rule 6 single source of truth `src/data/chain_data_schema.gd` const 명시
+- (formula gaps 3건) §4.3 normalized_breadth_v2 div-zero formula row inline guard 추가, 0·log2(0) convention 명시, nodes[] canonical ordering BFS 명시
+- (UX/AT 4건) §9.5 hover shadow 폐기, KB CitationDrop §9.4.2 Space-mark/Space-attach 패턴, AccessKit role floor §9.6 lock, F2 discoverability status bar toast + AccessKit description
+- (visual/audio 4건) freeze overlay 60→80%, 인장 32px 폐기, weight-stamp 3→5 variants + randomizer, weight-stamp-deep UI bus 0 dB
+- (engine API 3건) AC-50 phantom API → InputEvent.time, AC-48 OS.get_ticks_msec → Time.get_ticks_msec, AC-48 50ms → 16ms
+- (accessibility/contrast 1건) tree edge·unselected border `#D9D6CF` → `#8C8C8C` (3.0:1 WCAG 1.4.11 충족)
+
+**Recommended escalations (creative-director synthesis 권고)**:
+- 3rd review cycle mandatory — 2nd cascade가 cycle1 cascade에서 5 신규 회귀를 introduce했으므로 3rd cycle에서 회귀 부재 + IMPORTANT 잔류 항목 절대 수 감소 검증 의무.
+
+### Resolved (2026-05-07 cycle 1 — 12 BLOCKING closure, 1st cascade)
+
+3 design gate 결정 + cascade/mechanical revision으로 2026-05-07 design-review의 12 BLOCKING 항목 모두 closure. 결정 근거는 `design/gdd/reviews/reasoning-workspace-decisions-2026-05-07.md`.
+
+| BLOCKING # | Source | Closure |
+|---|---|---|
+| 1 | game-designer + systems-designer §3.1 Rule 1 DAG vs single parent_id | Gate ① — Forest of trees 잠금 (DAG 라벨 폐기) — §3.1 Rule 1·2 + §5.2 |
+| 2 | game-designer §3.1 Rule 2 depth ≤ 3 vs 4계층 | §3.1 Rule 2 — 학설/세부논거 계층은 노드 `memo` 본문에 포함 (트리 깊이 인플레이션 없음) |
+| 3 | systems-designer §4.3 normalized_breadth div-zero + linear-vs-star 차별화 실패 | §4.3 normalized_breadth_v2 = `1 − leaf_count/node_count` (선형/star/balanced 구별; div-zero boundary policy) |
+| 4 | systems-designer §4.3 evidence_distribution_entropy div-zero | §4.3 entropy boundary cases — node_count==1 또는 total_evidence_count==0 시 0 short-circuit |
+| 5 | systems-designer + qa-lead §3.1 Rule 6 schema_version 단일 레이어 가드 hole | §3.1 Rule 6 — Builder-side allow-list + EvaluationService Pre-evaluation Gate (ADR-0007 §3.1.2) dual-layer guard |
+| 6 | art-director §3.1 Rule 1 + §7.1 200×48px vs 60자 | §3.1 Rule 1 — Label 표시 정책 ellipsis truncation + hover tooltip + 편집 진입 + F2 list view에서 full label 노출 |
+| 7 | art-director + systems-designer §8.1.1 evidence_density modulation subpixel + selection 압도 | Gate ② — Bottom Evidence Rule (Channel B 신규 시각 채널) — §8.1.1.b + §4.4 + §7.3 knob 교체 |
+| 8 | godot-specialist §3.3 시그널 dual emitter + Browser autoload-or-scene + drag-drop API | Gate ③ B-1 — Signal contract lock + Workspace Layout ADR 위임; OQ-W13 신설; §3.3 표 정정 |
+| 9 | godot-specialist §3.1 Rule 7 freeze 동기/비동기 모순 | Gate ③ B-2 — Sync transition single-frame (a→d atomic) + fire-and-forget submit + async signal callback 복귀 |
+| 10 | qa-lead AC-37/47/50 측정 protocol | AC-37 (bottom rule pixel-ruler), AC-47 (focus ring 점선 spec + 색맹 시뮬레이터), AC-50 (240fps 카메라 또는 timestamp 인스트루멘트) — 각 측정 protocol 명시 |
+| 11 | godot-specialist + qa-lead AC-24 byte-identical (Godot Dictionary reference type) | AC-24 — 3-step deep-equality verification (JSON.stringify sorted + `==` 연산자 + mutation block) |
+| 12 | ux-designer §9.4.1 + §3.1 Rule 3 Ctrl+drag 컨벤션 + discoverable surface 0 | §3.1 Rule 3 — Plain drag from node body + cursor grab/grabbing 변환 + 우클릭 메뉴 "이동" 항목 (drop discrimination by source) |
+
+### Deferred to other systems / phases
+
+| OQ | Question | Owner | Target |
+|---|---|---|---|
+| **OQ-W3** | chain_data `memo_text` 필드 — 메모 텍스트 분석 도입 시 schema_version=2 bump 시점 검토 | systems-designer + #9 Submission & Evaluation | v1+ post-MVP |
+| **OQ-W4** | `workspace_state_changed` 시그널 기반 자동저장 빈도 정책 (매 mutation? 5초 throttle? 명시 저장 버튼?) | #3 Save/Load GDD | #3 Save/Load 디자인 시점 |
+| **OQ-W5** | 메모 패널 위치 — (A) inline next to selected node / (B) fixed bottom-right / (C) modal. 본 GDD §9.3에서 (A) 권고, (B) fallback. | ux-designer + UI Foundation epic | UI Foundation epic ratify (4-deep tree + 3+ root prototype 측정 후) |
+| **OQ-W6** | 메모 마크다운 서식 활성화 (현재 plain text MVP) | game-designer + ux-designer | v1+ post-MVP |
+| **OQ-W7** | AccessKit Godot 4.6 검증 — Tree canvas (non-standard widget) traversal. F2 list view fallback 규격 확정 필요 | accessibility-specialist + godot-specialist | UI Foundation epic + accessibility audit |
+| **OQ-W8** | Browser §3.6 WorkspaceHandoff 타임아웃 가드 — Workspace `FROZEN` 중 `workspace_handoff_ended` 무시 시 Browser 측 교착 가능 (§5.7 EC) | Browser GDD #5 author | Browser Layout ADR 또는 Browser §AC 보강 |
+| **OQ-W9** | Gamepad CitationDrop 두 단계 discrete 대안 — 버튼 할당, 시각 핸드셰이크 ("인용 대기 중" 배지), 취소 경로 (§9.4.3) | ux-designer + UI Foundation epic | UI Foundation epic 프로토타입 |
+| **OQ-W10** | Tree canvas panning behavior — right-stick analog pan vs. D-pad scroll vs. auto-center on focused node. 4-deep + 3+ root at 566px DeskPane floor 시 동작 (§9.4.3 + §9.7) | ux-designer + Workspace Layout ADR | Floor 해상도 ratify에 종속 |
+| **OQ-W11** | 장시간 세션 (≥10분) BGM 도입 검토 — 단선율 드론 또는 피아노 한 음 (§8.2.4) | audio-director + 플레이테스트 | v1+ 플레이테스트 결과 후 |
+| **OQ-W12** | 주요 비음성 사운드의 시각 지시자 필요 여부 (§8.2.5 접근성) | accessibility-specialist + 플레이테스트 접근성 라운드 | 플레이테스트 접근성 라운드 |
+| **OQ-W13** | CitationDrop signal topology — autoload `LibraryService` vs scene node `LibraryPane` 발신자 + Godot 4.6 native drag-drop API (`_get_drag_data`/`_can_drop_data`/`_drop_data`) vs autoload signal vs hybrid 채택. Gate ③ 결정에서 contract만 잠금, 구체 위임. | godot-specialist + Workspace Layout ADR | Workspace Layout ADR 작성 시점 (UI Foundation epic prerequisite) |
+
+### AC-level untestable (carry-over from §10)
+
+- **OQ-QA-1**: AC-46 (gamepad CitationDrop workflow) ADVISORY 상태 — OQ-W9 ratify 시 hard gate 전환.
+- **OQ-QA-2**: AC-49 (60fps with 30 nodes) blocked — Workspace Layout ADR가 Control class 결정 + headless scene 인스턴스화 가능 시 hard gate 전환.
+
+### Provisional contracts pending future ADRs
+
+- **§9 UI Requirements** — `PROVISIONAL contract`. UI Foundation epic + Workspace Layout ADR 작성 후 LOCKED 전환.
+- **§4.3 chain_coherence subscore** — v1+ forward declaration only. ADR-0007 amendment + submission-evaluation §4 갱신 시점에 잠금. 본 GDD는 amendment 불요 (chain_data schema 충분 — Pillar 1 가드 유지).

--- a/design/gdd/reviews/legal-reference-library-review-log.md
+++ b/design/gdd/reviews/legal-reference-library-review-log.md
@@ -1,0 +1,47 @@
+# Review Log: Legal Reference Library
+
+> **System**: #20 Legal Reference Library
+> **Doc**: design/gdd/legal-reference-library.md
+> **Status Source**: design/gdd/systems-index.md
+
+리뷰 이력 (최신이 위). 각 엔트리는 그 시점의 verdict, blockers, 해소 여부를 기록.
+
+---
+
+## Review — 2026-05-04 — Verdict: NEEDS REVISION (in-session: 2/5 resolved)
+Mode: lean (single-session, no specialist agents)
+Scope signal: L (Foundation, multi-system 의존, 새 ADR 1+ 필요)
+Specialists: 없음 (lean) — `--depth full` 재실행 시 game-designer + systems-designer + qa-lead + narrative-director + performance-analyst + godot-specialist + creative-director 가능
+Blocking items: 5 → 2 in-session 해소, 3 자문 입력 자료로 보존
+Recommended items: 12
+Nice-to-have: 3
+Prior verdict resolved: First review
+
+### Blockers
+
+| # | 항목 | 상태 |
+|---|------|------|
+| 1 | 저장 형식 명세 vs 스키마 예시 모순 (3.1.3 "Markdown+YAML" 선언, 3.1.4는 YAML 단독) | **Resolved (post-review same session)** — ADR-0001 Library Storage Format Proposed (.tres + Godot 커스텀 Resource 채택) + GDD 3.1.3·3.1.4 정정 적용 |
+| 2 | 법령 스키마 — 조의2(sub-article) 및 호(item) 누락 | **Deferred** — 자문가 Q5와 묶어 검수 |
+| 3 | Holding ID 합성 규칙 미명시 | **Resolved** — Section 3.1.2에 합성 규칙 추가 (런타임 `<file.id>/holding-<N>` 결합, 책임=Library 로더) |
+| 4 | AC-15 메모리 측정 방법론 부재 | **Deferred** — 측정 프로토콜 추가 또는 ADVISORY 격하, godot-specialist 자문 후 결정 |
+| 5 | Section 4.1 vs 7.3 권위 가중 활성 조건 모순 | **Resolved** — 4.1 본문 명시 + 7.3 노브 셀에 OQ-5 위임 + Open Questions에 OQ-5 신규 (a/b/c 옵션) |
+
+### Top Recommendations (deferred to next pass)
+- "항목" 단위 vs "파일" 단위 용어 정리 (3.1.1 vs 3.1.4)
+- `referenced_by_cases` 수동 큐레이션 부담 — OQ-4와 묶기
+- 4.1 공식 다항식 placeholder 의도 명시
+- 3.1.4 예시 사실관계 (시행일·선고일) 자문 검수 항목 추가
+- 검색 정렬 — ID 직접 매칭 보조 키
+- EC-2 검색 0건 한국어 오타 정책 — v1+ Levenshtein OQ
+- AC-16 측정 환경(빌드·H/W) 명시
+- AC-17 v1+ 시점 AC 분리
+
+### Senior Verdict 요약
+GDD는 디자이너 1인 4시간 도달 가능 깊이의 거의 최대치. Anti-Pillar 가드(`court_grade_weight=0` 잠금, EC-2 자동 추천 거부, EC-3 페이지네이션 거부)가 Pillar 2·4를 침해하지 않게 공식·EC 양쪽에서 막은 점이 강점. 잔여 3 블로커는 모두 자문가 답변에 의존하므로 자문 회의 입력으로 가져가는 것이 효율적. 자문 통과 시 Provisional → Approved 게이트 충족 가능.
+
+### Next Action
+1. `/architecture-decision` — Library Storage Format ADR (Markdown vs YAML vs Godot Resource) — 블로커 #1 선결 조건
+2. 자문 회의 (한국 변호사 또는 법학 교수 1인, 1시간) — Q1-Q5 + 블로커 #1·#2·#4 + 시드 데이터 5-10건
+3. 자문 회의 후 GDD 갱신 → Provisional → Approved
+4. 그 후 `/design-system case-data-schema` (#1)

--- a/design/gdd/reviews/reasoning-workspace-decisions-2026-05-07-cycle2.md
+++ b/design/gdd/reviews/reasoning-workspace-decisions-2026-05-07-cycle2.md
@@ -1,0 +1,206 @@
+# Reasoning Workspace — Design Decisions (2026-05-07 cycle 2)
+
+> 2nd `/design-review` cycle (8 specialist + creative-director synthesis) 결과: **MAJOR REVISION NEEDED, 22 BLOCKING + ~50 IMPORTANT**.
+> 본 문서는 22 BLOCKING + 핵심 IMPORTANT 응답 cascade 결정을 기록.
+> 사용자 자율 모드 ("허락맡지말고 쭉 해줘") 하에 best-judgment defaults 적용 — 사용자 이의 시 다음 세션에서 reverse 가능.
+
+---
+
+## Decision 1 — Pillar 2 Bottom Rule: MVP Count-Based Acceptance + v1+ Court-Grade Track
+
+**BLOCKING 대응**: game-designer Pillar 2 IMPORTANT — bottom rule "longer = more cited" 가 한국 상고심 court-grade weight를 inversion (5 inferior holdings ρ=1.0 vs 1 전합 판례 ρ=0.2).
+
+### 결정
+
+**MVP는 count-based bottom evidence rule 유지** (Gate ② 결정 보존). v1+에서 *weighted* 변형 ADR-0007 amendment를 통해 도입. MVP에서 본 한계는 **명시 documented limitation** — §4.4 "Pillar 2 도메인 한계" 절에서 sound-designer/qa-lead/리뷰어 모두 인지 가능하게 surface.
+
+### Rationale
+
+1. **Cycle 2 cascade 자체 scope 보호** — Gate ② revisit은 §4.3·§4.4·§7.1·§8.1.1.b·AC-37·entities.yaml·ADR-0007 amendment·#20 Library §3 검토 의무 — 본 cascade에서 처리하기에 과대 scope.
+2. **인지 가능성 우선** — Bottom rule이 *cycle 1에서 BLOCKING #7 closure 채널*로 잠긴 직후 weighting 도입은 cascade discipline 손상 (creative-director 지적 — cascade 규율 회복이 본 cycle 우선).
+3. **v1+ formula round + 자문가 검수 필요** — court_grade weight 매핑 (전합 / 부 / 하급심 / holding-level)은 한국 법조 자문가 1회 인터뷰 의무 (본 GDD §3.3 OQ-7 Verdict 라벨 의미론과 동시 자문 가능).
+4. **Pillar 1 가시화 손상 X** — count-based bottom rule도 *인용을 쌓을수록 굵어진다* 직관 보존; Pillar 2 위반은 *invisible weight*로 한정 (player가 5 하급심 인용 = 1 전합 인용으로 *느끼는* 문제는 v1+ 자문가 검수 후 visual upgrade로 해소).
+
+### Cascade impact (§4.4 + decisions log)
+
+§4.4 evidence_density "Pillar 2 도메인 한계 명시" 절 추가 — count-based proxy + v1+ ADR-0007 amendment 트리거 + weighted 변형 forward declaration.
+
+### v1+ Track (forward-declared)
+
+ADR-0007 amendment 작성 시점에 다음 항목 ratify:
+1. `precedent_seniority_bonus` subscore weight 활성 (현재 0.0 잠금 해제)
+2. `evidence_density` weighted 변형 — `weighted_density(n) = Σ_i court_grade_weight(evidence_i) / EVIDENCE_PER_NODE_CAP_WEIGHTED`
+3. court_grade_weight 매핑 — 전합: 1.5x, 부: 1.0x, 하급심: 0.5x (자문가 검수 후 잠금)
+4. Bottom rule 시각 — 길이 + 두께 dual-channel 또는 색 진하기 추가 (color-blind safe 변형 art-director 검토)
+
+---
+
+## Decision 2 — 인장빨강 #10 Verdict Reveal Lockdown (Art Bible §4 강제)
+
+**BLOCKING 대응**: art-director B-NEW-1, B-NEW-3, B-NEW-4 — 인장빨강 4건 violation (REJECTED flash, freeze 인장 모티프, 메모 카운터 cap 알림).
+
+### 결정
+
+**인장빨강 `#C8102E` 사용은 #10 Verdict Reveal Sequence 단독으로 lockdown** — Art Bible §4 시맨틱 ("결정적이다·돌이킬 수 없다·대법원의 공식 행위") 엄격 적용.
+
+본 GDD §8.1.1·§8.1.4·§8.1.6에서 *전체 폐기*:
+- §8.1.1 REJECTED flash → 미드그레이 점선 1.5px (shape cue + motion cue)
+- §8.1.4 인장 모티프 (32px) → 폐기. 배너 단독 + `weight-stamp-deep` 오디오로 결정성 전달
+- §8.1.6 메모 카운터 cap 알림 → 글꼴 무게 Medium 단독 처리
+
+### Rationale
+
+Art Bible §4 Design Test ("빨간색 요소를 지웠을 때 게임 플레이에 지장이 없는가? 지장이 있다면 빨강이 제 역할을 한 것이다") — 본 3 use case에서 빨강 제거 시 게임 진행에 지장 없음 → 빨강이 제 역할 X → 단순 *시각 노이즈*. 본 lockdown은 #10 Verdict Reveal 시점의 빨강이 *진정 결정적*임을 player에게 *희소 신호*로 보존.
+
+### Cascade impact
+
+- §8.1.1 REJECTED flash row 갱신 (미드그레이 점선 1.5px)
+- §8.1.4 freeze overlay 인장 모티프 폐기 + AC-38 갱신 (스케일 변화 X, 단순 페이드인)
+- §8.1.6 메모 카운터 글꼴 무게만 사용
+- §8.1.7 Asset Spec triggers — `vfx_freeze_banner_stamp_01.png` 폐기, color tokens `#C8102E0D` 폐기
+
+### Art Bible amendment 트리거
+
+art-director가 Art Bible §4 색 사용 정책에 다음 1줄 추가 의무:
+> "인장빨강 `#C8102E`는 #10 Verdict Reveal Sequence 단독 사용. 본 게임 어떤 다른 화면·feedback 상태에서도 인장빨강 사용 금지 — 결정성 신호의 희소성 보존."
+
+---
+
+## Decision 3 — AccessKit Role Floor Lock (OQ-W7 부분 종결)
+
+**BLOCKING 대응**: accessibility BLOCKING #1 — AccessKit role 미정의로 스크린 리더 empty output.
+
+### 결정
+
+§9.6에 **AccessKit role floor 명세**를 *본 GDD에서 직접 lock*. OQ-W7 "AccessKit verification" 위임 scope를 *floor 정의*에서 *floor 검증 (verification)*으로 reframe — UI Foundation epic은 actual screen reader 출력 측정만 책임.
+
+### Spec (§9.6에서 잠금)
+
+- **Tree canvas root Control**: `accessibility_role = AccessibilityRole.ROLE_TREE`. `accessibility_description = "가설 트리 캔버스. F2를 눌러 텍스트 목록 보기로 전환. Space로 인용 첨부 (LibraryPane → DeskPane 두 단계)."`
+- **각 HypothesisNode Control**: `accessibility_role = ROLE_TREE_ITEM`. `accessibility_name = node.label` (full 60자, ellipsis 미적용). `accessibility_description = "depth %d, evidence %d개 첨부됨, 자식 %d개" % [depth, len(evidence), child_count]`.
+- **Memo panel RichTextLabel**: `accessibility_name`을 underlying memo 문자열로 programmatically 설정 (Godot 4.6 RichTextLabel AccessKit 자동 노출 미보장 한계 — godot-specialist Item 9 IMPORTANT 인용).
+
+### Rationale
+
+기존 OQ-W7 "Tree canvas traversal AccessKit 검증"은 *floor 부재* 상태에서 verification만 위임 — 결과적으로 UI Foundation epic 시작 시점에 floor를 0부터 설계해야 함. Floor를 GDD에서 잠그면 UI Foundation epic은 *spec-driven* implementation 가능 + verification은 일관된 standard 보유.
+
+### v1+ Track
+
+- RichTextLabel AccessKit BBCode 처리 — Godot 4.7+에서 native 지원 시 `accessibility_name` programmatic 설정 폐기 검토.
+
+---
+
+## Decision 4 — KB CitationDrop Pattern Lock (Space-mark / Space-attach / Esc-cancel)
+
+**BLOCKING 대응**: ux-designer + accessibility BLOCKING — AC-45 KB-only workflow 통과 위해 cross-pane citation 키보드 경로 필수, OQ-W9 gamepad 패턴과 mirror 가능.
+
+### 결정
+
+§9.4.2 키보드 단축키 표에 **Space (LibraryPane focus) → "pending citation" 활성** + **Space (DeskPane node focus, pending 활성) → 첨부** + **Esc (pending 활성) → 취소** 3-step 패턴 lock.
+
+### Spec (§9.4.2)
+
+| Step | Key | Action |
+|---|---|---|
+| 1 | Tab to LibraryPane → 카드 focus | 표준 Tab traversal |
+| 2 | Space | "pending citation" 상태 활성 — 좌상단 floating 배지 "[library_id] 인용 대기 중" + status bar 안내 |
+| 3 | Tab to DeskPane → node focus | 표준 Tab traversal (pending 상태는 application-level — Pane 전환 무관) |
+| 4 | Space | pending library_id를 포커스 노드에 첨부 (Rule 4 정책 — cap·중복·타입 검증). 성공 시 `weight-stamp` audio + bottom rule grow + pending 해제. 거부 시 §5.3 정책 mirror + pending *유지* |
+| 5 (취소) | Esc | pending 취소, 배지 사라짐, status bar "인용 대기 취소" |
+
+### Rationale
+
+OQ-W9 gamepad 두 단계 discrete 대안과 *동일 mental model* — Space (KB) ↔ A button (gamepad), Esc (KB) ↔ B button (gamepad). 두 입력 modality 간 학습 전이 자연. AC-45 (KB-only workflow) 통과 가능 + accessibility 의무 충족.
+
+### Cascade impact
+
+- §9.4.2 키보드 단축키 표 3행 추가
+- AC-45 wording 갱신 — 8-step KB workflow 명시
+- AC-46 OQ-W9 dependency 보존 (gamepad만 ADVISORY 유지)
+
+---
+
+## Decision 5 — §8.1.1.b Inner Padding Direct Lock (Workspace Layout ADR 위임 폐기)
+
+**BLOCKING 대응**: art-director B-NEW-5 — Gate ② tradeoff (a) "art-director가 §8.1.1 revision 시 padding 명시" 미이행, ADR 위임만 표시.
+
+### 결정
+
+§8.1.1.b에 **inner padding spec을 본 GDD에서 직접 lock** (Workspace Layout ADR 위임 폐기 + Art Bible §3.1 amendment 트리거).
+
+### Spec (§8.1.1.b)
+
+| 영역 | 값 |
+|---|---|
+| Top padding | 6px |
+| Left padding | 8px |
+| Right padding | 8px |
+| Bottom padding | 4px (rule 부재) / 2px text + 2px rule 영역 (rule 활성) |
+| Effective text box (rule 부재) | 184×38px |
+| Effective text box (rule 활성) | 184×40px |
+| Label 폰트 | Pretendard Regular 14pt (line-height 18px) |
+
+Bottom rule 활성 시 좌측 8px padding 시작점에서 grow → ρ × 184px 길이.
+
+### Rationale
+
+Inner padding은 *visual spec*이고 *layout decision*과 분리 가능 — ADR scope (Control class·Pane resizing·signal topology)와 별개. 직접 잠그면 Workspace Layout ADR 작성을 단순화 + cycle 2 cascade에서 즉시 closure.
+
+### AC-37 정합 갱신
+
+기존 픽셀 수치 (40/120/200px ±2px) → (36.8/110.4/184px ±2px) — 184px = 200px − 8px×2.
+
+### Art Bible amendment 트리거
+
+art-director가 Art Bible §3.1 200×48 hero shape 명세에 본 padding spec 등재 의무.
+
+---
+
+## Cascade Discipline 강화 (creative-director Decision 2 권고)
+
+본 cycle은 cycle 1 cascade가 §3에 적용되었으나 §8/§9/AC tables에 propagate 누락 → 5 BLOCKING 회귀 발생. 본 cycle 종결 후 *cascade discipline checklist* 적용:
+
+1. **Decision → grep token mapping**: 각 design decision 후 영향 받는 키워드를 grep — 본 cycle 예시:
+   - "border modulation" → 0 hits 검증
+   - "drop-shadow" / "drop shadow" → 본 GDD 0 hits, ux-designer hover affordance 정합
+   - "인장빨강" / "C8102E" → §10 Verdict Reveal 외 0 hits
+   - "권장" in AC text → 0 hits (모든 AC는 unconditional)
+   - "OS.get_ticks_msec" → 0 hits
+   - "Input.get_action_press_timestamp" → 0 hits
+2. **Section coverage matrix**: 결정 별 영향 받는 section list 명시 (예: Gate ② → §3.1 Rule 4·§4.3·§4.4·§7.3·§8.1.1·§8.1.1.b·§9.5·AC-37·AC-51).
+3. **3rd review cycle scheduled** — 본 cycle 응답 cascade의 회귀 부재 검증 의무.
+
+---
+
+## Decision summary
+
+| # | Decision | BLOCKING 닫힘 |
+|---|---|---|
+| 1 | Pillar 2 MVP count-based + v1+ court-grade track | game-designer Pillar 2 |
+| 2 | 인장빨강 #10 lockdown + 4 use case 폐기 | art-director B-NEW-1·3·4 |
+| 3 | AccessKit role floor lock (§9.6) | accessibility #1, #2 (F2 discoverability cross-link) |
+| 4 | KB CitationDrop Space/Esc 패턴 (§9.4.2) | ux-designer + accessibility #8 (AC-45) |
+| 5 | §8.1.1.b inner padding direct lock | art-director B-NEW-5 |
+
+**남은 BLOCKING (mechanical cascade revision으로 처리, 본 문서 별도 design decision X)**:
+- (cascade) AC-51 stale, §9.5 hover drop-shadow → §8.1.1·§9.4.1·§9.5 갱신
+- (formula) §4.3 div-zero formula row guard, 0·log2(0) convention, nodes[] BFS canonical order → §3.1 Rule 6 + §4.3 갱신
+- (engine API) AC-50 phantom API → InputEvent.time, AC-48 OS.get_ticks_msec → Time.get_ticks_msec, AC-48 50ms → 16ms → §10 갱신
+- (Pillar 1 silent regression) submission-evaluation §3.1.2 5th check 추가 → submission-evaluation.md §3.1.2 갱신
+- (audio mix) weight-stamp 3→5 variants, weight-stamp-deep UI bus → §8.2 갱신
+- (visual) freeze 60→80%, READ_ONLY 5%→15%, 미드그레이 색 통일 → §8.1 갱신
+- (atomicity) Invariant 5 evidence move atomic, Invariant 6 tuning validation → §4.2 갱신
+
+---
+
+## Pillar 정합 자가검수 (post-cycle 2 decisions, per `feedback_domain_authenticity` 메모리)
+
+5 결정 모두 5 pillar + 한국 상고심 도메인 진정성 위반 점검:
+
+- **Decision 1** (Pillar 2 MVP count): ⚠️ *known limitation* — MVP는 한국 법조 court-grade weight inversion 위험을 안고 ship; v1+ 자문가 검수에서 visual + algorithm 동시 upgrade 의무. 본 trade-off는 사용자 결정 후 escalate 가능.
+- **Decision 2** (인장빨강 lockdown): ✅ Art Bible §4 정합 + Pillar 4 ("끝나도 따라온다") 결정문 시퀀스의 sonic+visual 희소 신호 보존.
+- **Decision 3** (AccessKit floor): ✅ 한국 법조 도메인 외 — 일반 접근성 표준 준수, Pillar 무관.
+- **Decision 4** (KB CitationDrop): ✅ 한국 법조 도메인 외 — 일반 접근성 표준 준수, Pillar 무관.
+- **Decision 5** (Inner padding direct lock): ✅ Art Bible 인쇄 미학 정합 (200×48 hero shape의 "꾸밈 없고 구조만 있다" 정신 — padding이 명시될수록 인쇄 정합).
+
+5 결정 중 4건 위반 부재; Decision 1은 MVP scope 한계를 명시 surface한 *수용된 단순화*로 분류 — 사용자 검토 권장.

--- a/design/gdd/reviews/reasoning-workspace-decisions-2026-05-07.md
+++ b/design/gdd/reviews/reasoning-workspace-decisions-2026-05-07.md
@@ -1,0 +1,166 @@
+# Reasoning Workspace — Design Gate Decisions (2026-05-07)
+
+> 2026-05-07 design-review (MAJOR REVISION NEEDED) 응답으로 작성된 3 design gate 결정 기록.
+> 각 결정은 BLOCKING 항목을 닫고 cascade revision의 잠금 입력으로 작용한다.
+
+---
+
+## Gate ① — Tree (Forest) 잠금 (DAG 라벨 폐기)
+
+**BLOCKING 대응**: §3.1 Rule 1 "DAG" vs single `parent_id` 스키마 모순 (game-designer + systems-designer)
+
+### 결정
+
+**케이스 종속 multi-root tree (forest)** 잠금. "DAG" 라벨은 GDD 전체에서 폐기.
+
+- 가설 노드 자체는 forest of trees: `parent_id: String` (single) + `children: Array[String]`
+- 다중 루트 허용 (`parent_id == ""` 노드 복수 OK — 병렬 가설)
+- evidence (`library_id` 문자열 배열) 측에서 many-to-many 관계 허용 — 동일 `library_id`가 *다른* 노드에 동시 존재 가능 (Rule 4 기존 정책 유지)
+
+### Rationale
+
+1. **데이터 스키마 자체가 forest (tree of trees)** — `parent_id: String` 필드는 단일 부모. 진정한 DAG는 `parent_ids: Array[String]` 가 필요한데 그 전환은 chain_data export·invariant·serialization 모든 지점에서 cascade 비용 폭증.
+2. **Player Fantasy의 "같은 판시 단락을 다른 가지에 옮겨붙이면" 약속은 *evidence 차원*의 many-to-many** — 가설 트리 자체가 DAG일 필요 없음. Rule 4 (`동일 ID 중복: 같은 노드 내 차단 / 다른 노드에 동일 ID는 허용`)가 이 약속을 이미 이행한다.
+3. **Pillar 4 영속성 — Forest serialization은 well-defined** (각 노드 1개 부모 ID만 저장). True DAG 직렬화는 노드별 부모 set + 토폴로지컬 정렬 필요로 #3 Save/Load 의존성 비용 증가.
+4. **Invariant 3 (Acyclicity)는 이미 tree property로 정의** — "≤ MAX_DEPTH 단계 내 root 도달"이 트리 사이클 부재의 충분 조건. DAG에서는 더 일반적인 cycle detection (DFS visited set) 필요.
+5. **"DAG" 라벨은 *문서 부정확*** — 실제 동작은 forest. 라벨 정정만으로 BLOCKING 해소.
+
+### Cascade impact
+
+- §3.1 Rule 1 첫 문장: "DAG" → "케이스 종속 multi-root tree (forest)"
+- §3.1 Rule 2: "다중 루트 허용 (병렬 가설 — `parent_id == ""`인 노드 복수 OK)" — 명시적 forest 정의 추가
+- §5.2 EC `chain_data DAG 계약 보유 — 사이클 허용 시 직렬화 루프` → "chain_data forest 계약 보유" (정정)
+- §4.3 `chain_coherence` 수식: forest 가정에 맞춰 `node_count == 1` div-zero 방어 (Gate ② 와 별도지만 같은 cascade)
+
+### Pillar 4 약속 재해석
+
+§2 Player Fantasy 두 번째 단락의 "같은 판시 단락을 다른 가지에 옮겨붙이면 그쪽이 굵어진다"는 이제 다음 두 메커니즘으로 분리되어 이행:
+
+1. **Evidence 첨부 many-to-many** (Rule 4) — 동일 `library_id`가 다른 노드에 *동시* 존재 (move 아닌 add).
+2. **Evidence 시각 가중** (Gate ② 결정의 bottom evidence rule) — 첨부된 evidence 수에 비례한 시각 굵기.
+
+"옮겨붙이면"의 운영 정의: 사용자가 evidence 카드를 한 노드에서 다른 노드로 *드래그하여 이동*하면 source 노드 evidence 배열에서 제거 + target 노드 배열에 추가 (UI 동작; data 측 effect는 두 step). 시각: source의 bottom rule 짧아지고 target의 bottom rule 길어진다.
+
+---
+
+## Gate ② — Bottom Evidence Rule (border thickness modulation 폐기)
+
+**BLOCKING 대응**: §8.1.1 evidence_density 0.125px subpixel 인지 한계 + selection state가 weight signal 압도 (art-director + systems-designer)
+
+### 결정
+
+evidence 시각 신호를 **별도 channel로 분리** — 노드 카드 *하단 가로 룰 (underline mark)*의 *길이*가 evidence 수에 비례. 기존의 보더 두께 modulation 폐기.
+
+### 사양
+
+| 변수 | 값 |
+|---|---|
+| 위치 | 노드 카드 하단 edge — 카드 외곽 보더 안쪽 즉시 inset 0px |
+| 두께 | 2.0px (고정) |
+| 색상 | 잉크블랙 `#1A1A1A` (Art Bible §3 line weight 표 — 활성 line) |
+| 길이 | `(len(n.evidence) / EVIDENCE_PER_NODE_CAP) × node_width` — MVP cap=5 기준 0%·20%·40%·60%·80%·100% 6단계 |
+| 정렬 | 카드 좌측 edge에서 right-grow (한국어 인쇄 관례 좌→우) |
+| 추가/제거 | 0.15초 linear width tween (Art Bible §7 "문서 간 전환 0.15초 페이드" 정합) |
+
+### Rationale
+
+1. **인지 임계 충족** — 200×48px 카드 기준 20% 단계 = 40px. 1080p 1:1 매핑에서도 명백히 구분. subpixel 문제 종결.
+2. **Selection signal과 channel 분리** — selection은 외곽 보더 두께 (binary 0.5/2.0px). evidence는 하단 룰 길이 (continuous 6 step). 두 신호가 동시 발화해도 충돌 없음.
+3. **Pillar 1 ("진실은 가중치다") 직접 구현** — "인용이 쌓일수록 *밑줄이 길어진다*"는 한국 법조 문서 관례 (중요 부분 밑줄)와 일치. 인쇄 미학 직접 차용.
+4. **Art Bible §3 "배경색 변화 없음" 준수** — 룰은 line element, 배경 채우기 아님.
+5. **색맹 가드 정합** — 길이라는 spatial cue 단독 사용. Art Bible §4 색 단독 의존 금지 정합.
+
+### 폐기 / 변경
+
+- **폐기**: §8.1.1 `evidence_density modulated` 행 (border 두께 ρ-modulation).
+- **변경**: §4.4 `evidence_density(n)` 수식은 유지하되 의미 재정의 — "노드 하단 룰 길이의 비율 ρ ∈ [0,1]"로 사용. 보더 두께 modulation 언급 제거.
+- **신규**: §7.3 knob `evidence_density_modulation_strength` (default 0.5) 폐기 → `evidence_rule_visible` (bool, default true) + `evidence_rule_thickness_px` (float, default 2.0, range 1.5–3.0).
+- **AC-37**: 측정 protocol 보강 — "노드의 bottom rule 길이가 evidence 수와 일치 (0/1/3/5 케이스 각각 0%·20%·60%·100% width 일치, ±2px 허용)".
+
+### 트레이드오프 — 검토 후 수용
+
+- **장점**: 인지 가능, channel 분리, Pillar 1 직접 구현, 색맹 안전, 문서 미학 정합.
+- **단점**: (a) 카드 하단 inner padding 미세 변경 — text vertical center 재조정 필요 (Art Bible §3.1 200×48px 기준 padding 확인 의무). (b) 기존 §8.1.1 modulation 행 + §7.3 knob 명세 cascade 수정 5개 지점.
+- **수용**: 단점 (a)는 art-director가 §8.1.1 revision 시 padding 명시. 단점 (b)는 본 cascade 작업의 일부.
+
+---
+
+## Gate ③ — Signal Topology Contract Lock (구체 emitter는 Workspace Layout ADR 위임)
+
+**BLOCKING 대응**: §3.3 dual emitter 모호 + Browser autoload-or-scene 미명세 + drag-drop API 선택 미결 (godot-specialist B-1) + Rule 7 freeze 동기/비동기 모순 (godot-specialist B-2)
+
+### 결정 — B-1: Signal contract lock + emitter 위임
+
+§3.3에서 시그널의 **계약 (semantics + payload)**만 잠그고, 구체 *emitter (autoload vs scene node)*와 *전달 채널 (signal vs Godot native drag-drop API vs hybrid)*은 Workspace Layout ADR에 위임.
+
+#### Locked contract (구체 emitter 무관)
+
+| 시그널 의미 | 페이로드 | Workspace 측 책임 | 본 GDD 잠금 사항 |
+|---|---|---|---|
+| Drag started | `library_id: String` | DeskPane drop zone hint 활성 (Workspace State == ACTIVE 일 때만) | exactly-once delivery per drag-start; FROZEN/READ_ONLY 상태에서는 hint 비활성 |
+| Drop completed | `library_id: String, viewport_position: Vector2` | hit-test → target node 결정 → Rule 4 정책 적용 | drop은 source가 어디든 Workspace Boundary에서 검증 |
+
+§3.3 시그널 표의 "발신자" 컬럼은 본 GDD에서 **`Library Subsystem (실제 emitter는 Workspace Layout ADR 결정)`** 단일 라벨로 통일. Library §3.2 CitationDrop state는 시그널 발화 *책임*만 정의 — 어느 클래스가 emit 하는지는 ADR 결정.
+
+#### Workspace Layout ADR 결정 사항 (deferred — TODO 명시)
+
+- LibraryService autoload가 emit하는가, LibraryPane scene node가 emit하는가
+- Godot 4.6 native drag-drop API (`_get_drag_data`/`_can_drop_data`/`_drop_data`)를 사용하는가
+- "drag started" 만 signal로, "drop completed"는 native callback으로 분리하는 hybrid 채택 가능성
+
+### 결정 — B-2: Freeze 동기 transition + async evaluation
+
+§3.1 Rule 7 freeze 타이밍을 명시 잠금:
+
+1. **Workspace state transition은 동기 (synchronous)**: Submit 클릭 → Workspace는 *즉시* (단일 frame 내) `ACTIVE → FROZEN` 전환 + chain_data Dictionary 빌드 + PlayerSubmission에 할당.
+2. **`EvaluationService.submit(submission)` 호출은 동기적으로 발생**: chain_data 빌드 직후 동일 frame에서 호출. submit() 내부의 `EvaluationService.current_state` 머신은 비동기 진행 (ADR-0007 §2 5-state machine).
+3. **Workspace는 submit() 반환을 await하지 않는다** — fire-and-forget. UI 차단은 FROZEN 상태가 보장 (입력 무시 + 오버레이 배너).
+4. **상태 복귀는 시그널 콜백 한정**: `submission_rejected` → `FROZEN → ACTIVE`; `evaluation_completed` → `FROZEN → READ_ONLY`. Workspace는 `EvaluationService` 내부 진행을 polling 하지 않는다.
+
+### Rationale
+
+- **B-1 위임의 정당성**: 시그널 발신자/채널은 *UI scene tree topology*에 종속 — DeskPane이 LibraryPane의 sibling인지 child인지에 따라 native API가 자연 fit이거나 autoload signal이 필요. UI Foundation epic + Workspace Layout ADR이 scene tree를 결정하기 전에 잠그면 premature commitment.
+- **B-1 contract lock의 충분성**: 본 GDD의 *행동 명세 (Rule 4 evidence 정책 + Workspace State guard + drop zone hint)*는 emitter-agnostic — 어떤 채널로 들어오든 동일하게 처리. 따라서 GDD 수준에서는 contract만으로 충분.
+- **B-2 동기 transition 명시 필요성**: 현 Rule 7 텍스트가 "submit() 호출 직전 FROZEN 전환"을 명시했으나 *호출 완료* 와 혼동 가능. 동기/비동기 boundary를 명시하면 ADR-0007 §2 EvaluationService 5-state 머신과 자연 정합.
+
+### Cascade impact
+
+- §3.3 시그널 표 "발신자" 컬럼: `LibraryService / LibraryPane` → `Library Subsystem (Workspace Layout ADR)`
+- §3.3 페이로드/Workspace 측 처리는 변경 없음 (이미 emitter-agnostic).
+- §3.1 Rule 7: "Freeze 트리거" 항목 동기 전이 + fire-and-forget 명시.
+- §3.2 State machine 표 ACTIVE row: Submit 클릭 → FROZEN 전이의 동기성 명시.
+- §6.4 Pending 의존성에 "Workspace Layout ADR — signal topology + drag-drop API decision" 추가.
+- 신규 OQ entry: **OQ-W13 — signal topology + drag-drop API choice** (Workspace Layout ADR 위임).
+
+### 위임 검증
+
+Workspace Layout ADR이 본 contract를 위반하지 않으려면 다음 4 invariant를 보장해야 한다 (ADR 작성 시 본 결정 인용 의무):
+
+1. Drag-start notification은 정확히 1회 per drag — 누락 시 drop zone hint 미활성, 중복 시 hint flicker.
+2. Drop-completion notification 페이로드에 `library_id` + `viewport_position` (또는 동등 hit-target reference) 필수.
+3. Workspace State == FROZEN/READ_ONLY 시 native drag-drop API의 `_can_drop_data` callback이 false 반환 의무 (또는 signal 채널의 drop 무시).
+4. Library Subsystem은 Workspace의 hit-test 결과 (drop 수락/거부)를 직접 관찰하지 않음 — Workspace 자기 책임.
+
+---
+
+## Decision summary
+
+| Gate | Decision | BLOCKING 닫힘 |
+|---|---|---|
+| ① | Forest of trees (DAG 라벨 폐기) | game-designer #1, systems-designer #1, EC §5.2 (chain_data 라벨) |
+| ② | Bottom Evidence Rule (border modulation 폐기) | art-director #6, systems-designer #7 |
+| ③ | Signal topology contract lock + Workspace Layout ADR 위임; freeze 동기 transition 명시 | godot-specialist B-1, godot-specialist B-2 |
+
+남은 BLOCKING (§4.3 div-zero, §3.1 Rule 6 schema_version gate, AC-37/47/50 측정 protocol, AC-24 byte-identical, §9.4.1 Ctrl+drag 컨벤션, §3.1 Rule 2 depth ≤ 3 vs 4계층) — Cascade revision (Task #4) + Mechanical revision (Task #5)로 처리.
+
+---
+
+## Pillar 정합 자가검수 (post-decision)
+
+Per `feedback_domain_authenticity` 메모리 — 결정 후 즉시 한국 상고심 도메인 + 5 Pillar 정합 sanity check.
+
+- **Gate ①** Forest 잠금: ✅ 한국 상고심 변호사 사고 모델 — *상고이유 1·2·3 병렬 + 각 이유 아래 쟁점 분기*는 forest 자연 표현. DAG 모델이 요구하는 "한 쟁점이 두 상고이유의 자식"은 한국 법조 문서 관례 외 (공유 쟁점은 별도 메모로 표현; 트리 구조는 분리 유지).
+- **Gate ②** Bottom Evidence Rule: ✅ 한국 법조 문서의 *밑줄 강조 관례* 직접 차용. 인쇄 미학 + Pillar 1 시각화. 위반 안전.
+- **Gate ③** Contract lock + freeze 동기: ✅ 동기 freeze는 "submit 직후 사후 편집 차단"이라는 Pillar 1 가드를 frame-precision 으로 보장. ADR-0007 §3.2 forward-constraint와 1:1 정합.
+
+3 결정 모두 5 pillar + 도메인 진정성 위반 없음.

--- a/design/gdd/reviews/reasoning-workspace-review-log.md
+++ b/design/gdd/reviews/reasoning-workspace-review-log.md
@@ -1,0 +1,334 @@
+# Reasoning Workspace — Review Log
+
+> Tracks all `/design-review` cycles for `design/gdd/reasoning-workspace.md`. Append new entries at the top (most recent first).
+
+---
+
+## Resolution — 2026-05-07 cycle 2 — 22 BLOCKING + ~50 IMPORTANT closure (autonomous mode 응답 사이클)
+
+2026-05-07 2nd `/design-review` cycle (8 specialist + creative-director synthesis: MAJOR REVISION NEEDED, 22 BLOCKING + ~50 IMPORTANT) 응답. 사용자 자율 모드 ("허락맡지말고 쭉 해줘") 하에 best-judgment defaults 적용. 다음 cycle은 *3rd `/design-review` mandatory* (creative-director Decision 2 — cycle 1 cascade가 5 신규 회귀 introduce했으므로 cycle 2의 회귀 부재 검증 의무).
+
+### 결정 산출물
+
+- `design/gdd/reviews/reasoning-workspace-decisions-2026-05-07-cycle2.md` — 5 design decisions (Pillar 2 MVP count-based + v1+ court-grade track / 인장빨강 #10 lockdown / AccessKit role floor lock / KB CitationDrop Space-mark·Space-attach·Esc-cancel / §8.1.1.b inner padding direct lock)
+
+### Cascade revisions 적용 (GDD 직접 수정)
+
+**§3.1 Rule 6 (chain_data export)**:
+- Single source of truth: `src/data/chain_data_schema.gd`의 `SCHEMA_V1_ALLOWED_FIELDS` + `SCHEMA_V1_NODE_FIELDS` const + import 의무 + `chain_data_schema_allow_list_duplication` forbidden_pattern 명시 (godot-specialist Item 7)
+- chain_data 빌드 normative: "fully constructed new Dict, no live references" 명시 (godot-specialist Item 8)
+- nodes[] canonical ordering: BFS from sorted root id (systems-designer F3)
+
+**§4.2 Invariants**:
+- Invariant 5 신규: Evidence move atomicity (systems-designer F8)
+- Invariant 6 신규: Tuning resource validation (systems-designer F7 — `evidence_hit_test_tolerance_px ≥ node_drag_threshold_px` runtime assertion)
+
+**§4.3 chain_coherence**:
+- normalized_breadth_v2 div-zero guard formula row inline 명시 (systems-designer F1)
+- 0·log2(0) convention 명시 (systems-designer F2)
+- 2-root forest semantic 한계 IMPORTANT 명시 (systems-designer F4 carry-over to v1+)
+
+**§4.4 evidence_density**:
+- Discretization step count = `evidence_per_node_cap` 종속 명시 (systems-designer F5)
+- Pillar 2 도메인 한계 명시 — count-based MVP 수용 + v1+ ADR-0007 amendment 트랙 (game-designer Pillar 2 / Decision 1)
+
+**§8.1.1 Node visual states 표**:
+- unselected border `#D9D6CF` → `#8C8C8C` (accessibility #3 — WCAG 1.4.11 1.3:1 → 3.0:1)
+- REJECTED flash 인장빨강 폐기 → 미드그레이 점선 1.5px (art-director B-NEW-1 / Decision 2)
+- "yellow" → "subtle grey tint" 명명 통일 (art-director I-1)
+
+**§8.1.1.b Bottom rule + inner padding**:
+- Inner padding spec direct lock — top 6 / left·right 8 / bottom 4 또는 2 text + 2 rule (art-director B-NEW-5 / Decision 5)
+- AC-37 픽셀 수치 갱신 (40/120/200px → 36.8/110.4/184px ±2px)
+
+**§8.1.2 Tree edges**:
+- 색상 라이트그레이 → 미드그레이 (accessibility #3 정합)
+- L-라우트 0.2초 드로 순차 명시 (art-director N-2)
+
+**§8.1.3 DeskPane**:
+- 드롭존 힌트 점선 색 미드그레이로 통일
+
+**§8.1.4 Freeze overlay**:
+- 60% → 80% opacity (art-director B-NEW-2)
+- 인장 32px 모티프 폐기 — 배너 단독 + `weight-stamp-deep` 오디오 (art-director B-NEW-3 / Decision 2)
+- AC-38 갱신 — 스케일 변화 X, 단순 페이드인
+
+**§8.1.5 READ_ONLY**:
+- modulate 5% → 15% (art-director I-3)
+
+**§8.1.6 Memo panel**:
+- 글자 수 카운터 cap 도달 인장빨강 폐기 → 글꼴 무게 Medium 단독 (art-director B-NEW-4 / Decision 2)
+
+**§8.1.7 Asset Spec triggers**:
+- `vfx_freeze_banner_stamp_01.png` 폐기 (인장 모티프 부재)
+- `tex_paper_aged_01.png` canonical 명 통일 (art-director I-2)
+- 인장빨강 5% 투명 토큰 폐기
+
+**§8.2 Audio**:
+- `weight-stamp` 3 → 5 variants + immediate-repeat avoidance randomizer (audio-director #2)
+- `weight-stamp-deep` Atmosphere bus → UI bus 0 dB (audio-director #4)
+- §8.2.1 weight-stamp/weight-stamp-deep measurable 제약 5건 명시 (audio-director #1)
+- §8.2.3 ambient bed -18 dB 이하·-24 dB 이상 floor 명시 (audio-director #3)
+- §8.2.4 "음악적 처리" → "앰비언트 조작만 허용" 명확화 (audio-director #5)
+- §8.2.4 OQ-W11 trigger criterion 명시 (audio-director #6)
+- §8.2.5 OQ-W12 closed (정책 lock — playtest는 implementation 검증) (audio-director #7)
+- §8.2.5 Dialogue 슬라이더 부재 rationale 명시 (accessibility N-1)
+
+**§9.4.1 Pointer interactions**:
+- Hover drop-shadow 도입 X 명시 — Art Bible §3 + §8.1.1 정합 (game-designer/ux-designer/art-director cross-concurrence BLOCKING)
+- Drag ghost grip dot indicator (좌상단 6×6px 잉크블랙) — node-source vs library-source visual differentiation (ux-designer ghost discrimination)
+- 우클릭 "이동" modal 동작 명시 — crosshair + status bar + Esc dismiss + 무효 target 점선 flash + modal 유지 (ux-designer)
+
+**§9.4.2 Keyboard alternatives**:
+- Ctrl+Arrow Left/Right 형제 reorder 신규 (ux-designer 한국 상고이유 순서)
+- Space-on-LibraryPane / Space-on-Node KB CitationDrop 패턴 lock — AC-45 unblock (ux-designer + accessibility #8 / Decision 4)
+- Esc on pending citation 취소
+- Ctrl+Enter 빈 트리 동작 명시 (ux-designer NICE-TO-HAVE)
+- F2 discoverability — 일회성 status bar toast 명시 (accessibility #2)
+
+**§9.5 Feedback patterns**:
+- "Node hover → 미세 drop-shadow 증가" 행 폐기 → "커서 → grab 변환, 노드 visual 변화 없음" (cross-concurrence BLOCKING)
+- Label / Memo char counter 글꼴 무게 Medium 단독 처리 (art-director B-NEW-4 / Decision 2)
+
+**§9.6 Accessibility floor**:
+- AccessKit role floor 명세 lock — ROLE_TREE / ROLE_TREE_ITEM + accessibility_name + accessibility_description (accessibility #1 / Decision 3)
+- WCAG 1.4.11 non-text contrast 3:1 의무 + 미드그레이 색 통일
+- KB CitationDrop §9.4.2 mirror
+- Focus indicator AC-47 spec lockdown — outer offset 2px 점선 (accessibility I-5)
+- Reduced motion 5 path 모두 적용 (accessibility I-4)
+- F2 discoverability — status bar + AccessKit description + #4 Settings GDD 위임 (accessibility #2)
+- #4 Settings GDD blocking gate 명시 (accessibility I-9)
+- 인장빨강 점선 red flash 행 갱신 (Decision 2 정합)
+
+**§9.8 Open UX Questions**:
+- OQ-W5 fallback trigger threshold 명시 (DeskPane width < 720px 또는 inline panel overlap)
+- OQ-W7 floor locked, verification deferred (Decision 3)
+- OQ-W9 escalation trigger — UI Foundation epic sign-off 시 BLOCKING 자동 전환
+
+**§10 Acceptance Criteria**:
+- AC-13 분리 — Logic AC + AC-13b Integration (qa-lead UI gesture 분리)
+- AC-22b 신규 — INACTIVE submission_rejected temp-storage (qa-lead §5.4)
+- AC-24 4-step verification (Instance distinctness step 추가 — qa-lead)
+- AC-37 픽셀 수치 184 inner width 정정
+- AC-38 인장 모티프 부재 — 단순 페이드인 (Decision 2)
+- AC-39 modulate 5% → 15%
+- AC-40 5 path 명시 (drag-drop / freeze fade / bottom rule tween / tree edge / red flash)
+- AC-44 11 information-bearing cue + AT-mode validation (qa-lead silence row + accessibility I-6)
+- AC-45 KB-only 8-step workflow 명시 (Decision 4)
+- AC-46 escalation trigger 명시 (qa-lead)
+- AC-47 spec lockdown — 권장 → unconditional, outer offset 2px 점선 (qa-lead + accessibility I-5)
+- AC-48 50ms → 16ms + Time.get_ticks_msec (godot-specialist Item 2 + Item 4)
+- AC-49 stub test 의무화
+- AC-50 phantom API 폐기 + InputEvent.time / Time.get_ticks_usec (godot-specialist Item 5)
+- AC-51 stale "border modulation" → "bottom evidence rule" (cross-concurrence BLOCKING)
+- AC-53 urgency cue boundary 명시 (qa-lead)
+- §10.13 신규 — Smoke-Check Baseline (qa-lead)
+
+**§6.4 Dependencies**:
+- #4 Settings & Accessibility GDD hard-gate 명시 (accessibility I-9)
+- Workspace Layout ADR scope 축소 — §8.1.1.b inner padding 위임 폐기 (Decision 5)
+
+**Open Questions**:
+- 12 BLOCKING (cycle 1) Resolved 표 위에 22 BLOCKING (cycle 2) Resolved 표 prepend
+- OQ-W11 audio trigger criterion (audio-director #6)
+- OQ-W12 closed → §8.2.5 absolute rule lock (audio-director #7)
+
+### Cross-document cascades
+
+- `design/gdd/submission-evaluation.md` §3.1.2 — 5번째 검증 step 추가 (chain_data schema validation, single source of truth from `src/data/chain_data_schema.gd`) — Pillar 1 dual-layer guard 실제 instantiation (game-designer B-NEW-2)
+
+### Headers / Status
+
+- 본 GDD 헤더: "Designed — 2nd Cascade Revision Applied (2026-05-07; 22 BLOCKING + 50 IMPORTANT resolved; 3rd review cycle scheduled)"
+- Decision Log cross-ref 추가 — cycle 1 + cycle 2 두 decisions 문서
+
+### 다음 세션 권장
+
+1. **3rd `/design-review` 사이클 mandatory** — cycle 2 cascade 회귀 부재 검증 + 잔여 IMPORTANT 절대 수 감소 측정 (creative-director Decision 2 권고)
+2. **Workspace Layout ADR 작성** — Gate ③ 4 invariant + OQ-W5 fallback ratify + OQ-W9 + OQ-W10 + OQ-W13 + (§8.1.1.b inner padding은 본 GDD에서 closure)
+3. **`/consistency-check`** — bottom evidence rule + 미드그레이 색 통일 + KB CitationDrop pattern + AccessKit floor 다른 GDD 정합
+4. **Pillar 2 v1+ track 사용자 검토** — Decision 1 known limitation 수용 여부 final ratification (현재 best-judgment default 적용 — 사용자 reverse 시 Gate ② revisit + ADR-0007 amendment scope 진입)
+5. **Art Bible amendment 2건** — §3.1 hero shape inner padding 등재 + §3 점선 dropzone 허용 1줄 등재 + §4 인장빨강 #10 lockdown 1줄 등재
+6. **chain_data_schema.gd 신규 파일** — `src/data/chain_data_schema.gd`에 `SCHEMA_V1_ALLOWED_FIELDS` + `SCHEMA_V1_NODE_FIELDS` const 정의 (구현 시점에)
+
+---
+
+## Resolution — 2026-05-07 — 12 BLOCKING closure (응답 사이클)
+
+2026-05-07 review (MAJOR REVISION NEEDED, 11 BLOCKING + 12번째 ux-designer Ctrl+drag = 12 BLOCKING)에 대한 응답 사이클. 다음 세션 `/design-review` 재실행 시 *prior verdict resolved*로 인식 가능.
+
+### 결정 산출물
+- `design/gdd/reviews/reasoning-workspace-decisions-2026-05-07.md` — 3 design gate 결정 (Gate ① Forest 잠금 / Gate ② Bottom Evidence Rule / Gate ③ Signal contract lock + Workspace Layout ADR 위임 + freeze 동기 transition)
+
+### Cascade revisions 적용 (GDD 직접 수정)
+- §3.1 Rule 1: DAG 라벨 폐기 → Forest of trees + Label 표시 정책 ellipsis truncation (200×48px 물리 제약)
+- §3.1 Rule 2: 4계층 추론에서 학설/세부논거는 노드 memo 본문에 포함 (depth ≤ 3 유지)
+- §3.1 Rule 3: Plain drag from node body (Ctrl+drag 폐기) + cursor grab 변환 + 우클릭 메뉴 "이동" 항목
+- §3.1 Rule 6: chain_data dual-layer guard (Builder allow-list + EvaluationService Pre-evaluation Gate)
+- §3.1 Rule 7: Freeze 동기 single-frame transition (a→d atomic) + fire-and-forget submit + async signal callback 복귀
+- §3.2: Submit 전이의 sync/async 명시
+- §3.3: 시그널 발신자 표 → "Library Subsystem (Workspace Layout ADR)" + 위임 검증 invariant 4건 cross-ref
+- §4.3: normalized_breadth_v2 + entropy boundary policy (div-zero short-circuit)
+- §4.4: evidence_density semantics → bottom rule 길이 비율 (border 두께 modulation 폐기)
+- §5.1: chain_coherence boundary cross-ref
+- §5.2: forest 계약 + plain drag 정정
+- §6.2: Workspace Layout ADR scope 확장 (signal topology + 노드 inner padding)
+- §7.2: knob `ctrl_drag_threshold_px` → `node_drag_threshold_px`
+- §7.3: knob `evidence_density_modulation_strength` 폐기 → `evidence_rule_visible` + `evidence_rule_thickness_px`
+- §7.6: 부등식 정합 (`evidence_hit_test_tolerance_px ≥ node_drag_threshold_px`)
+- §8.1.1: 시각 채널 분리 (Channel A selection / Channel B evidence weight) + `evidence_density modulated` row 폐기
+- §8.1.1.b: Bottom evidence rule 신규 subsection (Pillar 1 메인 가시화 채널)
+- §8.2.2: Audio table "Ctrl+drag" → "plain drag"
+- §9.4.1: Pointer interaction table 정정 (cursor grab + drop discrimination by source + 우클릭 "이동")
+- §9.4.2: KB Ctrl+Arrow 명세 정합 (KB-only modifier 한정)
+- AC-13: cycle detection 명세에서 plain drag 명시
+- AC-24: Godot Dictionary deep-equality 3-step verification protocol (JSON.stringify sorted + `==` + mutation block)
+- AC-37: bottom rule pixel-ruler 측정 protocol (40/120/200px ±2px)
+- AC-38: stamp scale 1.15→1.0 → 1.2→1.0 (Art Bible §7 정합)
+- AC-47: focus ring 점선 spec + 색맹 시뮬레이터 검증 protocol
+- AC-50: 240fps 카메라 또는 timestamp 인스트루멘트 측정 protocol + target hardware 명시
+- OQ-W13 신규: signal topology + drag-drop API choice (Workspace Layout ADR 위임)
+- Resolved subsection: 12 BLOCKING resolution table 추가
+- 헤더 Status: "Designed — Revisions Applied (2026-05-07)" + Decision Log cross-ref
+
+### Registry update
+- `design/registry/entities.yaml` `workspace_evidence_per_node_cap` notes 갱신 + revised 2026-05-07 (bottom evidence rule 채널 도입)
+
+### 다음 세션 재검토 권장
+1. **새 세션 `/design-review design/gdd/reasoning-workspace.md`** — prior verdict 본 entry 참조 (12 BLOCKING resolved 추적). 23 IMPORTANT + 9 Nice-to-Have는 본 사이클 미처리 — 재검토 시점에 surface.
+2. **Workspace Layout ADR 작성** — Gate ③ 위임 4 invariant + OQ-W13 (signal topology) + OQ-W5/W9/W10 ratify + 노드 inner padding 명세.
+3. **`/consistency-check`** — bottom evidence rule + new knobs 다른 GDD 정합 검증.
+
+---
+
+## Review — 2026-05-07 cycle 2 — Verdict: MAJOR REVISION NEEDED (재발생)
+
+Scope signal: L
+Specialists: game-designer, systems-designer, qa-lead, ux-designer, art-director, audio-director, godot-specialist, accessibility-specialist, creative-director (synthesis)
+Blocking items: 22 | Recommended: ~50 | Nice-to-Have: ~10
+Prior verdict resolved: 12 BLOCKING (cycle 1) — 본 cycle에서 verification: 12 항목 모두 GDD에서 *텍스트 단위* 적용됐으나 cascade 누락 5건이 BLOCKING으로 재surface (AC-51 border modulation stale / §9.5 hover drop-shadow / 인장빨강 4 use case 누락 / freeze 인장 32px / 인장빨강 메모 카운터). 즉 cycle 1 12 BLOCKING은 *직접* 재발 아님이지만, cycle 1 cascade revision의 *불완전성*이 cycle 2에서 5 신규 BLOCKING 회귀로 표출.
+
+### Summary
+
+Cycle 1 closure 12 BLOCKING은 §3 + §4에 적용됐으나 §8 / §9 / AC tables / submission-evaluation §3.1.2 propagate 누락. 8 specialist (cycle 1의 7 + accessibility-specialist 신규 추가)가 독립적으로 도달한 결함 패턴은 *cascade 규율 실패 + 미처리 carry-over surface*. creative-director synthesis: GDD 핵심 아키텍처는 건전 — 재설계 X, cascade 규율 회복이 본 cycle 우선. 3rd review cycle mandatory.
+
+### Top BLOCKING items (22건)
+
+**Cascade discipline 회귀 (cycle 1 cascade 누락)**:
+1. [game-designer + qa-lead + ux-designer cross-concurrence] AC-51 stale "border modulation" — Channel B(bottom rule) cascade 누락
+2. [game-designer + ux-designer + Art Bible §3 verified] §9.5 hover drop-shadow vs §8.1.1 + Art Bible 모순
+3. [art-director] §8.1.1 REJECTED flash 인장빨강 단독 — Art Bible §4 위반
+4. [art-director] §8.1.6 메모 카운터 인장빨강 cap 알림 — Art Bible §4 시맨틱 희석
+5. [art-director] §8.1.4 인장 32px — Art Bible §3 minimum violation + §1 원칙 4 충돌
+
+**Visual / Audio 신규 모순**:
+6. [art-director] §8.1.4 freeze overlay 60% opacity — "흐릿" 미달
+7. [art-director] §8.1.1.b padding 미완결 (Gate ② tradeoff (a) 미이행)
+8. [audio-director] weight-stamp 3 variants — 65 fires/session에서 fatigue
+9. [audio-director] weight-stamp-deep Atmosphere bus(-18 dB) ↔ "게임 전체에서 이 소리만이 분명" 모순
+
+**Formula / Schema gaps (v1+ time-bomb)**:
+10. [systems-designer] normalized_breadth_v2 div-zero (node_count=0) 가드 formula row 미명시
+11. [systems-designer] 0·log2(0) convention 미명시 (entropy NaN 전파)
+12. [systems-designer] nodes[] array order 미정의 — AC-23/AC-24 byte-identical 위협
+13. [godot-specialist + game-designer cross-concurrence] §3.1 Rule 6 dual-layer guard 단일 source 미명시 + submission-evaluation §3.1.2 미이행
+
+**AC quality / Engine API**:
+14. [godot-specialist] Rule 7 single-frame atomic ↔ AC-48 50ms 모순 (16.6ms vs 50ms)
+15. [qa-lead + godot-specialist cross-concurrence] AC-50 `Input.get_action_press_timestamp()` phantom Godot 4.6 API
+16. [qa-lead] AC-47 focus ring "권장" 언어 — pass/fail 판정 불가
+
+**Accessibility (WCAG ship-blocking)**:
+17. [accessibility] AccessKit role floor 미정의 — 스크린 리더 empty output
+18. [accessibility] F2 list view discoverability 0 — AT 사용자 발견 불가
+19. [accessibility] unselected border `#D9D6CF` on `#F5F2EC` = 1.3:1 — WCAG 1.4.11 fail
+20. [accessibility + ux-designer cross-concurrence] KB CitationDrop 경로 미정의 — AC-45 unpassable
+
+**Performance contract**:
+21. [godot-specialist] AC-48 `OS.get_ticks_msec()` deprecated since Godot 4.0
+22. [godot-specialist] Dictionary immutability after freeze — 명시적 normative 필요
+
+### Cross-specialist agreements (high-confidence — 5 cross-concurrences)
+
+- **AC-51 stale "border modulation"** (game-designer + qa-lead + ux-designer)
+- **§9.5 hover drop-shadow contradiction** (game-designer + ux-designer + Art Bible verified)
+- **KB CitationDrop missing → AC-45 unpassable** (ux-designer + accessibility)
+- **AC-50 phantom API** (qa-lead + godot-specialist verified)
+- **dual-layer guard not implemented downstream** (game-designer + godot-specialist)
+
+### Specialist disagreements
+
+없음. 8 specialist 모두 다른 angle에서 *cascade discipline 실패* + *미처리 carry-over surface*에 수렴.
+
+### Recommended revision order (creative-director Decision priority)
+
+1. **Pillar 2 Bottom Rule 사용자 결정** — count-based MVP vs court-grade upgrade (Decision 1)
+2. **인장빨강 #10 lockdown** — 4 use case 폐기 (Decision 2 / cascade discipline)
+3. **AccessKit floor lock + F2 discoverability** — accessibility BLOCKING #1·#2 (Decision 3)
+4. **AC quality sweep** — godot-specialist 3 BLOCKING (Item 2·5·7) + qa-lead AC-47/51 (Decision 4)
+5. **Cascade discipline checklist 강화** — grep token mapping + section coverage matrix (Decision 5 / 회귀 방지)
+
+### Out-of-scope (deferred via §9 PROVISIONAL marker / OQ-W7 verification reframe)
+
+- OQ-W9 (gamepad CitationDrop), OQ-W10 (panning), §9.7 floor-resolution은 Workspace Layout ADR 위임 — 본 verdict의 sub-blocker 카운트 X
+- OQ-W7 verification은 floor lock 후 재정의 — UI Foundation epic prototype 측정으로 reframe
+
+### Carry-over for next review (3rd cycle)
+
+다음 /design-review 세션은 *3rd cycle*로서 본 entry를 prior verdict로 인식하고 22 BLOCKING resolved/deferred/explicitly-rejected 상태 + 50 IMPORTANT 잔류 절대 수 감소 측정 의무. 5 cross-concurrence 회귀 부재 우선 검증.
+
+---
+
+## Review — 2026-05-07 cycle 1 — Verdict: MAJOR REVISION NEEDED
+
+Scope signal: L
+Specialists: game-designer, systems-designer, qa-lead, ux-designer, art-director, godot-specialist, creative-director (synthesis)
+Blocking items: 11 | Recommended: 23 | Nice-to-Have: 9
+Prior verdict resolved: First review — no carry-over
+
+### Summary
+
+작성된 GDD가 빌드되면 Pillar 1("진실은 가중치다") + Pillar 4("끝나도 따라온다") 약속을 지킬 수 없다. 6 specialist가 독립적으로 도달한 결함 패턴은 명세-Pillar 정렬 부재 — polish 이슈가 아닌 정체성 이슈. 핵심 불일치 3건이 cascade 재작성을 강제한다: ① §3.1 Rule 1의 "DAG" 라벨 vs `parent_id: String` 단일 부모 스키마(Pillar 4 영속성 약속 침식), ② §4.3 v1+ chain_coherence 수식의 single-root/single-node div-zero + linear-vs-star 구별 실패, ③ §8.1.1 evidence_density 변조의 0.125px subpixel 단계가 1920×1080 인지 임계 미달(Pillar 1 시각 신호가 mid-range에서 작동 안 함). §9 PROVISIONAL marker는 적절(Workspace Layout ADR 위임 정합)하나, §9.4.1 Ctrl+drag 플랫폼 컨벤션 위반은 layout과 무관한 interaction model 결함이므로 revision 범위 포함.
+
+### Top BLOCKING items
+
+1. [game-designer + systems-designer] §3.1 Rule 1 "DAG" vs single `parent_id` schema — 데이터 모델 자체가 Player Fantasy "같은 판시 단락을 다른 가지에 옮겨붙이면" 약속과 불일치
+2. [game-designer] §3.1 Rule 2 depth ≤ 3이 한국 상고심 4계층 추론(상고이유→쟁점→판례→학설/세부논거)을 절단 — Pillar 2/4 진정성
+3. [systems-designer] §4.3 normalized_breadth div-zero (node_count=1) + linear chain ≡ star tree 차별화 실패
+4. [systems-designer] §4.3 evidence_distribution_entropy 두 div-zero 경로 (total_evidence_count=0; log2(node_count=1)=0)
+5. [systems-designer + qa-lead] §3.1 Rule 6 schema_version 단일 레이어 가드 hole (submission-evaluation §3.1.2 Pre-evaluation Gate 미커버)
+6. [art-director] §3.1 Rule 1 + §7.1: 200×48px 카드 vs 60자 라벨 물리적 불가능
+7. [art-director + systems-designer] §8.1.1 evidence_density modulation subpixel 인지 한계 + selection state가 weight signal 압도
+8. [godot-specialist] §3.3 시그널 dual emitter "LibraryService / LibraryPane" + Browser autoload-or-scene 미명세 + drag-drop API 선택 미결
+9. [godot-specialist] §3.1 Rule 7 freeze 타이밍 vs ADR-0007 submit() 동기/비동기 모순
+10. [qa-lead] AC-37 / AC-47 / AC-50 측정 불가 (픽셀 임계값 / design TBD / measurement protocol 부재)
+11. [godot-specialist + qa-lead] AC-24 byte-identical 검증 방법 미정의 (Godot Dictionary reference type)
+12. [ux-designer] §9.4.1 + §3.1 Rule 3 Ctrl+drag 플랫폼 컨벤션 위반 + 이동 액션 discoverable surface 0
+
+### Cross-specialist agreements (high-confidence)
+
+- **DAG-vs-tree mismatch** raised by game-designer + systems-designer
+- **Subpixel rendering perception failure** raised by art-director + systems-designer
+- **Div-zero in v1+ formulas** raised by systems-designer + godot-specialist
+- **Pillar 1 weight signal degradation** observed by art-director + game-designer
+- **Pillar 4 replay discontinuity** raised by game-designer (Resolved 재플레이 트리 초기화 + #14 Alpha tier MVP-out)
+
+### Specialist disagreements
+
+없음. 6 specialist 모두 다른 angle에서 동일한 결함 패턴(명세-구현 정렬 부재 / 경계 case 미정의 / Pillar signal 약화)에 도달.
+
+### Recommended revision order (dependency-based)
+
+1. **Decision gate**: DAG vs Tree (C-1) — Pillar 4 명세가 따라옴
+2. **Decision gate**: evidence_density 메커니즘 (C-3) — Pillar 1 명세가 따라옴
+3. **Decision gate**: §3.3 시그널 토폴로지 (godot B-1/B-2) — §3.3 + §9.4.1 명세가 따라옴
+4. 위 3개 결정 후 §4.3 경계 케이스, AC 측정 protocol, Art Bible 정합 수정은 mechanical revision
+5. Workspace Layout ADR은 §9 PROVISIONAL 정리와 함께 별도 트랙으로 진행
+
+### Out-of-scope (deferred via §9 PROVISIONAL marker)
+
+- §9.4.3 OQ-W9 (gamepad CitationDrop), OQ-W10 (panning), §9.7 floor-resolution, §9.6 list view interaction model — Workspace Layout ADR 위임. 본 verdict의 sub-blocker로는 카운트되지 않음.
+
+### Carry-over for next review
+
+다음 /design-review 세션은 본 review log entry를 *prior verdict*로 인식하고 11 BLOCKING + 23 IMPORTANT 각각이 resolved/deferred/explicitly-rejected 어느 상태인지 항목별 추적 의무.

--- a/design/gdd/reviews/submission-evaluation-review-log.md
+++ b/design/gdd/reviews/submission-evaluation-review-log.md
@@ -1,0 +1,34 @@
+# Submission & Evaluation — Design Review Log
+
+> 본 파일은 `design/gdd/submission-evaluation.md`의 design review 이력을 추적합니다.
+> 각 항목은 `/design-review` 실행 시 자동 추가됩니다.
+
+---
+
+## Review — 2026-05-06 — Verdict: NEEDS REVISION → Approved (revisions applied in-session)
+Scope signal: L
+Specialists: none (lean mode — single-session analysis)
+Blocking items: 3 | Recommended: 5 | Nice-to-have: 4
+
+### Summary
+1차 lean review에서 BLOCKING 3건 식별 — (1) §3.1.4·§4.7·EC-5·AC-19 4지점 verdict 매핑 모순 (player_disp == correct_disp + 0.3 ≤ score < 0.5 영역 미정의 + EC-5 verdict 클레임이 함수와 불일치), (2) §4.2 core_citation_coverage 수식이 출력 범위 [0,1] 위반 가능 (player 측 순회로 holding 다중 인용 시 1.5까지 확장), (3) AC-19 verdict 집합이 §4.7 함수로 도달 불가능. 사용자 결정 후 in-session 수정으로 12 항목(BLOCKING 3 + Recommended 5 + Nice-to-have 4) 전수 적용. 핵심 결정: (a) 파기환송 임계값 0.5 → 0.3 (disp_match 시) — 처분 일치 신호 보존 + 학습 곡선 유지 우대, (b) coverage 수식을 정답 인용(c) 측 순회로 재구조화 — 자연 cap [0,1] + 표준 recall 의미론, (c) AC-19를 결정적 단언(final_score==0.37 + verdict=="파기환송")으로 재서술. 부수 정정: §7.1 임계값 표 3행→2행 통합(verdict_threshold_low 공유), AC-7/12/14 갱신, §6 #6 row에 freeze 계약 forward-constraint 명시, AC-22 측정 방법론(`Performance.get_monitor(MEMORY_STATIC)` delta) 명시, OQ-2 ADR 사전 스코프 4건 명시.
+
+### Key Decisions
+- **Verdict policy**: disp_match + 0.3 ≤ score < 0.7 → 파기환송 (관대 정책 채택). disp_match + score < 0.3 → 각하 (한국 법조계 용례와 다른 게임 의미론을 §3.1.4에 합리화 + OQ-7 변호사 자문 위임).
+- **Coverage 수식 방향**: 정답 인용 c 측 순회 — `(Σ_c max(σ(p,c) for p in P)) / |C|`. 자연 cap [0,1] + 같은 case 다중 holding 인용으로 인한 외관적 과장 회피.
+- **재평가 정책**: EC-8 캐시 X, 항상 재계산 — AC-23 byte-identical 보장이 캐시 불필요 + 가중치 변경 자동 반영.
+
+### Forward Constraints Surfaced
+- **#6 Reasoning Workspace** v1+ 디자인 시 §3.2 freeze 계약(submit() 시점에 workspace memo 불가변 스냅샷) 통합 의무. §6 Dependencies 표에 명시.
+
+### ADR-XXXX (Submission Evaluation Algorithm) — 사전 스코프 (OQ-2)
+1. PlayerSubmission/EvaluationResult Resource 정적 타입 트리 + 경로
+2. EvaluationService autoload 등록 순서 (LibraryService → CaseService → EvaluationService 권장)
+3. verdict 임계값 외부화 위치 (entities.yaml constant + per-case override 금지 룰)
+4. comment_templates.tres 위치 + 형식 (단순 Dictionary vs i18n 트리, OQ-8과 연동)
+
+Prior verdict resolved: First review (no prior).
+
+### Re-review 권장 시점
+- **Full mode**: ADR-XXXX Accepted 직후 — game-designer (Pillar 1 정합), systems-designer (수식 boundary), qa-lead (AC 테스트성), creative-director (verdict 의미론 lawyer-pre-consult) 4 specialist 적대적 검토.
+- **Lawyer consult 후**: OQ-7·OQ-9 자문가 피드백 반영 시 verdict label·holding 부분 매칭 0.5 변별력 재검증.

--- a/design/gdd/submission-evaluation.md
+++ b/design/gdd/submission-evaluation.md
@@ -1,0 +1,490 @@
+# Submission & Evaluation
+
+> **Status**: Designed (skeleton 2026-05-05; lean review revisions applied 2026-05-06)
+> **Author**: kjuioqq8@gmail.com + game-designer + systems-designer
+> **Last Updated**: 2026-05-06
+> **Layer**: Feature
+> **Priority**: MVP
+> **Implements Pillar**: 1 (Truth Is Weighted) + Anti-Pillar 가드 (정답/오답 이분 평가 거부)
+> **Source Concept**: design/gdd/game-concept.md
+> **Position in Index**: #9 in design order
+> **Architectural Backing**: ADR-0007 (Submission Evaluation Algorithm) — Proposed 2026-05-06 — closes OQ-2 4건; ADR-XXXX (v1+ Chain Coherence Algorithm) deferred
+
+---
+
+## 1. Overview
+
+*Submission & Evaluation*은 플레이어가 #7 Brief Editor에서 작성한 상고이유서(채택한 처분 + 인용한 Library ID 목록 + (v1+) 추론 체인 데이터)를 입력받아 *가중 평가*를 수행하는 코어 평가 시스템이다. case-data-schema가 케이스마다 보유하는 `scoring_weights` Dictionary와 `correct_disposition` / `correct_citations`를 기준 데이터로, 플레이어 제출물에 대해 5개 subscore(MVP 활성: `disposition_match` + `core_citation_coverage` + `redundant_citation_penalty` / v1+ 활성: `chain_coherence` + `precedent_seniority_bonus`)를 계산하고 `case.scoring_weights[k] × subscores[k]`로 가중 합산한 단일 점수와 함께 *결정문 결과*(파기/기각/각하/파기환송)·*subscore 항목별 한 줄 코멘트*를 산출한다. 핵심 설계 원칙은 ADR-0003에서 케이스 측이 결정한 *알고리즘은 코드, 가중치는 데이터* — 본 GDD는 알고리즘 명세를 정의하고 가중치는 case .tres에 외부화된다. Pillar 1(*진실은 가중치다*)의 직접 구현체이며, Anti-Pillar 가드로 `case_disposition_match_minimum_weight = 0.4` 잠금에 의해 *처분만으로 결판이 나지 않도록*(최소 60%는 인용 + 추론 측에서 결정) 강제한다. MVP는 단순 정답 비교(처분 일치 + 인용 매칭률 + 무관 인용 페널티)로 가설 검증에 집중하고, "추론 체인의 질" 측 평가(`chain_coherence`)는 v1+로 분리되어 자문가 검수 후 본격 도입한다 — 이 *MVP/v1+ 분리선*이 본 GDD의 핵심 디자인 결정이다. 책임 경계: 본 GDD는 *평가 알고리즘*만 정의하며, 결정문 *연출*은 #10 Verdict Reveal Sequence, 결과 *보존·재플레이*는 #11 Career Progression의 책임이다.
+
+---
+
+## 2. Player Fantasy
+
+상고이유서 봉투를 닫고 *제출* 버튼을 누른 직후의 정적 — 이 게임에서 가장 짧고 가장 무거운 순간이다. 더는 추가 자료를 찾을 수도, 가설 트리를 다듬을 수도, 인용을 빼고 더할 수도 없다. 결정은 떠났고 며칠이 흐른다. 결정문 봉투가 책상에 도착하고(그 *연출*은 #10 책임), 봉투가 열리는 순간 플레이어가 보는 것은 처분 한 줄(*파기·기각·각하·파기환송*)과 — 그 *직후* 이 시스템이 산출하는 *subscore breakdown*이다. 처분 일치 여부, 인용한 법령·판례 중 어느 것이 핵심이었고 어느 것이 무관했는지, 어떤 인용을 누락했는지가 가중치별 막대로 펼쳐지고 *한 줄 코멘트*가 따라온다 — *이 인용은 핵심이었다 / 이 인용은 본 사건과 거리가 있다 / 핵심 판시 1건을 누락했다*. 플레이어가 받는 감각은 "정답을 맞췄다/틀렸다"가 아니라 *내 추론 체인의 무게가 어떻게 분포되었는가*다. 단일 정답을 채점받는 학원형 평가가 아닌, *법조계가 변호사를 평가하는 방식*에 가까운 구조 — 결론보다 그 결론에 도달한 가중 정당화가 채점된다. 이 감각이 Pillar 1(*진실은 가중치다*)을 player-facing으로 직접 구현하며, Anti-Pillar 가드("정답/오답 이분 평가 거부")의 가시화 지점이다. *케이스가 끝나도 따라온다*(Pillar 4)는 잔향은 결정문 처분만이 아니라 *어느 인용이 자기 추론에 깊이 박혔는가*에서 온다 — 다음 케이스에서 같은 판례를 만났을 때 플레이어는 *그때 그 판례*라는 잔향을 느낀다.
+
+---
+
+## 3. Detailed Rules
+
+### 3.1 Core Rules
+
+#### 3.1.1 Submission 입력 데이터 셋 (PlayerSubmission 클래스)
+
+#7 Brief Editor가 *Submit* 트리거를 누른 시점에 본 시스템에 전달되는 입력 Resource:
+
+| 필드 | 타입 | 의미 |
+|------|------|------|
+| `case_id` | String | 평가 대상 케이스의 ID (`case_data:[year]-[seq]`) |
+| `player_disposition` | String | 플레이어가 채택한 처분 — `library_dispositions_court` enum 멤버 |
+| `player_citations` | Array[String] | 플레이어가 인용한 Library ID 목록 (인용 순서 보존) |
+| `chain_data` | Dictionary (v1+) | 추론 체인 노드·엣지·근거 인용 매핑 (#6 Workspace export) — MVP는 비어있음 |
+| `submission_time_ms` | int | 작성 소요 시간 (텔레메트리용, 평가에는 미반영) |
+
+PlayerSubmission도 mirror principle 적용 — 정적 타입 GDScript Resource 클래스 (ADR-0001/0003 패턴 mirror). 인용 순서는 보존되지만 평가 함수는 *순서 무관* (Set 비교 + 가중 매칭) — 순서는 #14 Retrospective Replay 표시용.
+
+#### 3.1.2 Submission 검증 (Pre-evaluation Gate)
+
+평가 시작 전 다음 검사 수행 — 미통과 시 *비활성화* 결과 반환 (계산 X, 콘솔 push_error):
+
+1. `case_id`로 `CaseService`에서 활성 케이스 1건 조회 가능
+2. `player_disposition`이 `library_dispositions_court` enum 멤버
+3. `player_citations.size() >= 1` (빈 인용 거부 — EC-1)
+4. `player_citations[*]`가 모두 `LibraryService.validate_citations()` 통과 (미존재 ID 거부 — EC-2)
+5. **`chain_data` schema validation (reasoning-workspace 2026-05-07 cycle 2 BLOCKING closure — Pillar 1 silent regression dual-layer guard)** — `chain_data == {}` 또는 `chain_data["schema_version"] == 1`이면서 다음 allow-list 정합:
+   - Top-level keys: `src/data/chain_data_schema.gd`의 `SCHEMA_V1_ALLOWED_FIELDS = ["schema_version", "nodes", "edge_count", "max_depth_reached", "total_evidence_count"]` 외 키 부재
+   - 각 `nodes[i]` keys: `SCHEMA_V1_NODE_FIELDS = ["node_id", "label", "depth", "parent_id", "evidence", "memo_length", "child_count"]` 외 키 부재
+   - 비허용 필드 검출 시 `submission_rejected("schema_violation:[field_name]")` emit + `push_error("chain_data schema_version=1 violation: forbidden field %s")`. 본 검증은 `src/data/chain_data_schema.gd`의 동일 const를 import하여 reasoning-workspace 빌더의 allow-list와 *single source of truth* 공유 — 양쪽 inline 정의는 forbidden_pattern `chain_data_schema_allow_list_duplication` (architecture.yaml registry 등록 의무).
+
+검증 통과 시 §3.1.3로 진행, 실패 시 평가 중단 + UI에 *제출 거부* 메시지 (단순 정답 비교 의미가 사라지므로 평가 자체 X).
+
+#### 3.1.3 5 Subscore 정의
+
+각 subscore는 [0.0, 1.0] 범위 (penalty는 [-0.3, 0.0]). MVP/v1+ 활성 분리:
+
+| Subscore | MVP/v1+ | 측정 대상 | 의미 |
+|----------|---------|-----------|------|
+| `disposition_match` | **MVP** | `player_disposition == case.correct_disposition` | 처분 일치 — 1.0 또는 0.0 (이산) |
+| `core_citation_coverage` | **MVP** | player_citations ∩ correct_citations | 정답 인용 매칭률 (Set 기반 Jaccard 변형) |
+| `redundant_citation_penalty` | **MVP** | player_citations \ correct_citations | 무관 인용 페널티 (음수 — Anti-Pillar 가드) |
+| `chain_coherence` | **v1+** | chain_data 노드의 인용 근거 적합도 | 추론 체인 자체의 일관성 — 본 GDD MVP scope 외 (§OQ-1) |
+| `precedent_seniority_bonus` | **v1+** | 인용한 판례의 court_grade 분포 | 전합 인용 보너스 — `case.scoring_weights[..].seniority_bonus = 0` 잠금 (Anti-Pillar 가드, case-data-schema AC-10 mirror) |
+
+**MVP 동작 잠금**: MVP 모든 케이스의 `scoring_weights.chain_coherence = 0` + `scoring_weights.precedent_seniority_bonus = 0`. 가중치 0이므로 이 두 subscore는 평가 결과에 영향이 없음 — *알고리즘은 v1+에 대비해 5 키 모두 구현*하되 *데이터 가중치만 0*으로 잠금. 이 분리가 v1+ 활성 시 코드 변경 없이 데이터 변경만으로 이행 가능하게 만든다.
+
+#### 3.1.4 Final Score 합산 + Verdict 결정
+
+```
+final_score = (disposition_match × W_disp)
+            + (core_citation_coverage × W_core)
+            + (redundant_citation_penalty × W_redund)   # 음수
+            + (chain_coherence × W_chain)               # MVP=0
+            + (precedent_seniority_bonus × W_senior)    # MVP=0
+```
+
+여기서 `W_*`는 `case.scoring_weights[k]`로부터 직접 읽음. final_score는 [0.0, 1.0] 범위로 정규화 (clamp).
+
+**Verdict 결정** (game-concept 5 Pillar + case-data-schema `library_dispositions_court` 4 enum 멤버를 *플레이어 결과*에 매핑):
+
+```
+verdict = (
+    "파기"      if (player_disposition == correct_disposition AND final_score >= 0.7)
+    else "파기환송" if (player_disposition == correct_disposition AND final_score >= 0.3)
+    else "기각"   if (player_disposition != correct_disposition AND final_score >= 0.3)
+    else "각하"
+)
+```
+
+이 매핑은 *Pillar 1 가시화* — 처분 일치만으로 "파기"가 보장되지 않는다. 인용·추론 측 가중 점수가 0.7 이상이어야 *파기* 카타르시스. 0.3-0.7 구간 처분 일치는 *파기환송* (방향은 맞았지만 근거가 부족 — disp 일치 신호는 보존되어 "다시 시도 가능" 학습 곡선 유지). 처분 불일치라도 0.3 이상은 *기각* (논거는 있었으나 결론이 빗나감). 0.3 미만은 *각하* (처분 일치 여부 무관 — 분석 자체가 성립 X).
+
+한국 법조계 실무에서 *각하*는 절차적 부적법(관할권·당사자적격 결여) 전용이고 본안 부실은 *기각*이지만, 본 게임의 verdict label은 *플레이어 추론의 무게* 측면에서 재의미화된다 — final_score < 0.3은 *논거의 무게가 측정 가능한 임계 미달* 상태이므로 *각하*. 이 라벨 의미론은 OQ-7 변호사 자문 시 재검토.
+
+#### 3.1.5 Comment Generation (한 줄 코멘트)
+
+각 subscore에 대해 결정 트리로 단일 코멘트 1건 생성. *코멘트 내용은 외부 데이터*(MVP는 entities.yaml 또는 별도 .tres comment_templates) — 알고리즘은 *어느 코멘트를 보일지*만 결정. 본 GDD는 코멘트 *템플릿 키 목록*만 정의하고 한국어 본문은 콘텐츠 작성 시점에 작성:
+
+| Subscore | 조건 | 템플릿 키 |
+|----------|------|-----------|
+| `disposition_match` | 1.0 | `comment.disp.match` |
+| `disposition_match` | 0.0 | `comment.disp.miss` |
+| `core_citation_coverage` | ≥ 0.8 | `comment.core.high` |
+| `core_citation_coverage` | 0.4-0.8 | `comment.core.mid` |
+| `core_citation_coverage` | < 0.4 | `comment.core.low` |
+| `redundant_citation_penalty` | ≥ -0.05 | `comment.redund.clean` (penalty 거의 없음) |
+| `redundant_citation_penalty` | < -0.05 | `comment.redund.bloat` (무관 인용 다수) |
+
+총 코멘트 템플릿 7건 (disp: 2 + core: 3 + redund: 2). v1+ chain 코멘트는 별도. 코멘트 본문 톤은 #13 Persona System(멘토)이 작성 시 절제된 코멘트 — 본 GDD는 *문법 슬롯*만 정의.
+
+#### 3.1.6 EvaluationResult (출력 데이터 셋)
+
+평가 완료 시 본 시스템이 산출하는 출력 Resource:
+
+| 필드 | 타입 | 의미 |
+|------|------|------|
+| `case_id` | String | 평가 대상 케이스 ID |
+| `final_score` | float | [0.0, 1.0] 정규화 |
+| `verdict` | String | 결정문 처분 — `library_dispositions_court` 4 enum 멤버 |
+| `subscores` | Dictionary | 5 키 → float (penalty 음수 허용) |
+| `weighted_contributions` | Dictionary | 5 키 → float (각 subscore × weight, 합 = final_score) |
+| `comments` | Array[String] | 활성 템플릿 키 → 본문 치환된 코멘트 목록 |
+| `correct_set` | Array[String] | player가 매칭한 correct_citations (UI 표시용) |
+| `missed_set` | Array[String] | player가 누락한 correct_citations |
+| `redundant_set` | Array[String] | player가 인용했지만 무관한 citations |
+| `evaluated_at` | int | Unix timestamp ms |
+
+EvaluationResult는 #10 Verdict Reveal Sequence가 봉투 연출 입력으로 사용하고, #11 Career Progression이 케이스북에 보존하며, #14 Retrospective Replay가 subscore breakdown 표시에 사용한다. 또한 mirror principle 적용 (정적 타입 Resource — ADR-0001/0003 패턴).
+
+### 3.2 States and Transitions
+
+본 시스템은 *호출형 평가 함수*가 아니라 *상태를 가진 서비스*다 (`EvaluationService` autoload). case lifecycle (`Submitted` → `Resolved`)와 별도의 평가 *진행* 상태:
+
+| State | 설명 | 트리거 |
+|-------|------|--------|
+| `Idle` | 평가 대기 — Submission 미수신 | 초기 상태, Reporting 후 복귀 |
+| `Validating` | §3.1.2 검증 수행 | `submit(submission)` 호출 |
+| `Computing` | §3.1.3 + §3.1.4 평가 계산 | Validating 통과 |
+| `Reporting` | §3.1.5 + §3.1.6 결과 산출 + 시그널 emission | Computing 완료 |
+| `Done` | EvaluationResult 시그널 송출, Idle 복귀 대기 | Reporting 완료 |
+
+검증 실패 시 Validating → `Idle` 복귀 + `submission_rejected(reason)` 시그널. 정상 흐름은 Idle → Validating → Computing → Reporting → Done → Idle.
+
+이 상태 머신은 case-file-browser §AC-20 메모 휘발 정책의 *Workspace 측 동치 정책*에 영향: 본 시스템 진입(=`submit()` 호출) 시점에 #6 Workspace의 메모 영역은 *불가변 스냅샷*으로 freeze된다 (재제출 차단 — case lifecycle `Submitted` 상태 잠금과 mirror). 즉 *제출 후에는 추론 트리 수정 X* — Pillar 1 가드 (제출 후 후속 수정으로 사후 정당화 방지). **[#6 forward-constraint]**: #6 Reasoning Workspace 디자인 시 본 freeze 계약(submit() 시점에 workspace memo 불가변)을 #6 측 행동 계약에 통합 필수 — 본 GDD가 #6 v1+ 디자인의 *행동 계약 일부*를 사전 잠금.
+
+### 3.3 Interactions with Other Systems
+
+- **#1 Case Data Schema**: `CaseService.get_case(case_id)` → `correct_disposition` + `correct_citations` + `scoring_weights` 입력. 본 시스템은 케이스 데이터를 *읽기 전용*으로만 접근.
+- **#5 Case File Browser**: Browser 상태 `SubmissionPending` ↔ 본 시스템 `Validating`/`Computing`/`Reporting`. EvaluationResult 산출 후 `evaluation_completed(result)` 시그널 → Browser가 `VerdictArrived`로 전이. (case-file-browser entities.yaml `case_browser_states` 정합)
+- **#6 Reasoning Workspace** (v1+): `chain_data` Dictionary 입력. MVP는 빈 Dict 허용. v1+ chain_coherence 활성 시 인터페이스 본격 사용.
+- **#7 Brief Editor**: PlayerSubmission 구성·전달. Editor가 *Submit* 버튼을 누르면 `EvaluationService.submit(submission)` 호출. Editor는 본 시스템에서 결과를 받지 않음 (Editor의 책임 종결).
+- **#10 Verdict Reveal Sequence**: `evaluation_completed(result)` 시그널 → #10이 봉투 도착·페이드인·인장·*파기/기각* 큰 글자 연출 시퀀스 트리거. 본 시스템은 *결과 데이터*만 제공, 연출 X.
+- **#11 Career Progression**: EvaluationResult를 케이스북(player career data)에 보존. final_score가 평판(#12) 입력. 재플레이 시 보존 정책은 #11 OQ (case-data-schema OQ-6 mirror).
+- **#12 Reputation System** (VS): final_score → 평판 변화량 매핑. 본 GDD scope 외, #12에서 결정.
+- **#14 Retrospective Replay** (Alpha): EvaluationResult.subscores + correct_set/missed_set/redundant_set을 보존. 결정문 도착 시점의 *플레이어 추론 vs 정답*을 시각화 (Disco Elysium 풍 가중 분기 표시).
+
+---
+
+## 4. Formulas
+
+### 4.1 disposition_match
+
+처분 일치 — 단순 이산 비교.
+
+`disposition_match = 1.0 if (player_disposition == case.correct_disposition) else 0.0`
+
+**Variables:**
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `player_disposition` | p_d | String | enum | 플레이어 채택 처분 (`library_dispositions_court`) |
+| `correct_disposition` | c_d | String | enum | 케이스 정답 처분 |
+
+**Output Range:** {0.0, 1.0} (이산). 빈 처분은 §3.1.2 Pre-evaluation Gate에서 거부됨.
+
+**Example:** player_disposition="파기", correct_disposition="파기" → 1.0. player_disposition="기각", correct_disposition="파기" → 0.0.
+
+### 4.2 core_citation_coverage
+
+정답 인용 매칭률. *holding-N 부분 매칭* 정책 적용 — 플레이어가 `case:.../holding-1`을 인용하고 정답이 `case:.../holding-1`이면 정확 매칭, 플레이어가 `case:...` 전체 인용하고 정답이 `case:.../holding-N`이면 *부분 매칭 0.5*.
+
+```
+core_citation_coverage = (Σ_c match_score(c, player_citations)) / |correct_citations|
+where match_score(c, P) = max(citation_similarity(p, c) for p in P)
+      citation_similarity(p, c):
+          1.0 if p == c
+          0.5 if same_case_id(p, c) AND (p_or_c is whole_case AND other is holding)
+          0.0 otherwise
+```
+
+**수식 방향**: 정답 인용(c) 측을 순회 — 자연 cap [0,1] (각 c는 최대 1.0 기여 + 분모 |C|로 정규화) + 표준 recall 의미론 (정답 covering 측 평가). 반대 방향(player 측 순회)은 |P| > |C| 시 1.0 초과 위험 + 같은 case의 다중 holding 인용으로 외관적 과장 가능 — 의도적으로 회피.
+
+**Variables:**
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `player_citations` | P | Array[String] | size 1-15 | 플레이어 인용 목록 |
+| `correct_citations` | C | Array[String] | size 3-15 | 케이스 정답 인용 목록 |
+| `match_score(c, P)` | μ | float | 0.0–1.0 | c가 P 어느 항목과 가장 잘 매칭되는 점수 |
+| `citation_similarity(p, c)` | σ | float | {0.0, 0.5, 1.0} | 두 인용 ID의 형태별 일치도 |
+
+**Output Range:** [0.0, 1.0] (자연 cap — clamp 불필요). 0.0 = 정답 인용 1건도 매칭 안 됨, 1.0 = 모든 정답 인용을 정확히 인용.
+
+**Example (MVP 잠금)**: 정답 `[law:civil-act-art-100, case:2024da12345/holding-1, case:2024do6789]`. 플레이어 `[law:civil-act-art-100, case:2024da12345, case:2024da99999]` → match_scores per c: [1.0 (law 정확), 0.5 (whole vs holding-1 부분), 0.0 (미인용)] → coverage = 1.5/3 = 0.5.
+
+**Note**: holding-N의 holding-N+1 부분 매칭은 0.0 (다른 holding은 다른 판시) — 같은 case 내 모든 holding을 매칭으로 보면 인용의 변별력 사라짐.
+
+### 4.3 redundant_citation_penalty
+
+무관 인용 페널티. *플레이어가 인용했지만 정답에 없는* 인용에 비례한 음수 점수. Anti-Pillar 가드 — 인지 과부하 방지 + Pillar 3 (사고 만이 압박이다) 가드 (스팸 인용 = 무차별 시도 회피).
+
+```
+redundant_count = |player_citations \ matched_set|
+where matched_set = {p in P | max(citation_similarity(p, c) for c in C) > 0}
+redundant_ratio = redundant_count / |player_citations|
+redundant_citation_penalty = -min(0.3, redundant_ratio × 0.5)
+```
+
+**Variables:**
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `redundant_count` | r | int | 0-15 | 매칭 실패한 인용 수 |
+| `redundant_ratio` | ρ | float | 0.0–1.0 | 무관 인용 비율 |
+| `redundant_citation_penalty` | π | float | -0.3–0.0 | 페널티 (clamp at -0.3) |
+
+**Output Range:** [-0.3, 0.0]. cap=-0.3 — 무관 인용 다수여도 평가 자체가 무력화되지 않도록 (50% 무관 = -0.25 페널티).
+
+**Example 1** (50% 무관): 플레이어 6 인용 중 정답 매칭 3건 + 무관 3건 → ρ = 0.5, π = -min(0.3, 0.5×0.5) = -min(0.3, 0.25) = **-0.25**.
+
+**Example 2** (100% 무관 — cap 작동): 플레이어 5 인용 모두 무관 → ρ = 1.0, π = -min(0.3, 1.0×0.5) = -min(0.3, 0.5) = **-0.3** (cap 도달).
+
+### 4.4 chain_coherence (v1+)
+
+*MVP scope 외* — `case.scoring_weights.chain_coherence = 0` 잠금이므로 final_score 영향 0. 알고리즘은 v1+ 자문 검수 후 본격 정의 (§OQ-1). 임시 스텁:
+
+```
+chain_coherence_v1plus = TBD  # OQ-1 — chain node 인용 적합도 + 전이 일관성 평가
+chain_coherence_mvp = 0.0     # 모든 MVP 케이스에서 가중치 0이므로 사실상 미사용
+```
+
+**Output Range (MVP)**: 0.0 (잠금). v1+ 활성화 트리거는 자문가 검수 + chain 평가 알고리즘 ADR (case-data-schema OQ-2의 v1+ 측 closure).
+
+### 4.5 precedent_seniority_bonus (v1+)
+
+*MVP scope 외* — `case.scoring_weights.precedent_seniority_bonus = 0` 잠금 (case-data-schema AC-10 + entities.yaml `case_disposition_match_minimum_weight` mirror). v1+ 알고리즘 스텁:
+
+```
+seniority_bonus_v1plus = avg(library_get(c).court_grade_weight for c in matched_set)
+seniority_bonus_mvp = 0.0
+```
+
+`court_grade_weight`는 Library §7.3에서 정의 (현재 0 잠금). v1+ 활성화 트리거는 Library OQ-5 + case OQ-2의 *공동 결정*.
+
+### 4.6 final_score 합산
+
+```
+final_score = clamp(
+    weights.disposition_match × subscores.disposition_match +
+    weights.core_citation_coverage × subscores.core_citation_coverage +
+    weights.redundant_citation_penalty × subscores.redundant_citation_penalty +  # 음수
+    weights.chain_coherence × subscores.chain_coherence +                          # MVP=0
+    weights.precedent_seniority_bonus × subscores.precedent_seniority_bonus,       # MVP=0
+    0.0, 1.0
+)
+```
+
+**Variables:**
+| Variable | Symbol | Type | Range | Description |
+|----------|--------|------|-------|-------------|
+| `weights.*` | w_k | float | 0.0–1.0 (penalty 0.0–0.3) | case.scoring_weights[k] |
+| `subscores.*` | s_k | float | -0.3–1.0 | §4.1-4.5 결과 |
+| `final_score` | F | float | 0.0–1.0 | clamp 후 |
+
+**Output Range**: [0.0, 1.0] (clamp).
+
+**Normalization Constraint** (§7.2 Tuning Knobs guard):
+- positive weights 합 (`w_disp + w_core + w_chain + w_senior`) ≤ 1.0
+- penalty weight (`w_redund`) 별도 관리 — 0.0–0.3 안전 범위
+
+**MVP 가중치 합 추정** (w_chain = w_senior = 0): w_disp + w_core ≤ 1.0. 예시 잠금: w_disp = 0.4 (case_disposition_match_minimum_weight 잠금) + w_core = 0.5 + w_redund = 0.1 + 나머지 0.
+
+**Example (MVP 워크드)**: case `case_data:2026-001` 가중치 = `{disp:0.4, core:0.5, redund:0.1, chain:0.0, senior:0.0}`. 플레이어 결과 = `{disp:1.0, core:0.5, redund:-0.25, chain:0.0, senior:0.0}` → 0.4×1.0 + 0.5×0.5 + 0.1×(-0.25) + 0 + 0 = 0.4 + 0.25 - 0.025 = **0.625**. clamp 후 0.625. verdict 결정 룰 §3.1.4 적용 → player_disposition == correct_disposition AND 0.625 ∈ [0.5, 0.7) → **파기환송**.
+
+### 4.7 Verdict 결정 함수
+
+§3.1.4를 형식화:
+
+```
+verdict(player_disp, correct_disp, final_score) =
+    "파기"      if player_disp == correct_disp AND final_score >= 0.7
+    "파기환송"  if player_disp == correct_disp AND 0.3 <= final_score < 0.7
+    "기각"      if player_disp != correct_disp AND final_score >= 0.3
+    "각하"      otherwise
+```
+
+**Threshold rationale (§7.1 Tuning Knobs)**:
+- 0.7 = "파기" cutoff: 인용·근거가 정답 처분과 일관되게 강할 때만 카타르시스 (Pillar 1 가드).
+- 0.3 = "파기환송" 하한 (disp 일치 시): 처분 방향은 맞고 약간의 근거가 있음 — 다시 시도 가능한 시그널, 학습 곡선 보존.
+- 0.3 = "기각" 하한 (disp 불일치 시): 처분은 빗나갔으나 논거는 있음 — 학습 곡선 보존. (파기환송과 기각은 0.3 임계값을 공유하나 분기 조건이 다름 — disp 일치 여부.)
+- 0.3 미만 = "각하": 논거의 무게가 측정 가능한 임계 미달 — 처분 일치 여부 무관, 명확한 negative feedback.
+
+**4 Verdict 분포 균형**: MVP playtest 5인 + 시드 케이스 평가 시 4 verdict가 모두 surface 되도록 케이스 가중치 튜닝 권장.
+
+---
+
+## 5. Edge Cases
+
+- **EC-1: 빈 인용 제출 (`player_citations.size() == 0`)**
+  - **If** PlayerSubmission이 인용 0건이면, **then** §3.1.2 Pre-evaluation Gate에서 *제출 거부* + UI 메시지 "최소 1건의 인용이 필요합니다" 표시 + 콘솔 push_warning. 평가 자체 미수행, 케이스 lifecycle은 `InProgress` 유지 (Submitted 진입 X). 플레이어는 #7 Brief Editor로 복귀하여 인용 추가 후 재제출. 디자인 이유: 빈 인용 평가는 *모든 케이스에서 동일 final_score 0.0* — 변별력 없는 No-op이므로 사전 차단이 명확한 negative feedback.
+
+- **EC-2: 미존재 Library ID 인용**
+  - **If** `player_citations`에 `LibraryService.validate_citations()` 미통과 ID 1건 이상이면, **then** §3.1.2 Pre-evaluation Gate에서 *제출 거부* + UI에 *어느 ID가 미존재인지* 표시 + 콘솔 push_error("Submission rejected: invalid Library IDs: %s"). #7 Brief Editor 측 책임 — Editor가 인용 추가 시점에 검증하므로 이 EC는 *방어적 가드*. case-data-schema EC-1 mirror.
+
+- **EC-3: `player_disposition` enum 위반**
+  - **If** `player_disposition`이 `library_dispositions_court` enum 외 값이면, **then** §3.1.2 Pre-evaluation Gate에서 *제출 거부* + 콘솔 push_error. #7 Brief Editor 측 책임 — Editor UI는 enum 4 멤버만 선택 가능해야 함. 이 EC는 *방어적 가드*.
+
+- **EC-4: `case.scoring_weights` 정규화 위반 (positive weights 합 > 1.0)**
+  - **If** 평가 시점에 `w_disp + w_core + w_chain + w_senior > 1.0`이면, **then** 콘솔 push_warning("Case %s: scoring_weights normalization violated, sum=%f") + 평가는 진행 (final_score는 clamp at 1.0로 안전). 이 EC는 *케이스 콘텐츠 작성 가드* — case-data-schema가 `_validate_and_register()` 단계에서 사전 검증하는 것이 이상적이지만 본 GDD scope 외. 
+
+- **EC-5: 모든 인용이 무관 (`matched_set.size() == 0`)**
+  - **If** `core_citation_coverage = 0.0` AND `redundant_count == player_citations.size()`이면, **then** 평가 *진행*. 결과는 final_score = w_disp × disp_match + 0 + w_redund × (penalty cap -0.3). disposition만으로 판정. 코멘트는 `comment.core.low` + `comment.redund.bloat` 활성. UI에 *모든 인용이 본 사건과 거리가 있다*는 강한 negative 코멘트 표시. 디자인 이유: 처분만 맞춰서 *카타르시스 파기*는 안 되도록 — Pillar 1 가드 (인용 매칭 0.0 → final_score 최대 = 0.4 잠금 → "파기" 0.7 미달 → "파기환송" — disp 일치 신호는 보존되어 다시 시도 가능 시그널). disp 불일치 + 인용 매칭 0.0 → final_score = 0 + redund penalty < 0.3 → "각하".
+
+- **EC-6: case 비활성화 상태에서 제출 시도**
+  - **If** `CaseService.get_case(case_id).is_active == false` (case-data-schema EC-1·2·3 발동 케이스)이면, **then** §3.1.2 Pre-evaluation Gate에서 *제출 거부* + UI 에러. 이 EC는 *프로세스 가드* — 비활성화 케이스는 #5 Browser에서 진입 자체가 차단되어야 하지만 (Browser §EC) 본 시스템도 방어적 가드.
+
+- **EC-7: 평가 중 `EvaluationService` 재호출 (이중 제출)**
+  - **If** State가 `Validating`/`Computing`/`Reporting` 중에 두 번째 `submit()` 호출되면, **then** 두 번째 호출 *거부* + 콘솔 push_warning("Evaluation in progress: re-submit ignored"). #5 Browser·#7 Editor가 *Submit 버튼 비활성화*로 사전 차단해야 함 — 이 EC는 *방어적 가드*.
+
+- **EC-8: 재평가 (`Resolved` 상태에서 같은 case_id 재제출)**
+  - **If** case lifecycle이 `Resolved` 상태이고 같은 `case_id`로 `submit()` 호출되면, **then** *재평가 허용* — EvaluationResult 새로 산출하고 `evaluation_completed` 시그널 emission. **항상 재계산 원칙** (캐시 X — AC-23이 byte-identical 결정성을 보장하므로 캐시 불필요 + 결정성 단순함 + 가중치 데이터 변경 시 자동 반영). 단 #11 Career Progression의 결과 보존 정책(case-data-schema OQ-6)이 결정 — *첫 결과만 보존* / *모든 시도 보존* / *최고 점수 보존* 중 하나. 본 시스템은 매번 평가를 수행하고 *결과 영속화*는 #11 책임.
+
+- **EC-9: `chain_data`가 누락된 v1+ 케이스 평가 (호환성)**
+  - **If** v1+ 케이스가 `chain_coherence` 가중치 > 0인데 `chain_data == {}`이면, **then** subscore = 0.0 적용 + 콘솔 push_warning. v1+ 활성 시 #6 Workspace가 chain_data를 정상 export 보장해야 함 — 이 EC는 *마이그레이션 안전망*.
+
+---
+
+## 6. Dependencies
+
+| 시스템 | 관계 | 양방향 메모 |
+|--------|------|-------------|
+| #1 Case Data Schema | HARD — `case.correct_disposition` + `correct_citations` + `scoring_weights` 입력 | case-data-schema §3.3에서 본 GDD 명시 ✓, §OQ-2가 본 GDD에 위임 ✓ |
+| #20 Legal Reference Library | HARD — `LibraryService.validate_citations()` (EC-2 방어적 가드) | Library §3.3에서 외부 호출 인터페이스 명시 ✓ |
+| #5 Case File Browser | HARD — Browser `SubmissionPending` ↔ 본 시스템 활성 / `evaluation_completed` 시그널 → Browser `VerdictArrived` 전이 | Browser §3.2 + §AC-20·AC-21에서 본 시스템 위임 ✓ |
+| #7 Brief Editor | HARD — PlayerSubmission 구성·전달 (`EvaluationService.submit(submission)`) | Brief Editor 미디자인 — 본 GDD §3.1.1 PlayerSubmission 인터페이스가 #7 디자인의 *입력 계약* |
+| #6 Reasoning Workspace | SOFT (MVP) / HARD (v1+) — `chain_data` 입력. MVP는 빈 Dict 허용. **§3.2 freeze 계약** (submit() 시점에 workspace memo 불가변 스냅샷) — #6 측 행동 의무 | Workspace 미디자인 — 본 GDD §3.1.1 chain_data 슬롯 + §3.2 freeze 계약이 #6 v1+ 디자인의 *입력·행동 계약* |
+| #10 Verdict Reveal Sequence | HARD — `evaluation_completed(result)` 시그널 → #10 봉투 연출 | #10 미디자인 — 본 GDD §3.1.6 EvaluationResult가 #10의 *입력 계약* |
+| #11 Career Progression | HARD — EvaluationResult 보존 + final_score → 평판 입력 | #11 미디자인 — case-data-schema OQ-6과 *공동 결정* (재플레이 보존 정책) |
+| #12 Reputation System (VS) | SOFT — final_score → 평판 변화량 | #12 미디자인 — 본 GDD scope 외 |
+| #14 Retrospective Replay (Alpha) | HARD — EvaluationResult.subscores + matched/missed/redundant sets 보존 + 시각화 | #14 미디자인 — 본 GDD §3.1.6 EvaluationResult가 *완전한 회고 입력* |
+| #13 Persona System (VS) | SOFT — 코멘트 톤이 멘토 페르소나 영향 가능 | #13 디자인 시 코멘트 템플릿 본문 작성 책임 |
+| #15 Source Citation (v1+) | SOFT — Library ID 출처 표시 (player가 인용한 ID도 출처 노출 가능) | v1+ — 본 GDD scope 외 |
+
+본 GDD가 의존하는 ADR:
+- ADR-0001 (Library Storage Format) — `LibraryService.validate_citations()` 인터페이스 + 정적 타입 Resource 패턴 mirror
+- ADR-0001 Amendment 1 + 1.1 — Library ID 형식·holding 분리 패턴
+- ADR-0003 (Case Data Storage Format) — `CaseFile` 13 필드 + scoring_weights 외부화 결정 + autoload 순서 + mirror principle
+
+본 GDD가 trigger하는 *향후 ADR 후보*:
+- **ADR-0007 (Submission Evaluation Algorithm)**: PlayerSubmission/EvaluationResult/CommentTemplates Resource 정적 타입 트리, EvaluationService autoload (THIRD position + heuristic guard), entities.yaml verdict 임계값 외부화 + per-case override 금지, comment_templates.tres 위치. **Proposed 2026-05-06** (godot-specialist 검증 완료 — autoload await deadlock 가드 + AC-22 측정 박법 보정 포함).
+- **ADR-XXXX (v1+ Chain Coherence Algorithm)**: 추론 체인 평가 알고리즘 정의 — 자문가 검수 + #6 Workspace 디자인 후 진입.
+
+---
+
+## 7. Tuning Knobs
+
+### 7.1 Verdict 임계값 (글로벌 잠금)
+
+| 노브 | MVP 기본 | 안전 범위 | 너무 낮으면 | 너무 높으면 |
+|------|----------|-----------|-------------|-------------|
+| `verdict_threshold_pagi` | 0.7 | 0.6-0.8 | "파기" 카타르시스 흔해짐 → Pillar 1 변별력 ↓ | "파기" 도달 불가능 → 좌절 |
+| `verdict_threshold_low` | 0.3 | 0.2-0.4 | 파기환송(disp 일치)·기각(disp 불일치) 모두 흔해짐 → 학습 곡선 약화 | "각하" 빈번 → 좌절 + 첫 30분 이탈 |
+
+이 2 임계값은 **글로벌 잠금** — entities.yaml `submission_verdict_thresholds` constant로 등록 권장. 케이스별 override는 *원칙적으로 X* (Pillar 1 가드: 모든 케이스가 동일 평가 룰). 파기환송과 기각은 동일 0.3 임계값(`verdict_threshold_low`)을 공유 — 분기 조건은 player_disp == correct_disp 여부.
+
+### 7.2 case.scoring_weights 정규화 가드 (per-case)
+
+| 노브 | MVP 기본 | 안전 범위 | 잠금 |
+|------|----------|-----------|------|
+| `w_disp` (`disposition_match`) | 0.4 | 0.4-0.6 | **≥ 0.4 잠금** (case-data-schema AC-9 — `case_disposition_match_minimum_weight`) |
+| `w_core` (`core_citation_coverage`) | 0.4-0.5 | 0.3-0.6 | positive weights 합 ≤ 1.0 |
+| `w_redund` (`redundant_citation_penalty`) | 0.1 | 0.0-0.3 | 별도 — penalty weight |
+| `w_chain` (`chain_coherence`) | **0.0 (MVP 잠금)** | 0.0 (v1+ unblock) | case-data-schema OQ-2 + Library OQ-5 공동 결정 |
+| `w_senior` (`precedent_seniority_bonus`) | **0.0 (MVP 잠금)** | 0.0 (v1+ unblock) | case-data-schema AC-10 mirror — Anti-Pillar |
+
+**MVP 가중치 시드 추천 (per-case)**:
+- 단순 케이스 (difficulty 1-2): `{disp:0.5, core:0.4, redund:0.1, chain:0, senior:0}` — 처분 측 비중 높음
+- 표준 케이스 (difficulty 3): `{disp:0.4, core:0.5, redund:0.1, chain:0, senior:0}` — 인용 측 비중 높음
+- 어려운 케이스 (difficulty 4-5): `{disp:0.4, core:0.5, redund:0.1, chain:0, senior:0}` — 표준과 동일 (MVP), v1+에서 chain 활성
+
+### 7.3 Subscore Penalty Cap
+
+| 노브 | MVP 기본 | 안전 범위 | 의미 |
+|------|----------|-----------|------|
+| `redundant_penalty_cap` | -0.3 | -0.5 ~ -0.2 | redundant_citation_penalty 하한 (§4.3) |
+| `redundant_ratio_multiplier` | 0.5 | 0.3-0.8 | `penalty = -min(cap, ratio × multiplier)` (§4.3) |
+
+너무 약하면 스팸 인용 페널티 사라짐 (Pillar 3 가드 약화), 너무 강하면 학습 곡선 좌절.
+
+### 7.4 Comment Templates (콘텐츠 노브)
+
+| 노브 | 위치 | 의미 |
+|------|------|------|
+| `comment_templates.tres` | `assets/data/evaluation/` | 코멘트 템플릿 키 → 한국어 본문 매핑 (§3.1.5 7-키 셋) |
+| `comment_max_length_chars` | 80 | 한 줄 코멘트 최대 길이 (UI 가독성) — 한글 80자 ≈ #10 Verdict Reveal Sequence UI 패널 폭 2줄 추정. #10 디자인 시 mockup 폭 결정으로 재검토 (현재 추정값) |
+
+코멘트 본문 톤은 #13 Persona System 디자인 시 결정. MVP는 *중립적·간결*한 톤 (멘토 미도입 상태).
+
+### 7.5 v1+ Unblock 트리거 가드
+
+- `chain_coherence` 활성화는 *모든* MVP 케이스의 `w_chain = 0` → v1+ 단계에서 케이스 별로 ≥ 0.1로 변경 시 활성. 단일 케이스 활성 X — 일괄 마이그레이션. Library OQ-5와 case OQ-2가 *동일 결정*.
+- `precedent_seniority_bonus` 활성화는 Library §7.3 `court_grade_weight` 활성화와 *동일 결정*. 한 곳에서 결정, 두 곳에서 동시 활성.
+
+이 가드의 의미: MVP 동안 이 두 subscore는 *코드는 구현되어 있지만 가중치 0으로 사실상 미사용*. v1+ 활성 시 코드 변경 없이 데이터(per-case scoring_weights) + 글로벌 config 변경만으로 이행 가능.
+
+---
+
+## 8. Acceptance Criteria
+
+### 8.1 Pre-evaluation Gate (§3.1.2)
+
+- **AC-1**: **GIVEN** PlayerSubmission이 `player_citations.size() == 0`일 때, **WHEN** `EvaluationService.submit()` 호출, **THEN** `submission_rejected("empty_citations")` 시그널 emission + EvaluationResult 미생성 + 콘솔 push_warning (EC-1).
+- **AC-2**: **GIVEN** PlayerSubmission이 미존재 Library ID 1건 보유, **WHEN** submit() 호출, **THEN** `submission_rejected("invalid_library_id")` + push_error("Submission rejected: invalid Library IDs: %s") (EC-2).
+- **AC-3**: **GIVEN** PlayerSubmission의 `player_disposition`이 `library_dispositions_court` 외 값, **WHEN** submit() 호출, **THEN** `submission_rejected("invalid_disposition")` + push_error (EC-3).
+- **AC-4**: **GIVEN** `case.scoring_weights` positive 합이 1.0 초과, **WHEN** evaluate(), **THEN** push_warning + 평가 진행 + final_score는 clamp at 1.0 (EC-4).
+
+### 8.2 Subscore 정확성 (§4)
+
+- **AC-5**: **GIVEN** player_disposition == correct_disposition, **WHEN** evaluate(), **THEN** subscores.disposition_match == 1.0 (§4.1).
+- **AC-6**: **GIVEN** player_disposition != correct_disposition, **WHEN** evaluate(), **THEN** subscores.disposition_match == 0.0 (§4.1).
+- **AC-7**: **GIVEN** player_citations = [law:civil-act-art-100, case:2024da12345, case:2024da99999] AND correct_citations = [law:civil-act-art-100, case:2024da12345/holding-1, case:2024do6789], **WHEN** evaluate(), **THEN** subscores.core_citation_coverage == 0.5 (= (1.0 + 0.5 + 0.0)/3 — 정답 c 측 순회 §4.2 워크드).
+- **AC-8**: **GIVEN** matched_set.size() == 3 AND player_citations.size() == 6 (3 redundant), **WHEN** evaluate(), **THEN** subscores.redundant_citation_penalty == -0.25 (-min(0.3, 0.5×0.5)) (§4.3 워크드).
+- **AC-9**: **GIVEN** MVP 모든 케이스, **WHEN** evaluate(), **THEN** subscores.chain_coherence == 0.0 AND subscores.precedent_seniority_bonus == 0.0 (MVP 잠금 §3.1.3).
+
+### 8.3 Final Score + Verdict (§4.6, §4.7)
+
+- **AC-10**: **GIVEN** subscores = {disp:1.0, core:0.5, redund:-0.25, chain:0, senior:0} AND weights = {disp:0.4, core:0.5, redund:0.1, chain:0, senior:0}, **WHEN** evaluate(), **THEN** final_score == 0.625 (§4.6 워크드).
+- **AC-11**: **GIVEN** player_disp == correct_disp AND final_score >= 0.7, **WHEN** verdict() 결정, **THEN** verdict == "파기".
+- **AC-12**: **GIVEN** player_disp == correct_disp AND 0.3 <= final_score < 0.7, **WHEN** verdict(), **THEN** verdict == "파기환송".
+- **AC-13**: **GIVEN** player_disp != correct_disp AND final_score >= 0.3, **WHEN** verdict(), **THEN** verdict == "기각".
+- **AC-14**: **GIVEN** final_score < 0.3 (disp 일치 여부 무관), **WHEN** verdict(), **THEN** verdict == "각하" (disp 일치 + 저점 / disp 불일치 + 저점 양 분기 통합).
+
+### 8.4 EvaluationResult 출력 (§3.1.6)
+
+- **AC-15**: **GIVEN** submit() 호출이 검증 통과, **WHEN** Reporting 상태 진입, **THEN** `evaluation_completed(EvaluationResult)` 시그널 1회 emission + EvaluationResult.subscores · weighted_contributions · comments · correct_set · missed_set · redundant_set 모두 채워짐.
+- **AC-16**: **GIVEN** EvaluationResult, **WHEN** weighted_contributions.values().sum() 계산, **THEN** 결과 == final_score (정규화 검증).
+
+### 8.5 상태 머신 (§3.2)
+
+- **AC-17**: **GIVEN** EvaluationService State == Idle AND submit(valid_submission) 호출, **WHEN** 다음 frame, **THEN** State 전이 Idle → Validating → Computing → Reporting → Done → Idle (단일 frame 내 또는 다중 frame across).
+- **AC-18**: **GIVEN** State ∈ {Validating, Computing, Reporting} AND 두 번째 submit() 호출, **WHEN** 두 번째 호출 발생, **THEN** 두 번째 호출 거부 + push_warning("Evaluation in progress") (EC-7).
+
+### 8.6 Pillar / Anti-Pillar 가드
+
+- **AC-19**: **GIVEN** matched_set.size() == 0 (모든 인용 무관) AND player_disp == correct_disp AND case 가중치 = MVP 표준 시드 (w_disp=0.4, w_core=0.5, w_redund=0.1, w_chain=w_senior=0), **WHEN** evaluate(), **THEN** final_score == 0.37 (= 0.4×1.0 + 0.5×0.0 + 0.1×(-0.3) — redundant_ratio=1.0이므로 penalty cap 도달) AND verdict == "파기환송" (Pillar 1 가드 — disp 일치 신호는 보존되지만 인용 부재로 파기 0.7 미달, 카타르시스 차단; EC-5).
+- **AC-20**: **GIVEN** MVP 모든 케이스의 case.scoring_weights, **WHEN** disposition_match weight 측정, **THEN** w_disp >= 0.4 (case-data-schema `case_disposition_match_minimum_weight` 잠금 mirror — 본 시스템은 *읽는 측*).
+
+### 8.7 성능 (release build)
+
+- **AC-21**: **GIVEN** 평균 케이스 (correct_citations 6 + player_citations 6), **WHEN** submit() → evaluation_completed 시그널, **THEN** 경과 시간 ≤ 50ms (Pillar 3 *사고만이 압박이다* — 평가 지연이 인위적 압박감 X).
+- **AC-22**: **GIVEN** EvaluationService, **WHEN** `OS.get_static_memory_usage()` baseline 후 100회 evaluate() 반복 + 종료 후 delta 측정, **THEN** (delta / 100) ≤ 256 KB per evaluation. 단일 호출 측정은 Godot GC defer + `Performance.get_monitor` 샘플링 노이즈로 부정확 — averaging 필수 (ADR-0007 Risk 6). gdunit4 native hook 부재 시 manual evidence — `production/qa/evidence/eval-memory-[date].md`에 baseline·iteration·평균 delta 기록.
+
+### 8.8 결정성 (Test-Standards 준수)
+
+- **AC-23**: **GIVEN** 동일 PlayerSubmission + 동일 case, **WHEN** 두 번 evaluate() 호출, **THEN** 두 EvaluationResult가 byte-identical (random 사용 X, time-dependent 사용 X — `evaluated_at`은 Reporting 시점 timestamp이므로 비교 제외) (test-standards Determinism 준수).
+
+---
+
+## Open Questions
+
+- **OQ-1 (deferred to v1+)**: `chain_coherence` subscore 알고리즘 정의 — 추론 트리 노드의 인용 근거 적합도, 부모-자식 전이 일관성, 중복 가설 페널티 등. 자문가 검수 필수 (variation 평가 알고리즘은 법학·인지심리 도메인 깊이 의존). #6 Reasoning Workspace 디자인 + 자문 회의 후 별도 ADR로 정의. case-data-schema OQ-2의 v1+ 측 closure.
+
+- **OQ-2 (closed by ADR-0007 Proposed 2026-05-06)**: ADR-0007 (Submission Evaluation Algorithm) §1·2·3·4 잠금 — (a) Resource 트리는 src/data/ + class_name/extends Resource/@export (mirror ADR-0001/0003); (b) EvaluationService autoload THIRD position + entry_count()/case_count() heuristic guard (await pre-fire deadlock 방어); (c) verdict 임계값은 design/registry/entities.yaml `submission_verdict_thresholds`에 외부화 + per-case override 금지 forbidden_pattern 등록; (d) comment_templates.tres는 assets/data/evaluation/ + CommentTemplates Resource (Dictionary[String, String]). ADR-0007 Accepted 후 OQ-2 closed.
+
+- **OQ-3 (deferred to #13 Persona System)**: 코멘트 본문 톤 — MVP는 중립적·간결, 멘토 도입 후(VS) 멘토 페르소나의 *결*을 코멘트에 반영할지. 결정 입력은 #13 디자인 시 본 GDD §3.1.5 7-키 셋 검토.
+
+- **OQ-4 (deferred to #11 Career Progression)**: 재플레이 결과 보존 정책 — 첫 결과만 / 모든 시도 / 최고 점수 (case-data-schema OQ-6 mirror). 본 시스템은 매번 평가 수행하고 영속화는 #11 책임 — #11 디자인 시 결정.
+
+- **OQ-5 (deferred to #14 Retrospective Replay)**: EvaluationResult가 제공하는 matched_set/missed_set/redundant_set의 *시각화 방식* — 가중 분기 표시 (Disco Elysium 풍) vs 단순 리스트 + 색상 코딩. Alpha 단계 #14 디자인 시 결정.
+
+- **OQ-6 (deferred to #12 Reputation System)**: final_score → 평판 변화량 매핑 함수. VS 단계 #12 디자인 시 결정. 본 GDD scope 외.
+
+- **OQ-7 (deferred to playtest)**: 4 verdict 임계값 (0.7 / 0.5 / 0.3) 튜닝 — MVP 5인 playtest에서 4 verdict 분포 측정 후 보정. 자문가 검수 시 *변호사가 보기에 verdict 라벨이 합리적인가* 확인 (예: "파기환송" 임계값이 실제 법조계 감각과 일치하는지).
+
+- **OQ-8 (deferred to ADR)**: comment_templates.tres 형식 — Dictionary 기반 단순 매핑 vs 조건 분기 트리 (i18n 대비) — ADR 시점에 결정. MVP는 한국어 단일 언어이므로 단순 매핑으로 충분.
+
+- **OQ-9 (deferred to v1+)**: holding-N 부분 매칭 0.5 점수의 변별력 — 자문가 시점에서 *법조계가 판례 인용을 holding 단위로 다룰 때*의 가중치가 본 GDD 가정과 일치하는지. 변호사 자문 회의 항목 추가 권장.

--- a/design/gdd/systems-index.md
+++ b/design/gdd/systems-index.md
@@ -1,0 +1,212 @@
+# Systems Index: 파기 (破棄)
+
+> **Status**: Draft (lean review mode — director gates skipped)
+> **Created**: 2026-05-03
+> **Last Updated**: 2026-05-07 (cycle 2 cascade — 22 BLOCKING closure + ADR-0008 Proposed)
+> **Source Concept**: design/gdd/game-concept.md
+> **Art Bible**: design/art/art-bible.md
+
+> **Revision 2026-05-04**: System #20 Legal Reference Library 추가. 케이스마다 법령·판례 텍스트가 중복 저장되는 구조를 막기 위한 전역 데이터베이스. #1 Case Data Schema의 역할이 *케이스별 콘텐츠 + Library 참조 ID*로 축소됨. #5, #6, #7, #15가 Library에 직접 의존성 추가됨. 디자인 순서 1번이 #20으로 변경.
+
+> **Review 2026-05-04 (lean)**: #20 Legal Reference Library `/design-review` 1차 — Verdict NEEDS REVISION (5 블로커 + 12 권장). 동 세션에서 블로커 #3(Holding ID 합성 규칙)·#5(4.1↔7.3 활성 조건) 즉시 해소. **ADR-0001 (Library Storage Format)** Proposed로 작성되어 블로커 #1 해소 → 3/5 in-session resolved.
+>
+> **자문 전략 재편 2026-05-04**: 잔여 블로커 #2(조의2/호 스키마)는 MCP(`korean-law-mcp`) fetch + `production/research/legal-corpus/` 문서 관리로 자가 검증. 블로커 #4(AC-15 메모리 측정 프로토콜)는 *자문가 대상 아님* → godot-specialist/performance-analyst 라우팅 또는 ADVISORY 격하. 인간 자문가 회의는 VS 진입 직전 1회로 연기 (Persona 진정성 + Q4 학설 + 게임 톤 검수).
+>
+> **MVP Approved 트리거**: MCP 기반 자료 수집 완료 + 시드 5-10건 검증 + ADR-0001 Accepted.
+
+---
+
+## Overview
+
+*파기 (破棄)* 는 한국 대법원 상고심 변호사를 시뮬레이션하는 텍스트·UI 전용 솔로 도메인 추론 게임이다. 전통적 의미의 캐릭터·환경·전투·경제 시스템은 존재하지 않으며, 게임 전체가 *판결문·법령·판례·상고이유서*라는 6종 문서 위에서 작동한다. 핵심 루프는 "케이스 인입 → 자료 검토 → 가설 구성 → 상고이유서 작성 → 결정문 도착 → 회고"이며, 시스템 분해는 이 루프를 지원하는 시각·데이터·평가·진행·메타 레이어로 구성된다.
+
+5 Pillar 중 *진실은 가중치다* (Pillar 1)와 *사고 만이 압박이다* (Pillar 3)가 코어 시스템 디자인을 가장 강하게 제약하며, *커리어가 곧 보상이다* (Pillar 5)가 Feature 레이어의 진행 시스템들을 통합한다. 총 20개 시스템, 그중 13개가 MVP 범위에 포함되지만 다수는 매우 작은 시스템이고 실제 디자인 무게는 7개 핵심 시스템(#20 Library, #5 Browser, #6 Reasoning Workspace, #7 Brief Editor, #8 Investigation Slots, #9 Submission & Evaluation, #10 Verdict Reveal Sequence)에 집중된다.
+
+---
+
+## Systems Enumeration
+
+| # | System Name | Category | Priority | Status | Design Doc | Depends On |
+|---|-------------|----------|----------|--------|------------|------------|
+| 20 | Legal Reference Library | Core | MVP | Reviewed (Provisional — ADR-0001 trilogy + ADR-0002 + **ADR-0006** Accepted 2026-05-05; AC-17 100ms ✅ via lazy full_opinion side-car; gdunit4 193/193 PASS; lawyer consult deferred to VS gate) | design/gdd/legal-reference-library.md | — |
+| 1 | Case Data Schema | Foundation | MVP | Designed (ADR-0003 Accepted 2026-05-05; first seed verified — gdunit4 20/20 case + 143/143 total) | design/gdd/case-data-schema.md | Legal Reference Library |
+| 2 | UI Foundation (inferred) | Core | MVP | Not Started | — | — |
+| 3 | Save/Load (inferred) | Core | MVP | Not Started | — | — |
+| 4 | Settings & Accessibility (inferred) | Meta | MVP | Not Started | — | UI Foundation |
+| 5 | Case File Browser | Gameplay | MVP | Designed Provisional (2026-05-05; **ADR-0004 Proposed 2026-05-06** — Korean text rendering hybrid by family closes OQ-1; AC-14·15·16 art-director sign-off pending; Browser Layout ADR pending OQ-8) | design/gdd/case-file-browser.md | Case Data Schema, UI Foundation, Legal Reference Library |
+| 6 | Reasoning Workspace | Gameplay | MVP | Designed Provisional (2026-05-07 cycle 2 cascade applied — 22 BLOCKING + ~50 IMPORTANT closure via 5 design decisions + mechanical revision; **ADR-0008 Workspace Layout Proposed 2026-05-07** closes Gate ③ 4 invariant + OQ-W5/W9/W10/W13; **3rd /design-review cycle scheduled** to verify cascade discipline + IMPORTANT 잔여 감소) | [reasoning-workspace.md](reasoning-workspace.md) | Case Data Schema, UI Foundation, Case File Browser, Legal Reference Library, ADR-0001/0004/0007/0008 |
+| — | Client Voice Track (cross-system) | Cross-system | MVP-gate (locked 2026-05-06 Option D 하이브리드) | OQ logged | case-data-schema OQ-7 + case-file-browser OQ-9 (+ #13 OQ-10 VS) | Case Data Schema, Case File Browser, Art Bible §6, ADR-0004 |
+| 7 | Brief Editor | Gameplay | MVP | Not Started | — | Case Data Schema, UI Foundation, Case File Browser, Reasoning Workspace, Legal Reference Library |
+| 8 | Investigation Slots | Gameplay | MVP | Not Started | — | Case File Browser, Reasoning Workspace |
+| 9 | Submission & Evaluation | Gameplay | MVP | Designed (2026-05-05; lean review revisions applied 2026-05-06; **ADR-0007 Proposed 2026-05-06** — Submission Evaluation Algorithm closes OQ-2 4건; chain_coherence v1+ deferred) | design/gdd/submission-evaluation.md | Case Data Schema, Brief Editor, Legal Reference Library |
+| 10 | Verdict Reveal Sequence | Gameplay | MVP | Not Started | — | UI Foundation, Submission & Evaluation |
+| 11 | Career Progression | Progression | Alpha | Not Started | — | Case Data Schema, Save/Load, Submission & Evaluation, Reputation System |
+| 12 | Reputation System | Progression | Vertical Slice | Not Started | — | Submission & Evaluation |
+| 13 | Persona System | Narrative | Vertical Slice → Full Vision | Not Started | — | Case File Browser, Reasoning Workspace, Brief Editor |
+| 14 | Retrospective Replay | Meta | Alpha | Not Started | — | Reasoning Workspace, Brief Editor, Submission & Evaluation |
+| 15 | Source Citation | Meta | Vertical Slice | Not Started | — | Case File Browser, Reasoning Workspace, Brief Editor, Legal Reference Library |
+| 16 | Tutorial & Onboarding (inferred) | Meta | MVP | Not Started | — | Case File Browser, Reasoning Workspace, Brief Editor, Investigation Slots |
+| 17 | Meta-Frame (inferred) | Meta | MVP | Not Started | — | UI Foundation, Save/Load |
+| 18 | Sharing System (inferred) | Meta | Alpha | Not Started | — | Career Progression, Retrospective Replay |
+| 19 | Telemetry (inferred) | Meta | Full Vision | Not Started | — | (cross-cutting) |
+
+---
+
+## Categories
+
+이 게임에 적용되는 카테고리만 사용 (전통적 게임의 Combat/Economy/Audio 등은 미적용 또는 매우 축소).
+
+| Category | Description | Systems in This Game |
+|----------|-------------|----------------------|
+| **Core** | 모든 시스템이 의존하는 기반 — 이 게임에서는 데이터 스키마/Library와 시각 시스템 | #20, #1, #2, #3 |
+| **Gameplay** | 30초·5분·세션 루프를 만드는 시스템 | #5, #6, #7, #8, #9, #10 |
+| **Progression** | 시간이 흐르며 변호사가 자라는 시스템 | #11, #12 |
+| **Narrative** | 인격(멘토·라이벌·대법관)의 절제된 결을 전달하는 시스템 | #13 |
+| **Meta** | 코어 외부의 메타 시스템 (설정·튜토리얼·메뉴·공유·분석 등) | #4, #14, #15, #16, #17, #18, #19 |
+
+> **N/A 카테고리** (이 게임에 없음): Combat, Economy (in-game currency), Loot, Multiplayer, AI Behavior, Procedural Generation, Voice Acting, Cutscenes (결정문 시퀀스 외).
+
+---
+
+## Priority Tiers
+
+| Tier | Definition | Target Milestone | Design Urgency |
+|------|------------|------------------|----------------|
+| **MVP** | 코어 루프가 작동하기 위한 필수 시스템. "차분한 정밀 추론이 재미있는가?" 가설 검증용 | 첫 플레이테스트 (2-4주) | 가장 먼저 디자인 |
+| **Vertical Slice** | 1 케이스의 풀 폴리시 + Pillar 4·5의 작동 검증 | VS 데모 (6-8주) | MVP 후 즉시 |
+| **Alpha** | 커리어 모드 가동, 3-5 케이스, 모든 시스템 rough | Alpha (3-4개월) | VS 후 |
+| **Full Vision** | 풀 콘텐츠, 모든 시스템 polished, 출시 준비 | Beta/Release (12-24개월) | 필요 시 |
+
+---
+
+## Dependency Map
+
+### Foundation Layer (의존성 0)
+1. **Legal Reference Library** (#20) — 모든 케이스가 참조하는 전역 법령·판례·학설 데이터베이스. Pillar 4·5의 작동 기반.
+2. **Case Data Schema** (#1) — 케이스별 콘텐츠 (사실관계·1·2심 판결문·인용 ID·정답·평가 가중치). Library 참조 ID로 법령·판례를 가리킴.
+3. **UI Foundation** (#2) — Art Bible의 시각 정체성('법정 기록')을 코드로 정식화. 6개 시스템이 직접 의존하는 최대 보틀넥.
+4. **Save/Load** (#3) — 60-120분 세션의 중간 저장 + 케이스북·커리어 영속화.
+
+> 엄밀히 말하면 #1 Case Data Schema는 #20 Library에 의존하므로 Foundation 정의("의존성 0")를 깨지만, 실용적으로 두 시스템은 *함께 Foundation 역할*을 한다 — 다른 모든 시스템이 둘 다 필요로 함.
+
+### Core Layer (Foundation에만 의존)
+1. **Settings & Accessibility** (#4) — depends on: UI Foundation
+2. **Case File Browser** (#5) — depends on: Case Data Schema, UI Foundation, Legal Reference Library
+
+### Feature Layer (Core에 의존)
+1. **Reasoning Workspace** (#6) — depends on: Case Data Schema, UI Foundation, Case File Browser, Legal Reference Library
+2. **Brief Editor** (#7) — depends on: Case Data Schema, UI Foundation, Case File Browser, Reasoning Workspace, Legal Reference Library
+3. **Investigation Slots** (#8) — depends on: Case File Browser, Reasoning Workspace
+4. **Submission & Evaluation** (#9) — depends on: Case Data Schema, Brief Editor
+5. **Verdict Reveal Sequence** (#10) — depends on: UI Foundation, Submission & Evaluation
+6. **Reputation System** (#12) — depends on: Submission & Evaluation
+7. **Career Progression** (#11) — depends on: Case Data Schema, Save/Load, Submission & Evaluation, Reputation System
+8. **Persona System** (#13) — depends on: Case File Browser, Reasoning Workspace, Brief Editor
+9. **Retrospective Replay** (#14) — depends on: Reasoning Workspace, Brief Editor, Submission & Evaluation
+
+### Presentation Layer (Feature 위에 얹는 표시)
+1. **Source Citation** (#15) — depends on: Case File Browser, Reasoning Workspace, Brief Editor, Legal Reference Library
+
+### Polish Layer (메타·전체 의존)
+1. **Tutorial & Onboarding** (#16) — depends on: Case File Browser, Reasoning Workspace, Brief Editor, Investigation Slots
+2. **Meta-Frame** (#17) — depends on: UI Foundation, Save/Load
+3. **Sharing System** (#18) — depends on: Career Progression, Retrospective Replay
+4. **Telemetry** (#19) — cross-cutting (모든 시스템에 attach, 별도 의존성 없음)
+
+---
+
+## Recommended Design Order
+
+| Order | # | System | Priority | Layer | Agent(s) | Est. Effort |
+|-------|---|--------|----------|-------|----------|-------------|
+| 1 | 20 | **Legal Reference Library** | MVP | Foundation | game-designer + technical-director + narrative-director | M |
+| 2 | 1 | Case Data Schema | MVP | Foundation | game-designer + technical-director | S |
+| 3 | 2 | UI Foundation | MVP | Foundation | game-designer + ux-designer + art-director | L |
+| 4 | 3 | Save/Load | MVP | Foundation | game-designer + lead-programmer | S |
+| 5 | 4 | Settings & Accessibility | MVP | Core | ux-designer + accessibility-specialist | S |
+| 6 | 5 | Case File Browser | MVP | Core | game-designer + ux-designer | M |
+| 7 | 6 | Reasoning Workspace | MVP | Feature | game-designer + ux-designer | L |
+| 8 | 7 | Brief Editor | MVP | Feature | game-designer + ux-designer | L |
+| 9 | 8 | Investigation Slots | MVP | Feature | systems-designer | S |
+| 10 | 9 | Submission & Evaluation | MVP | Feature | systems-designer + game-designer | L |
+| 11 | 10 | Verdict Reveal Sequence | MVP | Feature | game-designer + sound-designer + technical-artist | M |
+| 12 | 17 | Meta-Frame | MVP | Polish | ux-designer | S |
+| 13 | 16 | Tutorial & Onboarding | MVP | Polish | game-designer + ux-designer | M |
+| 14 | 12 | Reputation System | VS | Feature | systems-designer | M |
+| 15 | 13 | Persona System (Mentor) | VS | Feature | narrative-director + writer | M |
+| 16 | 15 | Source Citation | VS | Presentation | narrative-director + ux-designer | S |
+| 17 | 11 | Career Progression | Alpha | Feature | systems-designer + game-designer | L |
+| 18 | 14 | Retrospective Replay | Alpha | Feature | game-designer + ux-designer | M |
+| 19 | 18 | Sharing System | Alpha | Polish | ux-designer + community-manager | S |
+| 20 | 19 | Telemetry | Full Vision | Polish | analytics-engineer | M |
+
+> **Effort 정의**: S = 1 세션 (집중 디자인 대화 1회로 GDD 완성). M = 2-3 세션. L = 4+ 세션.
+> **총 예상**: ~47 세션 (S 7개 + M 8개 + L 5개). 단 MVP 범위는 ~27 세션으로 압축 가능.
+
+### 병렬 가능 시점
+- **#20 Library와 #1 Case Schema는 함께 디자인하는 게 자연스러움** — 스키마 결정이 서로 영향. 단 Library의 *데이터 모델*을 먼저 잡고, Case Schema는 그 위에서 *참조 형식* 결정.
+- **Foundation 잔여 (#2 UI Foundation, #3 Save/Load)**는 Library/Case Schema와 병렬 가능.
+- **MVP 폴리시 (#17 Meta-Frame, #16 Tutorial)**는 코어 디자인 후반에 병렬로 작성 가능.
+
+---
+
+## Circular Dependencies
+
+**없음** ✓ — Phase 3 분석 시 그래프 사이클 검출되지 않음.
+
+---
+
+## High-Risk Systems
+
+| System | Risk Type | Risk Description | Mitigation |
+|--------|-----------|-----------------|------------|
+| **#20 Legal Reference Library** | Design + Content | Library 스키마는 *모든 케이스 콘텐츠*의 데이터 구조를 정함. 잘못 디자인되면 모든 케이스를 다시 작성해야 함. 또한 실제 한국 법령·판례를 어떤 단위로 저장하느냐는 자문가 협의 필요 | 변호사·법학자 자문 1회 후 데이터 모델 확정. 첫 케이스 작성과 동시에 Library 시드 데이터 5-10건으로 검증. |
+| **#9 Submission & Evaluation** | Design | "추론 체인의 질" 가중 평가 알고리즘이 비자명. 단순 정답 비교는 쉽지만 *왜 그 결론에 도달했는가*를 평가하는 것은 어려움 | MVP는 단순 정답 비교만, v1+에서 추론 체인 평가 본격. 자문가 1-2인 검수 필수. 5인 플레이테스트로 균형 조정. |
+| **#2 UI Foundation** | Design + Technical | 6개 시스템이 의존하는 최대 보틀넥. 표준 게임 UI 패턴이 아닌 *문서 IDE* 형 UI라 시행착오 많음 | Art Bible 강력한 anchor 제공. 첫 1주차에 페이퍼 → Godot 위젯 프로토타입으로 빠르게 검증. |
+| **#6 Reasoning Workspace** | Design + UX | 가설 트리 + Library 검색 + 메모 통합 UI. 표준 게임 UI 아닌 *Disco Elysium의 Thought Cabinet* 풍 | 가설 트리 단독 프로토타입 우선 (`/prototype reasoning-tree`). MVP는 트리 깊이 2-3단계로 제한. |
+| **#7 Brief Editor** | Design + UX | 텍스트 작성 IDE의 게임화. 자유 입력 vs. 구조화 선택의 균형 | MVP는 *구조화된 선택형* (상고이유 후보 + Library 카드 드래그앤드롭). 자유 텍스트는 v1+ 선택사항. |
+| **#10 Verdict Reveal Sequence** | Design | MVP의 카타르시스 모먼트. 작동하지 않으면 MVP 가설 NO. 너무 화려하면 게임 톤 무너짐 | Art Bible Section 7 그대로. 첫 케이스에서만 검증, 폴리시는 VS 단계. |
+| **#16 Tutorial & Onboarding** | Design | 한국 법학 모르는 플레이어가 첫 30분 포기 시 컨셉 검증 불가. 단 안티필러("드라마 없음")가 가벼운 톤 막음 | 첫 케이스 자체를 *튜토리얼-케이스 하이브리드*. 멘토 NPC의 절제된 코멘트가 가이드. 5인 테스트로 첫 30분 이탈률 측정. |
+
+---
+
+## Progress Tracker
+
+| Metric | Count |
+|--------|-------|
+| Total systems identified | 20 |
+| Design docs started | 5 (#20 Library — Reviewed Provisional / #1 Case Data Schema — Designed / #5 Case File Browser — Designed Provisional / #9 Submission & Evaluation — Designed + lean review revisions 2026-05-06 / **#6 Reasoning Workspace — Designed Provisional + cycle 2 cascade applied + ADR-0008 Proposed 2026-05-07**) |
+| Design docs reviewed | 2 (#20 — Reviewed Provisional, 3/5 blockers resolved + ADR-0001 Accepted; 2 deferred to lawyer review / **#6 — /design-review 2026-05-07 verdict MAJOR REVISION NEEDED**) |
+| Design docs approved | 0 |
+| MVP systems designed | 5 / 13 (#20 Provisional · #1 Designed · #5 Provisional · #9 Designed · **#6 NEEDS REVISION**) |
+| Vertical Slice systems designed | 0 / 3 |
+| Alpha systems designed | 0 / 3 |
+| Full Vision systems designed | 0 / 1 |
+
+---
+
+## Next Steps
+
+- [x] ✅ #20 Library — Reviewed Provisional + ADR-0001 Accepted
+- [x] ✅ #1 Case Data Schema — Designed + ADR-0003 Accepted
+- [x] ✅ #5 Case File Browser — Designed Provisional + ADR-0004 Proposed
+- [x] ✅ #9 Submission & Evaluation — Designed + lean review revisions 2026-05-06 + ADR-0007 Proposed
+- [x] ✅ #6 Reasoning Workspace — Designed 2026-05-06 (lean; pending /design-review; §9 PROVISIONAL pending Workspace Layout ADR)
+- [x] ✅ /design-review #6 — 2026-05-07 — Verdict **MAJOR REVISION NEEDED** (11 BLOCKING + 23 IMPORTANT; 6 specialist + creative-director synthesis; review log: design/gdd/reviews/reasoning-workspace-review-log.md)
+- [ ] **다음 권장**: 새 세션에서 #6 revision — 3 design gate 결정 우선 (① DAG vs Tree 스키마 · ② evidence_density 메커니즘 · ③ §3.3 시그널 토폴로지) 후 cascade 재작성 (§2/§3.1/§4.3/§5.1/§8.1.1)
+- [ ] Foundation 잔여 (#2 UI Foundation, #3 Save/Load)는 병렬 작성 가능
+- [ ] #7 Brief Editor — Reasoning Workspace chain_data 입력 계약 잠긴 후 unblocked
+- [ ] ADR Verification → Acceptance: ADR-0004 (5건 verification) + ADR-0007 (3건 verification + EvaluationService 구현)
+- [ ] 후속 ADR — ADR-0005 (External Research Tool Stack 30분 retrofit), Workspace Layout ADR (OQ-W5/W9/W10 ratify), Browser Layout ADR (Browser §6 OQ-8)
+- [ ] MVP 시스템 GDD 완료 시마다 `/design-review design/gdd/[system].md`
+- [ ] MVP 13개 GDD 완료 후 `/review-all-gdds`로 일관성 검증
+- [ ] 그 후 `/create-architecture`로 마스터 아키텍처 문서 작성
+- [ ] `/gate-check pre-production`으로 프로덕션 진입 게이트 통과
+
+### Cross-system MVP-gate Tracks (NEW 2026-05-06)
+
+- **Client Voice 트랙 (Option D 하이브리드 — locked 2026-05-06)**: 의뢰인 *목소리*를 Brief 봉투 안에 *글로만* 통합 (대화 X, 신규 시스템 X — paper-based authenticity 유지하면서 Pillar 4·5 충돌 해소). 액션:
+  - case-data-schema **OQ-7** — `client_letter` / `family_statement` / `lower_court_lawyer_memo` optional 필드 (≤2000/2000/1000 char) 정식 §3.1 Core Rules 진입
+  - case-file-browser **OQ-9** — BriefOpen 단계 *Voice 패널* 또는 *서신 첨부* 영역 신설; Theme type variation `&"LetterLabel"` / `&"StatementLabel"` / `&"MemoLabel"` 변형 (Art Bible §6 + ADR-0004 갱신 필요)
+  - **Target**: 첫 시드 케이스 fixture 작성 직전 (MVP 진입 게이트 통과 전)
+  - **VS 확장 트래커**: #13 Persona System에 *반복 의뢰인* 카테고리 추가 (case-file-browser **OQ-10**) — Pillar 4 *끝나도 따라온다* 핵심 구현. #13 GDD 작성 시 정의.

--- a/design/registry/entities.yaml
+++ b/design/registry/entities.yaml
@@ -36,8 +36,8 @@
 #   Sections: entities | items | formulas | constants
 #   Each entry: name, status, source, referenced_by[], attributes{}, added, revised
 
-version: 1
-last_updated: ""
+version: 9
+last_updated: 2026-05-07
 
 # ─── ENTITIES ────────────────────────────────────────────────────────────────
 # Named game-world objects: enemies, NPCs, characters, factions, bosses.
@@ -139,7 +139,441 @@ formulas: []
 #
 # Required fields: name, status, source, referenced_by, value, unit, added
 
-constants: []
+constants:
+  - name: library_id_format_law
+    status: active
+    source: design/gdd/legal-reference-library.md
+    referenced_by:
+      - design/gdd/legal-reference-library.md
+    value: "law:[slug]-art-[N]"
+    unit: id_format
+    notes: |
+      법령 항목 ID 형식. slug는 영문(예: criminal-act),
+      N은 조 번호. 케이스의 correct_citations[] 및 다른 시스템의
+      참조에서 이 형식을 따른다. 예: law:criminal-act-art-250.
+      Provisional — 자문 검수 후 잠금.
+    added: 2026-05-04
+    revised: ""
+
+  - name: library_id_format_case
+    status: active
+    source: design/gdd/legal-reference-library.md
+    referenced_by:
+      - design/gdd/legal-reference-library.md
+    # 2026-05-04 revised v3 — Q5-A direct DRF (형법 376 KB) + Q5-B 헌재 8부호 검증 추가.
+    # Old value: "case:[year][code][seq]"
+    # Old notes (v1): "code는 사건부호 영문화 (도→do, 다→da, 누→nu, 노→no, 헌바→heonba ...)" — 누를 Supreme Court 행정으로 잘못 분류.
+    # v2 (2026-05-04 lexguard): 18개 부호 중 10개(Supreme 6 + High 2 + District 2) 검증, 헌재 8개 미검증.
+    # v3 (2026-05-04 후속): 헌재 8개 부호 직접 DRF(target=detc) 검증 완료. 절차 분류 추가.
+    #   Source: production/research/legal-corpus/q05-hanja-and-case-codes/q05b-constitutional-codes.md
+    value: "case:[court-prefix?][year][code][seq]"
+    unit: id_format
+    notes: |
+      판결 항목 ID 형식. 한국 사법부 사건부호 — 4계층 (Q5 검증 2026-05-04):
+        Supreme Court: 도 do (형사) | 다 da (민사) | 두 du (행정)
+                       모 mo (형사 결정/재항고) | 므 meu (가사) | 스 seu (가사 특별)
+        High Court:    노 no (형사 항소) | 누 nu (행정 항소)
+                       나 na (민사 항소, 미검증) | 르 reu (가사 항소, 미검증)
+        District Court: 고합 gohap (형사 합의) | 가단 gadan (민사 단독)
+                        가합 gahap, 고단 godan, 구합 guhap — 미검증
+        Constitutional Court (verified 2026-05-04 via direct DRF target=detc):
+                        헌가 heonga (위헌법률심판제청) | 헌나 heonna (탄핵심판)
+                        헌다 heonda (정당해산심판)     | 헌라 heonra (권한쟁의심판)
+                        헌마 heonma (§68① 헌법소원)   | 헌바 heonba (§68② 헌법소원)
+                        헌사 heonsa (가처분)           | 헌아 heona  (재심)
+      예: case:2019do1234 (대법원). 하급심은 court-prefix 슬러그 옵션
+      (예: case:seoul-high-2024nu56537, case:busan-2024gohap56).
+      헌재 예: case:2013heonda1, case:2024heonna2.
+      Pre-1998 행정사건은 누 at 대법원 — 게임 timeline post-1998 권장 (era clash 회피).
+      Romanization: MOCT Revised Romanization 2000 (ㅡ→eu, ㅓ→eo).
+      헌재 분포 추정 (q05b-constitutional-codes.md 100-row sample): 헌마 86% · 헌바 8% · 헌아 4% · 헌가 2%
+      나머지 4개(헌나/헌다/헌라/헌사)는 위헌 keyword에서는 미surface — MVP 30건 fixture 시 헌마/헌바 위주.
+    added: 2026-05-04
+    revised: 2026-05-04
+    revised_note: |
+      v3: Q5-B 헌재 8부호 검증 완료(direct DRF). 4계층 매핑으로 확장.
+      절차 분류 추가(위헌제청/탄핵/정당해산/권한쟁의/§68①·②/가처분/재심).
+
+  - name: library_id_format_holding
+    status: active
+    source: design/gdd/legal-reference-library.md
+    referenced_by:
+      - design/gdd/legal-reference-library.md
+    value: "[case-id]/holding-[N]"
+    unit: id_format
+    notes: |
+      판시 단락 ID 형식. case ID 뒤에 /holding-N 접미. N은 1부터.
+      한 판결문이 여러 판시사항을 담을 때 단락별로 분리된 항목.
+      예: case:2019do1234/holding-1.
+    added: 2026-05-04
+    revised: ""
+
+  - name: library_court_grades
+    status: active
+    source: design/gdd/legal-reference-library.md
+    referenced_by:
+      - design/gdd/legal-reference-library.md
+    value: "[constitutional, supreme_panel, supreme_division, lower]"
+    unit: enum
+    notes: |
+      판례 항목의 court_grade 필드 enum. 4계층 — 헌법재판소 /
+      대법원 전원합의체 / 대법원 소부 / 하급심(고법+지법). Art Bible
+      Section 6의 3계층 보더 체계는 4계층으로 확장 필요 (전합 배지 추가).
+    added: 2026-05-04
+    revised: ""
+
+  - name: library_law_types
+    status: active
+    source: design/gdd/legal-reference-library.md
+    referenced_by:
+      - design/gdd/legal-reference-library.md
+    value: "[법률, 시행령, 시행규칙, 조례]"
+    unit: enum
+    notes: |
+      법령 항목의 law_type 필드 enum. 한국 법령 위계 4종.
+      법령 종류 필터(검색·필터 UI) 기준.
+    added: 2026-05-04
+    revised: ""
+
+  - name: library_dispositions_court
+    status: active
+    source: design/gdd/legal-reference-library.md
+    referenced_by:
+      - design/gdd/legal-reference-library.md
+      - design/gdd/case-data-schema.md
+      - design/gdd/submission-evaluation.md
+      - docs/architecture/adr-0001-amend-1-schema-refinement.md
+    # 2026-05-04 v4 — renamed from `library_dispositions` per ADR-0001 Amendment 1.
+    # Old name (v3): library_dispositions — covered all courts.
+    # v4 split: court (대법원·하급심) vs constitutional (헌재) — DRF가 supreme 미반환 + 헌재 enum 별도.
+    value: "[파기, 기각, 각하, 파기환송]"
+    unit: enum
+    applies_when: "court_grade in [supreme_panel, supreme_division, lower]"
+    notes: |
+      판례 항목의 disposition(주문) 필드 enum — *법원 트랙*. 게임 제목과 직결되는
+      "파기"가 카타르시스 모먼트 (#10 Verdict Reveal Sequence)의
+      핵심 결과 표기. v1+에 부분 파기, 환송 변형 등 확장 가능.
+      DRF에서 supreme 판례 disposition을 반환하지 않을 수 있음 — 빈 문자열 허용.
+    added: 2026-05-04
+    revised: 2026-05-04
+    revised_note: |
+      v4: ADR-0001 Amendment 1로 rename (library_dispositions → library_dispositions_court).
+      applies_when 추가 — 헌재 트랙은 library_dispositions_constitutional로 분리.
+
+  - name: library_dispositions_constitutional
+    status: active
+    source: design/gdd/legal-reference-library.md
+    referenced_by:
+      - design/gdd/legal-reference-library.md
+      - docs/architecture/adr-0001-amend-1-schema-refinement.md
+    value: "[기각, 인용, 각하, 위헌, 합헌, 한정합헌, 한정위헌]"
+    unit: enum
+    applies_when: "court_grade == constitutional"
+    notes: |
+      판례 항목의 disposition 필드 enum — *헌법재판소 트랙*. 헌재 결정의
+      종국 형태. 절차별 분포 (Q5-B 검증):
+        헌가(위헌제청)·헌바(§68②): 위헌/합헌/한정합헌/한정위헌
+        헌마(§68①): 인용/기각/각하
+        헌나(탄핵): 인용/기각/각하 (부분인용 시 절별 분리 — prec-002 surface)
+        헌다(정당해산): 인용/기각/각하
+        헌라(권한쟁의): 인용/기각/각하
+        헌사(가처분)·헌아(재심): 별도 처리 (각하/기각 위주)
+      탄핵·정당해산처럼 *부분인용*인 경우 disposition 필드는 종국 분류만 보유 —
+      절별 부분인용 정보는 holdings[].marker 단위로 표현.
+    added: 2026-05-04
+    revised: ""
+
+  - name: library_brief_cite_token
+    status: active
+    source: design/gdd/legal-reference-library.md
+    referenced_by:
+      - design/gdd/legal-reference-library.md
+    value: "{{cite:<library_id>}}"
+    unit: token_format
+    notes: |
+      상고이유서(#7 Brief Editor) 본문에 Library 인용을 임베드하는
+      인라인 토큰 형식. 렌더링 시 Library가 카드 데이터를 인라인
+      인용 블록으로 제공. 토큰 형식 안정성은 Library가 보장 —
+      향후 ID 형식 변경 시 마이그레이션 책임도 Library.
+    added: 2026-05-04
+    revised: ""
+
+  - name: case_data_id_format
+    status: active
+    source: design/gdd/case-data-schema.md
+    referenced_by:
+      - design/gdd/case-data-schema.md
+      - docs/architecture/adr-0003-case-data-storage-format.md
+    value: "case_data:[year]-[seq]"
+    unit: id_format
+    notes: |
+      게임 풀 케이스(플레이어가 푸는 사건) ID 형식. Library의 `case:` (실제
+      한국 판례)와 명시적으로 구별 — case_data: 11자 prefix, case: 5자 prefix.
+      year는 4자리 (예: 2026), seq는 3자리 zero-pad (001-999).
+      예: case_data:2026-001
+      ADR-0003 §Implementation Guideline #2.
+    added: 2026-05-05
+    revised: ""
+
+  - name: case_court_tracks
+    status: active
+    source: design/gdd/case-data-schema.md
+    referenced_by:
+      - design/gdd/case-data-schema.md
+      - design/gdd/case-file-browser.md
+      - docs/architecture/adr-0003-case-data-storage-format.md
+    value: "[supreme_division, supreme_panel, lower]"
+    unit: enum
+    notes: |
+      케이스의 court_track 필드 enum (MVP 범위). v1+ constitutional 추가 (OQ-4).
+      Library library_court_grades와 의미적 mirror — 케이스 측은 헌재 케이스 부재(MVP),
+      Library 측은 모든 4계층 보유. Case File Browser §3.5 카테고리 필터 토글이
+      이 enum에 1:1 매핑 (3 토글 + 다중 선택).
+    added: 2026-05-05
+    revised: 2026-05-05
+    revised_note: "Case File Browser referenced_by 추가."
+
+  - name: case_required_scoring_keys
+    status: active
+    source: design/gdd/case-data-schema.md
+    referenced_by:
+      - design/gdd/case-data-schema.md
+      - design/gdd/submission-evaluation.md
+      - docs/architecture/adr-0003-case-data-storage-format.md
+    value: "[disposition_match, core_citation_coverage, chain_coherence]"
+    unit: enum
+    notes: |
+      모든 케이스의 scoring_weights Dictionary가 반드시 보유해야 하는 키 셋.
+      EC-3 검증 입력. 추가 키(redundant_citation_penalty, precedent_seniority_bonus)는
+      optional — 부재 시 0.0 default. CaseService._validate_and_register()가 강제.
+      Submission & Evaluation §3.1.3는 5 키 모두 알고리즘에 구현 — chain/seniority는 MVP w=0 잠금.
+    added: 2026-05-05
+    revised: 2026-05-05
+    revised_note: "Submission & Evaluation referenced_by 추가."
+
+  - name: case_disposition_match_minimum_weight
+    status: active
+    source: design/gdd/case-data-schema.md
+    referenced_by:
+      - design/gdd/case-data-schema.md
+      - design/gdd/submission-evaluation.md
+      - docs/architecture/adr-0003-case-data-storage-format.md
+    value: 0.4
+    unit: weight
+    notes: |
+      Pillar 1 (Truth Is Weighted) 가드. 모든 케이스는 disposition_match 가중치
+      >= 0.4 보유 (case-data-schema §AC-9). 미충족 시 케이스 비활성화.
+      디자인 의도: 정답 처분 자체의 비중이 inference chain coherence보다 약하지
+      않게 — pillar 보호. Submission & Evaluation §AC-19·20에서 이 잠금이
+      "처분만으로 파기 카타르시스 차단" Pillar 가드의 수학적 기반.
+    added: 2026-05-05
+    revised: 2026-05-05
+    revised_note: "Submission & Evaluation referenced_by 추가."
+
+  - name: case_browser_states
+    status: active
+    source: design/gdd/case-file-browser.md
+    referenced_by:
+      - design/gdd/case-file-browser.md
+      - design/gdd/case-data-schema.md
+      - design/gdd/submission-evaluation.md
+    value: "[CatalogIdle, EnvelopeOpening, BriefOpen, FactsOpen, WorkspaceHandoff, SubmissionPending, VerdictArrived, CatalogFiltered]"
+    unit: state_machine
+    notes: |
+      Case File Browser의 *화면 상태 머신* — case-data-schema §3.2의 *케이스
+      lifecycle 상태*(Catalog/LowerCourtBrief/FactsLoaded/InProgress/Submitted/Resolved)
+      와 별개. Browser 상태가 *플레이어가 지금 무엇을 보고 있는가*라면 케이스
+      lifecycle은 *데이터 측 진행도*. case-file-browser §3.2 + 8.2가 두 머신의
+      매핑을 명시.
+        Browser CatalogIdle ↔ 케이스 lifecycle Catalog
+        Browser BriefOpen   ↔ 케이스 LowerCourtBrief
+        Browser FactsOpen   ↔ 케이스 FactsLoaded
+        Browser WorkspaceHandoff ↔ 케이스 InProgress (#6 위임)
+        Browser SubmissionPending ↔ 케이스 Submitted (#9 위임)
+        Browser VerdictArrived → 케이스 Resolved (Catalog 갱신 후 CatalogIdle 복귀)
+    added: 2026-05-05
+    revised: ""
+
+  - name: case_browser_pane_widths_px
+    status: active
+    source: design/gdd/case-file-browser.md
+    referenced_by:
+      - design/gdd/case-file-browser.md
+    value: "{catalog: 480, library_max: 470, library_min: 320, viewport_min: 1280}"
+    unit: pixels
+    notes: |
+      Case File Browser 3-Pane 레이아웃의 가로 px. 1920w 기준 CatalogPane 480 +
+      LibraryPane 470 (DeskPane 잔여 ~970). 1280w 기준 LibraryPane은 320으로
+      클램프 (DeskPane ~472). 미만 viewport는 EC-8 발동 (#2 UI Foundation v1+).
+      MVP 잠금 — 변경 시 case-file-browser §4.4 + AC-1·AC-2 동시 갱신.
+    added: 2026-05-05
+    revised: ""
+
+  - name: case_browser_envelope_animation_ms
+    status: active
+    source: design/gdd/case-file-browser.md
+    referenced_by:
+      - design/gdd/case-file-browser.md
+      - design/art/art-bible.md
+    value: 400
+    unit: milliseconds
+    notes: |
+      봉투 개봉 애니메이션 길이 (case-file-browser §3.2 EnvelopeOpening 상태
+      + Art Bible §6 문서 1 — 0.4s 종이 플랩). 안전 범위 350-500. 너무 짧으면
+      종이 질감 상실, 너무 길면 진입 압박 (Pillar 4 가드). 애니메이션 락 시간
+      =이 값 — LibraryPane 입력 무시 (case-file-browser AC-12).
+    added: 2026-05-05
+    revised: ""
+
+  - name: submission_verdict_thresholds
+    status: active
+    source: design/gdd/submission-evaluation.md
+    referenced_by:
+      - design/gdd/submission-evaluation.md
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    # Old value (v1, 2026-05-05): "{pagi: 0.7, pagi_hwansong: 0.5, gigak: 0.3}" — 3 thresholds
+    # 2026-05-07 v2 — submission-evaluation lean review BLOCKING #1 closure (2026-05-06): 파기환송 임계값 0.5→0.3 (disp_match 시) 잠금. §7.1 thresholds 표 3행→2행 통합 (verdict_threshold_low 0.3 — 파기환송·기각 공유). 학습 곡선 보존 + Pillar 1 가드 유지 + Anti-Pillar 가드(관대 정책). consistency-check 2026-05-07 cycle 2에서 staleness 검출 + autonomous patch 적용.
+    value: "{pagi: 0.7, low: 0.3}"
+    unit: thresholds
+    notes: |
+      Submission & Evaluation §3.1.4 verdict 결정 임계값. 글로벌 잠금
+      — 모든 케이스가 동일 평가 룰 (Pillar 1 가드). final_score [0.0, 1.0]
+      범위에서 4 verdict 매핑 (lean review 2026-05-06 후):
+        player_disp == correct AND score >= 0.7 → 파기
+        player_disp == correct AND 0.3 <= score < 0.7 → 파기환송 (관대 정책 — 학습 곡선 보존)
+        player_disp != correct AND score >= 0.3 → 기각
+        otherwise → 각하
+      MVP playtest 5인에서 4 verdict 모두 surface 되는지 측정 후 보정 (OQ-7).
+      안전 범위: pagi 0.6-0.8, low 0.2-0.4. 두 threshold만 — pagi_hwansong 폐기.
+    added: 2026-05-05
+    revised: 2026-05-07
+    revised_note: |
+      v2: lean review BLOCKING #1 closure (2026-05-06) 후 registry staleness가 consistency-check
+      cycle 2 (2026-05-07)에서 검출 + autonomous patch 적용. pagi_hwansong: 0.5 폐기 → low: 0.3
+      단일 임계값으로 통합. ADR-0007 referenced_by 추가 (entities.yaml constants를 이 ADR이 EvaluationService autoload에서 로드).
+
+  - name: submission_redundant_penalty_cap
+    status: active
+    source: design/gdd/submission-evaluation.md
+    referenced_by:
+      - design/gdd/submission-evaluation.md
+    value: "{cap: -0.3, ratio_multiplier: 0.5}"
+    unit: penalty_cap
+    notes: |
+      Submission & Evaluation §4.3 redundant_citation_penalty 계산 파라미터.
+        penalty = -min(cap, redundant_ratio × ratio_multiplier)
+      cap=-0.3 — 무관 인용 다수여도 평가 자체가 무력화되지 않도록 (50% 무관
+      = -0.25). Anti-Pillar 가드 + Pillar 3 (사고 만이 압박이다) 가드 — 스팸
+      인용 회피. 안전 범위: cap -0.5 ~ -0.2, multiplier 0.3-0.8.
+    added: 2026-05-05
+    revised: ""
+
+  - name: submission_state_machine
+    status: active
+    source: design/gdd/submission-evaluation.md
+    referenced_by:
+      - design/gdd/submission-evaluation.md
+    value: "[Idle, Validating, Computing, Reporting, Done]"
+    unit: state_machine
+    notes: |
+      EvaluationService autoload의 5-state 머신 (Submission & Evaluation §3.2).
+      case lifecycle (Submitted→Resolved) + Browser 상태 (SubmissionPending→
+      VerdictArrived)와 별개 — *평가 진행* 측 상태. 정상 흐름:
+        Idle → Validating → Computing → Reporting → Done → Idle
+      검증 실패 시 Validating → Idle (submission_rejected 시그널 + EvaluationResult
+      미생성). 이중 제출(EC-7)은 두 번째 호출 거부. Browser SubmissionPending
+      ↔ {Validating, Computing, Reporting} 매핑 / Browser VerdictArrived ←
+      Done 직전 evaluation_completed 시그널.
+    added: 2026-05-05
+    revised: ""
+
+  - name: workspace_max_tree_depth
+    status: active
+    source: design/gdd/reasoning-workspace.md
+    referenced_by:
+      - design/gdd/reasoning-workspace.md
+      - design/gdd/submission-evaluation.md
+    value: 3
+    unit: levels
+    notes: |
+      Reasoning Workspace 가설 트리의 MVP 최대 깊이 (§3.1 Rule 2 + §7.1).
+      루트=0 / 자식=1 / 손자=2 / 증손자=3. "상고이유 → 쟁점 → 판례 근거"
+      3계층 표현 허용. chain_data `max_depth_reached` 상한.
+      안전 범위: 2-5. <2: 가설 트리 무력화 (Pillar 1 가중치 신호 빈약);
+      >5: 인지 과부하 + chain_data 직렬화 비용 선형 확대.
+      v1+ chain_coherence subscore가 normalized_depth 항으로 소비
+      (Reasoning Workspace §4.3 forward declaration).
+    added: 2026-05-06
+    revised: ""
+
+  - name: workspace_evidence_per_node_cap
+    status: active
+    source: design/gdd/reasoning-workspace.md
+    referenced_by:
+      - design/gdd/reasoning-workspace.md
+      - design/gdd/submission-evaluation.md
+    value: 5
+    unit: count
+    notes: |
+      Reasoning Workspace 노드당 최대 evidence 수 (§3.1 Rule 4 + §7.1).
+      `total_evidence_count` 상한 = max_depth_reached × cap × node_count
+      범위. CitationDrop 6번째 거부 — "이 노드에는 인용을 5개까지만
+      첨부할 수 있습니다" hint. evidence_density(node) = len(evidence)/cap
+      (§4.4) 도 이 값을 분모로 사용 — bottom evidence rule (Channel B,
+      Pillar 1 가시화 채널, §8.1.1.b) 길이 ρ × node_inner_width.
+      안전 범위: 3-8. <3: 인용 전략 폭 협소; >8: 인용 희석 + bottom rule
+      6단계 ≫ 9단계로 이산 인지성 저하 (40px 단계 → 25px 미만).
+    added: 2026-05-06
+    revised: 2026-05-07 (bottom evidence rule 채널 도입 — Gate ② decisions-2026-05-07)
+
+  - name: workspace_node_label_char_limit
+    status: active
+    source: design/gdd/reasoning-workspace.md
+    referenced_by:
+      - design/gdd/reasoning-workspace.md
+    value: 60
+    unit: characters
+    notes: |
+      Reasoning Workspace HypothesisNode 레이블 길이 cap (§3.1 Rule 1·3 + §7.1).
+      노드 시각 200×48px 카드의 텍스트 영역에 본명조 SemiBold 16pt 기준
+      최대 한글 ~30자, Pretendard 14pt ~60자 (Art Bible §3.1).
+      안전 범위: 30-120. <30: 가설 문장 절단 불가피;
+      >120: 카드 레이아웃 붕괴 (200×48px 제약 충돌).
+    added: 2026-05-06
+    revised: ""
+
+  - name: workspace_node_memo_char_limit
+    status: active
+    source: design/gdd/reasoning-workspace.md
+    referenced_by:
+      - design/gdd/reasoning-workspace.md
+    value: 500
+    unit: characters
+    notes: |
+      Reasoning Workspace HypothesisNode 메모 길이 cap (§3.1 Rule 5 + §7.1).
+      `RichTextLabel scroll_active=true` 활성화 임계 (10+ 라인 본문). chain_data
+      `memo_length` 필드는 이 값까지의 character count (UTF-8 codepoint 기준,
+      AC-9). **메모 본문은 chain_data 미포함** (Pillar 1 guard — 평가는 인용·구조,
+      글쓰기 실력 X). 안전 범위: 200-2000. <200: 사고 보조 무력화;
+      >2000: #7 Brief Editor 역할 침범.
+    added: 2026-05-06
+    revised: ""
+
+  - name: workspace_delete_confirmation_subtree_threshold
+    status: active
+    source: design/gdd/reasoning-workspace.md
+    referenced_by:
+      - design/gdd/reasoning-workspace.md
+    value: 0
+    unit: count
+    notes: |
+      Reasoning Workspace 노드 삭제 확인 다이얼로그 발동 임계 (§3.1 Rule 3 + §7.4).
+      Default 0 = 모든 삭제에서 확인 다이얼로그 강제 — Pillar 3 ("사고 만이
+      압박이다") *cut* 앵커 보존. 시간 압박 0의 게임에서 확인 다이얼로그가
+      유일한 마찰 포인트. 변경 전 game-designer 검토 의무. 안전 범위: 0-5.
+      >5: 깊은 서브트리 삭제도 즉시 실행 — Pillar 3 약화.
+    added: 2026-05-06
+    revised: ""
 
 # Example:
 #

--- a/docs/architecture/adr-0008-workspace-layout.md
+++ b/docs/architecture/adr-0008-workspace-layout.md
@@ -1,0 +1,314 @@
+# ADR-0008: Workspace Layout — Pane Composition, Signal Topology, Drag-Drop API
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-07
+
+## Last Verified
+
+2026-05-07
+
+## Decision Makers
+
+kjuioqq8@gmail.com (PO) + technical-director (architecture lead) + godot-specialist (engine validation) + ux-designer + art-director (visual fitness review). Reasoning Workspace GDD #6 §6.4 Pending dependency closure.
+
+## Summary
+
+Reasoning Workspace의 DeskPane 내부 Control 토폴로지·CitationDrop signal vs Godot native drag-drop API 선택·메모 패널 위치 fallback ratify·gamepad two-step 패턴·트리 panning 구현을 잠금. Reasoning Workspace GDD §3.3 시그널 contract + Gate ③ 4 invariant를 위반하지 않는 범위에서 emitter·channel·layout 구체를 결정한다 (§8.1.1.b inner padding은 GDD에서 직접 lock된 상태이므로 본 ADR scope 외).
+
+## Engine Compatibility
+
+| Field | Value |
+|-------|-------|
+| **Engine** | Godot 4.6 |
+| **Domain** | UI / Scripting (Control hierarchy + native drag-drop callbacks + signal topology) |
+| **Knowledge Risk** | MEDIUM — Godot 4.6 native drag-drop API (`_get_drag_data` / `_can_drop_data` / `_drop_data`)는 Godot 4.0+ stable이나 `at_position` coordinate space + `set_drag_preview()` Control 책임 + AccessKit 연동은 4.5/4.6 release 변동 가능성 |
+| **References Consulted** | `docs/engine-reference/godot/VERSION.md` (4.6 pinned); `docs/engine-reference/godot/modules/control.md` 추정 — godot-specialist 2026-05-07 cycle 2 검증; `docs/engine-reference/godot/deprecated-apis.md` (`OS.get_ticks_msec` deprecated since 4.0 — `Time.get_ticks_msec` 사용); ADR-0004 (Theme type variations); ADR-0007 (EvaluationService autoload) |
+| **Post-Cutoff APIs Used** | None — `Control._get_drag_data` / `_can_drop_data` / `_drop_data` 모두 4.0+ stable. AccessKit `accessibility_role` properties는 Godot 4.5+ — 본 ADR이 Godot 4.5+ 의존을 명시. |
+| **Verification Required** | (1) `Control._drop_data(at_position: Vector2, data)` 호출 시 `at_position` 좌표계 (DeskPane local 추정 — godot-specialist Item 6 검증 의무); (2) `set_drag_preview(preview: Control)` ghost rendering이 70% opacity + grip dot indicator 정합성 — UI Foundation prototype 측정; (3) AccessKit `ROLE_TREE` + `ROLE_TREE_ITEM` 스크린 리더 출력 측정 (NVDA / VoiceOver / Orca 3 OS) — UI Foundation epic |
+
+## ADR Dependencies
+
+| Field | Value |
+|-------|-------|
+| **Depends On** | ADR-0001 (Library Storage Format — `LibraryService` autoload + Library ID 형식); ADR-0004 (Korean Text Rendering — Theme type variations + RichTextLabel + AccessKit 의존); ADR-0007 (Submission Evaluation Algorithm — `EvaluationService.submit()` + `submission_rejected` / `evaluation_completed` 시그널 입력 계약) |
+| **Enables** | Reasoning Workspace GDD §6.4 Pending hard-gate 해제 (§9 PROVISIONAL → LOCKED 전환); UI Foundation epic 진입 (Workspace 화면 Control class 구체 ratify); #6 구현 스토리 시작 unblock |
+| **Blocks** | Reasoning Workspace GDD #6 구현 스토리 전체 (본 ADR Accepted 전 시작 X); #2 UI Foundation epic Pane resizing 작업 (본 ADR이 layout topology 잠금) |
+| **Ordering Note** | UI Foundation epic 진입 전 본 ADR Accepted 필수. #4 Settings & Accessibility GDD는 *parallel track* — 본 ADR과 무관하게 진행 가능 (Workspace 자체는 #4 reduced_motion / text_scale / KB remap API 의존, 그러나 Layout 결정은 #4 부재 시에도 가능). |
+
+## Context
+
+### Problem Statement
+
+Reasoning Workspace GDD #6 §6.4 Pending dependency 4건 ratify 필요:
+
+1. **OQ-W5 메모 패널 fallback ratify** — GDD §9.3에서 (A) inline 권고 + (B) fixed bottom-right fallback. Trigger threshold 명시 (DeskPane width < 720px 또는 inline panel overlap) 후 fallback 발동 시점 잠금 미완.
+2. **OQ-W9 gamepad CitationDrop 두 단계 discrete 대안** — A button mark / A button attach / B button cancel 패턴 mirror, 정확한 floating 배지 위치·취소 경로·feedback 시점 잠금 미완.
+3. **OQ-W10 트리 panning** — right-stick analog vs D-pad scroll vs auto-center on focused node, 4-deep + 3+ root at 566px DeskPane floor 시 동작 미잠금.
+4. **OQ-W13 CitationDrop signal topology** — autoload `LibraryService` vs scene node `LibraryPane` 발신자 + Godot 4.6 native drag-drop API (`_get_drag_data` / `_can_drop_data` / `_drop_data`) vs autoload signal vs hybrid. Gate ③ contract만 잠금, 구체 위임.
+
+GDD §3.3 Gate ③ 4 invariant는 본 ADR이 위반 부재로 보장 의무:
+- Drag-start notification 정확히 1회 per drag
+- Drop-completion 페이로드 `library_id` + `viewport_position` (또는 등가) 필수
+- Workspace State == FROZEN/READ_ONLY 시 native API `_can_drop_data` callback false 반환 (또는 signal 채널 drop 무시)
+- Library Subsystem은 Workspace hit-test 결과 직접 관찰 X — Workspace 자기 책임
+
+### Constraints
+
+- ADR-0001 + ADR-0007 두 ADR이 정의한 LibraryService / EvaluationService autoload 패턴 mirror.
+- Reasoning Workspace GDD §8.1.1.b inner padding spec 본 GDD에서 lock — *본 ADR scope 외*.
+- ADR-0004 forbidden_pattern `inline_theme_override_without_type_variation` — Workspace UI Control은 모두 Theme type variation 사용.
+- Godot 4.6 native drag-drop API는 *function callbacks* (signal 아님) — `_get_drag_data`는 drag 초기화 시 *한 번* 호출, `_can_drop_data` / `_drop_data`는 hover/drop 시 호출.
+- AccessKit role floor (Reasoning Workspace GDD §9.6 lock): canvas root `ROLE_TREE`, 노드 `ROLE_TREE_ITEM` — 본 ADR이 Control 선택에서 보장.
+- Gamepad critical path 의무 (technical-preferences.md "Gamepad must support all critical gameplay paths") — Workspace는 critical 화면.
+
+### Requirements
+
+- DeskPane 3-pane 컴포지션 (CatalogPane | LibraryPane | DeskPane)에서 DeskPane 내부 Control 트리 구조 잠금.
+- CitationDrop은 LibraryPane card → DeskPane node 단방향 — Workspace State guard (FROZEN/READ_ONLY 차단) 보장.
+- KB CitationDrop (Reasoning Workspace §9.4.2 Space-mark/Space-attach) 구현 가능 — 두 단계 모두 application-level state.
+- 1366×768 floor 해상도에서 4-deep tree + 3+ roots 렌더링 가능 (panning + reflow).
+
+## Decision
+
+### 1. DeskPane Control Hierarchy
+
+DeskPane은 다음 Control 트리로 구성:
+
+```
+DeskPane (PanelContainer with theme_type_variation = &"DeskPane")
+├── DeskCanvas (SubViewportContainer + SubViewport + Node2D for tree canvas)
+│   ├── HypothesisNodeRoot (Node2D — tree container)
+│   │   └── HypothesisNode × N (Control with theme_type_variation = &"HypothesisNode")
+│   │       ├── LabelDisplay (Label, &"NodeLabel" type variation, ellipsis truncation)
+│   │       ├── LabelEditor (LineEdit, &"NodeLabelEdit" — hidden until F2/double-click)
+│   │       ├── EvidenceRule (ColorRect or Line2D — bottom evidence rule, ρ × 184px)
+│   │       └── (no shadow — Art Bible §3 정합)
+│   ├── TreeEdges (Line2D × M — orthogonal L-route, 0.5px 미드그레이 #8C8C8C)
+│   └── DropZoneHint (Panel — invisible until citation_drag_started, 1px 점선 미드그레이)
+├── MemoPanel (PanelContainer — position OQ-W5 resolution 아래)
+│   ├── MemoLabel (RichTextLabel, &"MemoLabel" + scroll_active=true — 펼친 상태 display)
+│   ├── MemoEdit (TextEdit, &"MemoEdit" — 펼친 상태 edit)
+│   └── CharCounter (Label, &"CaptionLabel" — 500/500 with weight Medium on cap)
+├── SubmitButton (Button, &"SubmitButton" — full-width DeskPane footer)
+├── FreezeOverlay (CanvasLayer — DeskPane 전체 덮음, FROZEN 한정)
+│   ├── OverlayDim (ColorRect — 80% 판결지 #F5F2EC)
+│   └── FreezeBanner (PanelContainer — 64px ink-black, &"FreezeBanner")
+│       └── BannerText (Label, &"CourtHeadline" — "제출이 처리 중입니다")
+└── ReadOnlyIndicator (Label — sticky top, READ_ONLY 한정, "제출 완료 — 열람 전용")
+```
+
+**Note**: HypothesisNodeRoot 하위 노드는 `Control` (Node2D 아님) — `_get_drag_data` / `_drop_data` / `_can_drop_data` 콜백 사용 + AccessKit `accessibility_role` property 사용 가능. SubViewportContainer는 panning 지원 (3절 OQ-W10).
+
+### 2. CitationDrop Signal Topology — Hybrid Native + Application-State (OQ-W13 closure)
+
+**채택**: Godot 4.6 native drag-drop API + LibraryService autoload signal *hybrid*. 두 채널 동시 활용:
+
+| Layer | 책임 |
+|---|---|
+| **Native API (`_get_drag_data` / `_can_drop_data` / `_drop_data`)** | LibraryPane 카드의 pointer drag → DeskPane node 직접 drop 경로 처리. KB CitationDrop의 *pointer mirror* — 동일 코드 path 재사용 |
+| **LibraryService signal `citation_drag_started(library_id)`** | DropZoneHint 활성화 *전용* — drag UI 진입 시 LibraryPane이 emit, DeskPane이 hint 활성. exactly-once per drag (Gate ③ invariant 1) |
+| **Application-level pending state (Workspace 자기 보유)** | KB 경로 (Space-mark + Tab + Space-attach) — `WorkspaceData.pending_citation: String` 단일 상태. Native drag와 KB pending은 *동시 활성 불가* — KB Space-mark 시 native drag 진행 중이면 거부 |
+
+#### Signal contract 매핑 (GDD §3.3 ↔ ADR-0008)
+
+| GDD §3.3 의미 | ADR-0008 구현 |
+|---|---|
+| `citation_drag_started(library_id)` 시그널 발신자 | **LibraryService autoload** (LibraryPane scene node가 카드 카드 drag 시작 시 LibraryService.emit_signal 호출 또는 KB Space-mark 시 동일 emit). 단일 emitter는 multi-LibraryPane 인스턴스 시에도 exactly-once 보장 — Gate ③ invariant 1 충족 |
+| `citation_dropped(library_id, viewport_position)` | **Native `_drop_data(at_position, data)`** — DeskPane이 직접 hit-test (signal 없음). `at_position`은 DeskPane Control local 좌표 (Godot 4.6 native API spec) — viewport-to-local 변환 *불필요* (godot-specialist Item 6: GDD §3.3 "viewport_position을 DeskPane 로컬 좌표로 변환" 명시는 native API 채택 시 *no-op*) |
+
+#### Workspace State guard (Gate ③ invariant 3)
+
+DeskPane의 `_can_drop_data(at_position, data)` 콜백은:
+```gdscript
+func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
+    if WorkspaceData.state != WorkspaceState.ACTIVE:
+        return false  # FROZEN / READ_ONLY / INACTIVE 차단
+    if not (data is Dictionary and data.has("library_id")):
+        return false
+    var library_id: String = data["library_id"]
+    var target_node = _hit_test(at_position)
+    if target_node == null:
+        return false
+    return _validate_citation_drop(library_id, target_node)  # Rule 4 정책 (cap·중복·타입)
+```
+
+#### Signal flow (drag start)
+
+LibraryPane 카드 drag 시작 시:
+```gdscript
+# LibraryPane.gd
+func _get_drag_data(at_position: Vector2) -> Variant:
+    var card: LibraryCard = _card_at(at_position)
+    if card == null:
+        return null
+    LibraryService.emit_signal("citation_drag_started", card.library_id)  # Gate ③ invariant 1
+    var preview = _build_drag_preview(card)  # 70% opacity, no grip dot (library-source)
+    set_drag_preview(preview)
+    return {"library_id": card.library_id, "source": "library"}
+```
+
+KB Space-mark 시:
+```gdscript
+# LibraryPane.gd input handler
+func _on_space_pressed_on_focused_card(card: LibraryCard) -> void:
+    LibraryService.emit_signal("citation_drag_started", card.library_id)  # 동일 emit path
+    WorkspaceData.pending_citation = card.library_id  # application-level state
+    _show_pending_badge(card.library_id)  # 좌상단 floating
+    _set_status_bar("[%s] 인용 대기 중. 노드 포커스 후 Space로 첨부" % card.library_id)
+```
+
+#### Library Subsystem 비관찰 (Gate ③ invariant 4)
+
+LibraryService는 `_drop_data` 결과를 직접 관찰 X. Drop 완료 후 Workspace가 CitationDrop accept/reject 결과를 *자기 처리* + 필요시 `LibraryService.notify_citation_attached(library_id, node_id)` 등의 *명시적* 알림 메소드 호출 (LibraryService 측 책임은 logging + telemetry로 한정). LibraryService는 drag 결과를 polling 하지 않는다.
+
+### 3. Memo Panel Position — OQ-W5 Fallback Lock
+
+**채택**: GDD §9.3 (A) inline next to selected node *primary* + (B) fixed bottom-right *fallback* — fallback trigger 명시:
+
+```
+fallback_to_B = (
+    DeskPane.size.x < 720
+    OR
+    (selected_node.global_position.x + selected_node.size.x + 16 + memo_panel_width)
+    > DeskPane.global_position.x + DeskPane.size.x
+)
+```
+
+여기서 `memo_panel_width = 320px` (메모 RichTextLabel 표시 영역 ~24자 width).
+
+`DeskPane._on_node_selected(node)` 또는 `_on_resize()` 시점에 본 술어 평가, true 시 MemoPanel을 (B) 위치(DeskPane 우하단 320×220px 고정)로 reflow. 전환 시 0.15s opacity fade (Reduced Motion 시 즉시 snap — AC-40 정합).
+
+DeskPane width 720px 미만은 1366×768 floor에서 occur 가능 (CatalogPane 480 + LibraryPane clamp 320 + DeskPane 566 → 566 < 720 fallback trigger). 즉 *floor 해상도에서는 (B)가 default*.
+
+### 4. Tree Panning — OQ-W10 Lock
+
+**채택**: SubViewportContainer + SubViewport + Camera2D 패턴 — Camera2D의 position이 panning 상태:
+
+| Input | Action |
+|---|---|
+| Mouse middle-drag (Pan modifier) | Drag delta만큼 Camera2D position 이동 — 1:1 픽셀 panning |
+| Right stick analog (gamepad) | 매 프레임 `camera.position += stick_vector * pan_speed * delta` (pan_speed = 600 px/s) |
+| D-pad navigate (gamepad) | 노드 포커스 이동 후 자동 `camera.position` lerp to focused_node (0.2s) |
+| Tab / Arrow (KB) | 노드 포커스 이동 후 동일 auto-center |
+| Mouse scroll wheel | DeskPane 영역 내에서 vertical pan (스크롤이 0인 경우 default behavior) |
+
+Camera2D 좌표 범위는 `HypothesisNodeRoot`의 bounding box + 200px padding으로 clamp — 트리 외부로 무한 panning 방지.
+
+**1366×768 floor + 4-deep + 3+ root 동작**: 본 panning은 horizontal + vertical 모두 지원 — DeskPane 566px width에서 4-deep linear chain (4 × 200px + spacing ≈ 900px)이 *horizontal scroll* 가능. 3+ root는 vertical 또는 horizontal 분기로 표현 (Layout direction은 default `top-down vertical` per GDD §9.7 — 다중 루트는 horizontal 분기).
+
+### 5. Gamepad CitationDrop Discrete Two-Step — OQ-W9 Lock
+
+**채택**: KB Space-mark/Space-attach 패턴과 동일 mental model의 gamepad mirror:
+
+| Gamepad input | Action |
+|---|---|
+| Focus LibraryPane (LB / RB pane switcher) → focus card (D-pad) | 카드 focus |
+| **A button (LibraryPane card focused)** | "pending citation" 활성화 — 좌상단 floating 배지 + status bar 안내 (KB Space-mark mirror) |
+| Focus DeskPane (LB / RB) → navigate node (D-pad) | 노드 focus |
+| **A button (DeskPane node focused, pending 활성)** | pending 첨부 (Rule 4 정책 적용) |
+| **B button (pending 활성)** | pending 취소 |
+
+floating "인용 대기 중" 배지는 DeskPane 좌상단 inset 16px, 폭 280px 고정, z-order는 Confirmation dialogs 아래 + Tree canvas 위 (GDD §9.1 z-order table 갱신 항목). FROZEN 진입 시 pending이 활성이면 자동 cancel + status bar "제출 처리로 인용 대기 취소".
+
+### 6. UI Foundation Epic 위임 항목 (post-ADR-0008)
+
+다음 3건은 본 ADR이 *boundary*만 명시 + UI Foundation epic prototype에서 actual 측정 후 ratify:
+
+1. **AccessKit 스크린 리더 출력 검증** — NVDA (Windows) / VoiceOver (macOS) / Orca (Linux) 3 OS 출력이 GDD §9.6 expected text와 일치하는지 (ROLE_TREE / ROLE_TREE_ITEM + name + description). 미일치 시 ADR-0004 Theme type variation 또는 본 ADR Control 선택 amendment.
+2. **Drag preview 70% opacity 시각 검증** — `set_drag_preview(preview)` Godot 4.6 rendering이 ghost 70% opacity 정합. node-source ghost는 grip dot indicator (좌상단 6×6px 잉크블랙, ux-designer cycle 2 IMPORTANT closure) — library-source ghost는 indicator 부재.
+3. **AC-49 60fps 30-node 측정** — 본 ADR Control class 결정으로 unblock. 미달 시 본 ADR amendment (Control class 변경 또는 SubViewport rendering 최적화).
+
+## Consequences
+
+### 긍정
+
+- GDD §3.3 Gate ③ 4 invariant 모두 보장 — *implementation-level* 검증 가능 (signal flow + state guard + payload contract).
+- KB CitationDrop과 pointer drag가 *동일 code path 재사용* — `WorkspaceData.pending_citation` 단일 상태 + LibraryService signal 단일 emitter. KB·gamepad·pointer 3 modality 일관.
+- §8.1.1.b inner padding이 GDD에서 lock된 상태에서 본 ADR scope 축소 — Control 토폴로지 + signal topology + panning에 집중.
+- AccessKit role floor가 GDD에서 lock된 상태에서 본 ADR Control 선택이 floor 보장 — UI Foundation epic 진입 시 prototype 측정만 책임.
+- OQ-W5 fallback trigger가 floor 해상도에서 *(B) default* — 1366×768 사용자도 안정적 UX.
+- Panning Camera2D 패턴 — 4-deep + 3+ root + 1366×768 floor 모두 수용.
+
+### 부정 / Trade-off
+
+- Hybrid native + signal topology — code path 2 (native drag + KB pending) maintain 부담. KB와 pointer 의 동기화 (예: pointer drag 진행 중 Space 입력 거부)는 명시적 guard 필요.
+- SubViewportContainer + Camera2D — UI 렌더링 비용 추가 (off-screen rendering buffer). 30-node 60fps 검증 의무 (AC-49 unblock 의존).
+- Library Subsystem 비관찰 (Gate ③ invariant 4) — LibraryService가 telemetry collection 하려면 Workspace 측의 *명시적 알림* 호출 필요 — coupling 1 추가.
+- Memo panel (A) → (B) fallback이 floor 해상도에서 default → playtest는 1080p+ 와 floor 모두 측정 의무.
+- Gamepad pane switcher (LB/RB)가 GDD §9.4.3에 미명시 — 본 ADR 추가 결정 사항. UI Foundation epic이 gamepad input mapping 잠그는 시점에 LB/RB 의미 ratify.
+
+### Migration Plan
+
+1. `src/data/chain_data_schema.gd` 신규 — `SCHEMA_V1_ALLOWED_FIELDS` + `SCHEMA_V1_NODE_FIELDS` const (Reasoning Workspace cycle 2 BLOCKING #13 closure 정합).
+2. `src/data/workspace_data.gd` 신규 — `class_name WorkspaceData extends Resource` + state machine + pending_citation property + invariant 검증 메소드.
+3. `src/scenes/workspace/desk_pane.tscn` + `desk_pane.gd` 신규 — 본 ADR §1 Control 트리.
+4. `src/scenes/workspace/hypothesis_node.tscn` + `hypothesis_node.gd` 신규 — `_get_drag_data` / `_can_drop_data` / `_drop_data` 구현.
+5. `src/scenes/workspace/memo_panel.tscn` + `memo_panel.gd` — (A) inline + (B) fallback reflow 로직.
+6. ADR-0004 Theme type variation 등록 — `&"DeskPane"`, `&"HypothesisNode"`, `&"NodeLabel"`, `&"NodeLabelEdit"`, `&"DropZoneHint"`, `&"FreezeBanner"`, `&"SubmitButton"` 추가 (현재 ADR-0004 §4에 미등록 — amendment 트리거).
+7. `LibraryService` autoload에 `signal citation_drag_started(library_id: String)` 추가 (ADR-0001 amendment 트리거).
+8. Architecture Registry (`docs/registry/architecture.yaml`) 갱신:
+   - api_decisions: `citation_drop_signal_topology_hybrid`, `memo_panel_inline_fallback_threshold`, `tree_panning_camera2d`, `gamepad_pane_switcher_lb_rb`
+   - state_ownership: `workspace_pending_citation_application_level`
+   - forbidden_patterns: `library_subsystem_observe_drop_result` (Gate ③ invariant 4), `chain_data_schema_allow_list_duplication` (cycle 2 BLOCKING #13 closure)
+   - performance_budgets: AC-48 (16ms chain_data build) + AC-49 (60fps 30-node) — 후자는 Workspace Layout ADR Accepted 후 unblock
+
+## ADR Dependencies
+
+본 ADR이 enables / blocks:
+
+- **Enables**: Reasoning Workspace GDD §6.4 Pending hard-gate 해제 + UI Foundation epic 진입 + #6 구현 스토리 시작.
+- **Blocks** (until Accepted): #6 구현 스토리, AC-49 hard gate.
+
+본 ADR이 depends on:
+
+- **Depends on**: ADR-0001 (LibraryService signal addition amendment), ADR-0004 (Theme type variations amendment), ADR-0007 (EvaluationService autoload signal contract).
+
+본 ADR이 trigger amendment 의무:
+
+- **ADR-0001 amendment** — `LibraryService.citation_drag_started` signal 추가 등록.
+- **ADR-0004 amendment** — Theme type variations 7건 추가 (DeskPane, HypothesisNode, NodeLabel, NodeLabelEdit, DropZoneHint, FreezeBanner, SubmitButton + MemoLabel/MemoEdit는 cycle 2에서 이미 surface — 모두 ADR-0004 §4 등재 의무).
+
+## GDD Requirements Addressed
+
+### Reasoning Workspace GDD #6 §6.4 Pending hard-gate (4건 ratify)
+
+- OQ-W5 메모 패널 fallback trigger ratified (§3 본 ADR)
+- OQ-W9 gamepad CitationDrop two-step ratified (§5 본 ADR)
+- OQ-W10 트리 panning ratified (§4 본 ADR)
+- OQ-W13 CitationDrop signal topology + drag-drop API ratified (§2 본 ADR — hybrid native + LibraryService signal)
+
+### Reasoning Workspace GDD §3.3 Gate ③ 4 invariant 보장
+
+- Invariant 1 (Drag-start exactly-once): LibraryService autoload single emitter
+- Invariant 2 (Drop-completion 페이로드): native `_drop_data(at_position, data)` data Dictionary `{"library_id", "source"}` + `at_position` Vector2 (DeskPane local)
+- Invariant 3 (FROZEN/READ_ONLY 차단): `_can_drop_data` Workspace State guard
+- Invariant 4 (Library Subsystem 비관찰): LibraryService는 drop 결과 polling X — Workspace 자기 책임
+
+### Reasoning Workspace GDD §9.6 AccessKit role floor 보장
+
+- Canvas root `ROLE_TREE` (DeskCanvas Control)
+- 노드 `ROLE_TREE_ITEM` (HypothesisNode Control)
+- 메모 `accessibility_name = node.memo` programmatic 설정 (RichTextLabel 한계 회피)
+
+### TR-WORKSPACE-LAYOUT-001 ~ 005 (tr-registry 등록 신규)
+
+- TR-WORKSPACE-LAYOUT-001: DeskPane Control hierarchy 잠금 (§1)
+- TR-WORKSPACE-LAYOUT-002: CitationDrop hybrid signal topology (§2)
+- TR-WORKSPACE-LAYOUT-003: MemoPanel inline + fallback (§3)
+- TR-WORKSPACE-LAYOUT-004: Tree panning Camera2D (§4)
+- TR-WORKSPACE-LAYOUT-005: Gamepad two-step CitationDrop (§5)
+
+## Open Questions / Future Work
+
+본 ADR은 OQ-W7 (AccessKit verification) deferred 상태 유지 — UI Foundation epic prototype 측정 의무 (§6 위임 항목 1).
+
+본 ADR은 ADR-0001 / ADR-0004 amendment 트리거 — 본 ADR Accepted 시점에 두 amendment 동시 작성 의무 (체인 amendment).
+
+v1+ 검토 항목:
+- Tree panning *minimap* 도입 — 4-deep + 5+ root 시점에 panning 만으로 부족 가능 (post-MVP playtest 측정).
+- Memo panel (C) modal option — Pillar 3 contemplative flow 침해 우려로 cycle 1 reject되었으나, floor 해상도 사용자 비율이 v1+ telemetry에서 30%+ 도달 시 재검토.

--- a/docs/architecture/control-manifest.md
+++ b/docs/architecture/control-manifest.md
@@ -1,0 +1,292 @@
+# Control Manifest
+
+> **Engine**: Godot 4.6 (runtime confirmed 4.6.1.stable.official.14d19694e via VR-UI6 prototype 2026-05-17)
+> **Last Updated**: 2026-05-18
+> **Manifest Version**: 2026-05-18
+> **ADRs Covered**: ADR-0001 + amend-1 + amend-1.1 + amend-2, ADR-0002 main (amend-1 Proposed — rules pre-applied via source verification), ADR-0003, ADR-0004 + amend-1, ADR-0006, ADR-0007 + amend-1 + amend-2, ADR-0008 + amend-1 + amend-2 + amend-3 + amend-4, ADR-0009, ADR-0010 + amend-1, ADR-0011
+> **Status**: Active — regenerate with `/create-control-manifest update` when new ADRs are Accepted or existing ADRs revised
+
+`Manifest Version` is the date this manifest was generated. Story files embed this date at creation time. `/story-readiness` compares a story's embedded version to this field to detect stories written against stale rules. `Last Updated` = `Manifest Version` (same date, separate consumers).
+
+This manifest is a programmer's quick-reference extracted from all Accepted ADRs, `.claude/docs/technical-preferences.md`, and `docs/engine-reference/godot/`. For the *reasoning* behind each rule, see the referenced ADR.
+
+---
+
+## Foundation Layer Rules
+
+*Applies to: Legal Reference Library (#20), Case Data Schema (#1), UI Foundation (#2), Save/Load (#3) — initialisation, persistence, and core data services.*
+
+### Required Patterns
+
+- **Autoload registration order locked**: `LibraryService` FIRST, `UIService` SECOND, `CaseService` THIRD, `EvaluationService` FOURTH, `SettingsService` FIFTH, `SaveLoadService` SIXTH in `project.godot [autoload]` section — source: ADR-0001, ADR-0007 §2, ADR-0010, ADR-0011, ADR-0009
+- **LibraryService FIRST `_ready()` fail-fast guard**: `assert(library_data_loaded)` before any consumer access — source: ADR-0001 amend-1 / amend-1.1
+- **CaseService `_ready()` awaits `LibraryService.library_loaded` signal before validating `correct_citations`** — source: ADR-0003 (Implementation Guideline #1)
+- **Library `.tres` data load via `ResourceLoader.load()` only** (NOT `FileAccess.open` raw parsing) — source: ADR-0001 §Decision
+- **Library `holding_id` is canonical key — never synthesized at call sites; always read from `LibraryHolding.holding_id` field** — source: ADR-0001 amend-1
+- **Library search index format**: in-memory `Dictionary` keyed by case_id + holding_id; built at LibraryService `_ready()` post-load — source: ADR-0002
+- **Use `Time.get_ticks_msec()` for performance instrumentation** (NOT deprecated `OS.get_ticks_msec()`) — source: ADR-0002 amend-1, `docs/engine-reference/godot/deprecated-apis.md`
+- **Case Data Schema**: each case file is `Resource` (`.tres`) with required fields `case_id`, `holdings`, `correct_citations` (Array[String] of `holding_id`) — source: ADR-0003
+- **Lazy `full_opinion` storage**: long opinion text in side-car `.txt`; `LibraryHolding.full_opinion` field is empty string until `LibraryService.load_full_opinion(holding_id)` called — source: ADR-0006
+- **UIService autoload SECOND**: owns Theme + KrCustomControl tree + Theme runtime reload + Kr3PaneLayout primitive + KrFreezeOverlay + Reduced Motion gateway + dual focus ring composite + `tween_property()` gateway + `announce_text(source, message, priority)` live-region API — source: ADR-0010 + amend-1 §G3
+- **KrCustomControl base class `_ready()` auto-subscribes** to `SettingsService` 3 signals (`display.text_scale` / `display.reduced_motion` / `accessibility.focus_indicator_thickness_px`) via `KrControlHelper.setup(self)` — source: ADR-0010 §Decision
+- **KrCustomControl subclasses use composition + static helper pattern** (NOT multiple inheritance — GDScript doesn't support it); each Kr* class extends appropriate Godot base + calls `KrControlHelper.setup(self)` in `_ready()` — source: ADR-0010 §Decision Note (godot-specialist 2026-05-17 redefine)
+- **`UIService.tween_property(target, property, final_value, duration)` gateway**: returns `null` when `display.reduced_motion == true` → caller sets property immediately; otherwise creates `Tween` and returns it — source: ADR-0010 §Decision + §Risk R7 enforcement
+- **17 Theme type variations registered**: `&"Pane"`, `&"Header"`, `&"Card"`, `&"LibraryCard"`, `&"HypothesisNode"`, `&"EnvelopeCard"`, `&"GroundsCard"`, `&"Dialog"`, `&"Button"`, `&"Banner"`, `&"ReadOnlyBanner"`, `&"CriticalBanner"`, `&"ToastBanner"`, `&"BodyLabel"`, `&"CommentLabel"`, `&"MemoLabel"`, `&"CourtHeadline"`, `&"CaptionLabel"`, `&"MemoEdit"` — source: ADR-0004 amend-1, ADR-0010 §17 Theme Type Variations
+- **`Theme.set_font_size()` runtime reload triggers automatic `NOTIFICATION_THEME_CHANGED` cascade** to all dependent Controls — VR-UI1 PASS confirmed; do NOT call `theme.emit_changed()` after setter (double-emit) — source: ADR-0004 amend-1, ADR-0010 §Risk R1, VR-UI1 prototype 2026-05-17
+- **AccessibilityRole assignment via `Control.accessibility_role = AccessibilityRole.ROLE_*`**; use ONLY constants that exist in Godot 4.6 `DisplayServer.AccessibilityRole` enum (46 entries 0..45) — source: ADR-0008 amend-4 §F1, ADR-0010 amend-1 §G1, VR-UI6 dump 2026-05-17
+- **Live-region announcement**: call `UIService.announce_text(source, message, priority)` — wraps `DisplayServer.accessibility_update_set_live(rid, mode)` + `accessibility_update_set_name(rid, message)`; mode enum `DisplayServer.LIVE_OFF=0 / LIVE_POLITE=1 / LIVE_ASSERTIVE=2` — source: ADR-0010 amend-1 §G3, VR-UI6 PASS
+- **KrBanner subclass `_ready()` MUST call `super._ready()`** which auto-invokes `UIService.announce_text(self, text, priority)` — source: ADR-0010 amend-1 §G5
+- **SaveLoadService SIXTH autoload**: 4-Resource splits (`active_case.tres` + `casebook.tres` + `career.tres` + `session_meta.cfg`) under `user://saves/` — source: ADR-0011 §Decision
+- **Atomic write pattern**: write-to-temp + `DirAccess.rename_absolute()` — POSIX guaranteed within same filesystem; Windows NTFS best-effort — source: ADR-0011 §F3, `docs/engine-reference/godot/current-best-practices.md` (File I/O section)
+- **Autosave is signal-trigger ONLY**: subscribe to typed signals (`workspace_state_changed`, `brief_editor_state_changed`, `brief_editor_submitted`, `evaluation_completed`, `submission_rejected`, `case_state_changed`); 250ms debounce except `casebook` immediate-write — source: ADR-0011 §Decision
+- **Crash recovery cascade entry point**: `SaveLoadService.active_case_recovered(case_id, snapshot)` signal — single subscriber-entry for both Workspace FROZEN auto-resubmit + Brief SUBMITTING auto-resubmit — source: ADR-0011 §3
+
+### Forbidden Approaches
+
+- **Never use `FileAccess.open` to read Library data files** — Use `ResourceLoader.load()`. ADR-0001 §Alternatives rejected raw parsing. Pattern: `library_data_load_via_FileAccess`
+- **Never synthesize `holding_id` in caller code** (e.g. `case_id + "-" + index`) — always read from `LibraryHolding.holding_id`. Pattern: `library_holding_id_synthesis_in_callers`
+- **Never call external API at runtime for library data** (Naver / Casenote etc.) — Library is pre-bundled `.tres`. Pattern: `library_runtime_external_api_call`
+- **Never violate autoload order** — moving EvaluationService from FOURTH breaks LibraryService FIRST + CaseService THIRD dependency chain. Pattern: `autoload_order_violation_evaluation`
+- **Never subscribe to non-typed signals via string-keyed `emit_signal("name", args)`** — always use typed `.emit(args)` syntax. Pattern: `signal_emit_string_keyed_when_typed_available` — source: ADR-0008 amend-1 §A5, amend-3 §E2 cascade
+- **Never extend Control directly bypassing KrCustomControl tree** — Pattern: `custom_control_outside_kr_hierarchy` — source: ADR-0010 §Forbidden Patterns
+- **Never use `create_tween()` directly** — always route through `UIService.tween_property()` (Reduced Motion gateway). Exception: UIService implementation itself. Pattern: `direct_create_tween_bypassing_reduced_motion`
+- **Never apply inline `theme_override_*` properties** to a Control — always use Theme + `theme_type_variation`. Pattern: `inline_theme_override_without_type_variation`
+- **Never open two `KrDialog popup_exclusive` simultaneously within one system** (e.g. Workspace cannot show submit confirmation + delete confirmation at once). Pattern: `dialog_concurrent_open_within_system`
+- **Never use a font outside the 3-family set** (`court_title` 본명조 MSDF + `body_sans` Pretendard + `code_mono` IBM Plex Mono). Pattern: `font_outside_three_family_set` — source: ADR-0004
+- **Never use `TextServer.SIMPLE` for Korean text** — must use complex/advanced text shaping for ㅇ/ㅎ ligatures + diacritics. Pattern: `text_server_simple_for_korean`
+- **Never bundle full glyph set for MSDF fonts** — generate per-codepoint MSDF only for KS X 1001 commonly-used subset (~2350 glyphs). Pattern: `font_msdf_full_glyph_set`
+- **Never use plain `Label` for long body text** — use `RichTextLabel` for paragraphs (bbcode + autowrap). Pattern: `label_for_long_body_text`
+- **Never assign hallucinated AccessibilityRole names** — `ROLE_REGION`, `ROLE_GROUP`, `ROLE_HEADING`, `ROLE_STATUS`, `ROLE_ALERT`, `ROLE_RADIO_GROUP`, `ROLE_COMBO_BOX`, `ROLE_CHECKBOX` (one word), `ROLE_TEXT_AREA` — none exist in 4.6 enum (PR review gate `accessibility_role_pre_verification_implementation`) — source: ADR-0008 amend-4 §F1, `docs/engine-reference/godot/modules/ui.md`
+- **Never display KrBanner subclass dynamically without calling `UIService.announce_text`** — live-region absence in role enum requires explicit announce. Pattern: `kr_banner_dynamic_show_without_announce`
+- **Never use polling-based autosave** (e.g. `_process` timer) — only signal-trigger. Pattern: `save_load_polling_based_autosave`
+- **Never write non-atomic to `user://`** — bypass of atomic-rename pattern can corrupt save on crash. Pattern: `save_load_non_atomic_write`
+- **Never serialize a preloaded Resource instance** — Resource refs in `.tres` cause Godot to attempt re-load by path; use Resource UID or build-from-data pattern. Pattern: `save_load_serialize_preloaded_resource_instance`
+- **Never declare a `class_name` that collides with an autoload name** (e.g. `class_name LibraryService` clashes with autoload). Pattern: `class_name_collides_with_autoload_name`
+
+### Performance Guardrails
+
+- **LibraryService boot**: < 200ms to load + index 100+ holdings — source: ADR-0001 §Performance Implications
+- **LibraryService search latency**: < 1ms average over first 100 `search()` calls — source: ADR-0002 §Validation Criteria #5
+- **SaveLoadService atomic write**: ≤ 16ms per save (1 frame) for typical Resource size (< 1MB) — source: ADR-0011 §Performance
+- **UIService Theme reload cascade**: < 50ms for 21+ KrCustomControl scene — source: ADR-0010 §Performance + VR-UI1 PASS confirmation
+- **`NOTIFICATION_WM_CLOSE_REQUEST` synchronous save budget**: OS provides multi-second graceful close window; ≤16ms save completes well within — source: ADR-0011 §VR-SL3 + `docs/engine-reference/godot/current-best-practices.md`
+
+---
+
+## Core Layer Rules
+
+*Applies to: Korean text rendering (cross-system #5/#6/#7/#10/#20), Settings & Accessibility (#4) — engine-facing infrastructure shared by all gameplay systems.*
+
+### Required Patterns
+
+- **Korean text uses MSDF font for `court_title` family (본명조)** + standard TTF for `body_sans` (Pretendard) + monospace for `code_mono` (IBM Plex Mono) — hybrid by family per ADR-0004 §Decision
+- **Font subset = KS X 1001 commonly-used + ASCII** (~2350 + 95 glyphs); never bundle full glyph set — source: ADR-0004 §Decision
+- **`SettingsService` autoload FIFTH position**: `user://user_settings.cfg` ConfigFile single-file (5 카테고리 sections + `[meta]` `schema_version=1`) — source: ADR-0009 §Decision
+- **5-step `set()` cascade order**: validation → in-memory apply → typed `setting_changed.emit(key, old, new)` → direct engine API call (AudioServer/InputMap/Theme) → 100ms debounced persist — source: ADR-0009 §Decision Architecture
+- **Direct engine API ownership (SettingsService ONLY)**: `AudioServer.set_bus_volume_db()`, `InputMap.action_add_event/erase_events/action_has_event`, `DisplayServer.is_screen_reader_running()` — source: ADR-0009 §Decision + forbidden_pattern `settings_direct_engine_api_bypass`
+- **`SettingsService.get(key, default)` is the only read path** — never cache settings values in member variables; always re-query or subscribe to `setting_changed` — source: ADR-0009 §Decision + forbidden_pattern `settings_local_cache`
+- **`text_scale` apply path**: `UIService.theme.set_font_size(...)` for each type variation; NOTIFICATION_THEME_CHANGED auto-cascades to dependent Controls (VR-UI1 PASS) — source: ADR-0009 §Decision + ADR-0004 amend-1
+- **`reduced_motion` apply path**: signal-only — subscribers use `UIService.tween_property()` gateway which checks setting internally; no per-control logic needed — source: ADR-0010 §Decision
+- **`keyboard_shortcut_remap` apply path**: `InputMap.action_add_event` for each remapped action; reject reserved keys (Esc/Space/Tab/Enter/arrows) + conflict-detect (last-registration wins + warning dialog) — source: ADR-0009 + GDD §3.1.3
+- **Crash recovery on settings parse error**: `DirAccess.rename_absolute(user://user_settings.cfg → user://user_settings.cfg.backup.YYYYMMDD-HHMMSS)` + reset to defaults + `UIService.announce_text(self, msg, ASSERTIVE)` + CriticalBanner — source: ADR-0009 §Decision Crash Recovery
+
+### Forbidden Approaches
+
+- **Never include SettingsService values in `EvaluationService.submit()` or `PlayerSubmission`** — Pillar 1 violation. Pattern: `settings_value_in_evaluation`
+- **Never include SettingsService values in `chain_data` Dictionary** — Pattern: `settings_in_chain_data` (mirrors `chain_data_include_ephemeral_field`)
+- **Never cache SettingsService.get() result in member variable** — SSOT violation. Pattern: `settings_local_cache`
+- **Never call `AudioServer.set_bus_volume_db()` / `InputMap.action_add_event()` outside SettingsService** — Pattern: `settings_direct_engine_api_bypass`
+- **Never use `DisplayServer.ime_get_text()` cross-platform without `OS.get_name() == "macOS"` guard** — method is macOS-only; silent no-op on Windows/Linux. Pattern: `ime_get_text_cross_platform_assumption` — source: `docs/engine-reference/godot/modules/input.md`
+- **Never use `TextEdit.composition_finished` signal** — does NOT exist in Godot 4.6 stable. Pattern: `ime_path_a_composition_finished_use` — source: ADR-0008 amend-4 §F2, `docs/engine-reference/godot/modules/ui.md`
+
+### Performance Guardrails
+
+- **SettingsService boot `_ready()`**: 5-20ms (ConfigFile.load + `_apply_all_to_engine`) — source: ADR-0009 §Performance
+- **`set()` call latency**: < 1ms (in-memory + signal + engine API; persist is debounced) — source: ADR-0009 §Performance
+- **`persist()` flush**: < 16ms (ConfigFile.save + rename_absolute) — source: ADR-0009 §Performance
+- **`screen_reader_detected` polling**: 30s interval Timer × ~0.1ms per check — negligible — source: ADR-0009 §Performance
+
+---
+
+## Feature Layer Rules
+
+*Applies to: Reasoning Workspace (#6), Brief Editor (#7), Submission & Evaluation (#9), Case File Browser (#5) — gameplay systems built on Foundation + Core.*
+
+### Required Patterns
+
+- **WorkspaceData state machine 4 states**: `INACTIVE = 0`, `ACTIVE = 1`, `FROZEN = 2`, `READ_ONLY = 3`; transitions only via `_transition_to_active()` / `_transition_to_frozen()` / `_transition_to_read_only()` — source: ADR-0008 §1
+- **State transitions emit typed signal `workspace_state_changed(old: int, new: int)`** — source: ADR-0008 §1 + amend-1 §A5
+- **chain_data Dictionary is fully constructed new Dict literal** — never reference live WorkspaceData fields; each node's `evidence: Array[String]` field explicitly `.duplicate()` called — source: ADR-0008 §3.1 Rule 6 normative (cycle 4 godot-specialist IMPORTANT-1)
+- **chain_data nodes[] array follows BFS canonical ordering**: roots sorted by `node_id` lexicographically → BFS within each subtree with children sorted by `node_id` at each depth — source: ADR-0008 §1 + systems-designer F3 BLOCKING closure
+- **chain_data contains ONLY Variant primitives**: String / int / float / bool / Array / Dict — no Resource refs, no Object refs — source: ADR-0007 amend-1
+- **chain_data schema_version=1 locked**: any v2+ bump requires explicit migration ADR — source: ADR-0007 amend-1
+- **chain_data allow-list validator**: per-node fields restricted to `node_id`, `label`, `parent_id`, `evidence`, `depth`, `child_count`, `evidence_count`; forbidden field injection → `push_error` + `submission_rejected("schema_violation")` — source: ADR-0008 amend-1 §A6
+- **Disposition enum MVP scope locked to 4 values**: `ACCEPT`, `REJECT`, `PARTIAL_ACCEPT`, `REMAND` — case content must use only these; v1+ extension via explicit ADR — source: ADR-0007 amend-2
+- **CitationDrop hybrid signal topology**: Godot 4.6 native drag-drop callbacks (`_get_drag_data` / `_can_drop_data` / `_drop_data`) + LibraryService `citation_drag_started(library_id)` typed signal + application-level `WorkspaceData.pending_citation: String` for KB Space-mark/attach + Gamepad A→A two-step — source: ADR-0008 §2 + amend-1 §A3
+- **Drop target state guard scope**: DeskPane HypothesisNode `_can_drop_data` rejects when `WorkspaceData.state != ACTIVE`; Brief Editor CitationPanel is independent guard — source: ADR-0008 amend-3 §E1
+- **Cross-viewport drag-drop confirmed dispatch**: native callbacks fire across SubViewport boundary (VR-D6 PASS 2026-05-17 — 4/4 prototype drags); DragManager autoload fallback NOT needed — source: ADR-0008 amend-3 §E3 + VR-D6 prototype
+- **Hit-test tie-break**: when overlapping nodes receive drop, topmost (highest z-index then latest add) wins — source: ADR-0008 amend-1 §A3
+- **MemoPanel layout**: default (B) fixed bottom-right; (A) inline next to selected node activates when `root_count ≤ 2 AND DeskPane.size.x ≥ 720`; 0.15s opacity fade via `UIService.tween_property()` — source: ADR-0008 §3 + amend-1 §A4
+- **Tree panning Camera2D**: mouse middle-drag 1:1, gamepad right-stick analog 600 px/s (deadzone from `input.gamepad_stick_deadzone`), D-pad/Tab/Arrow auto-center via 0.2s lerp, scroll wheel vertical pan; clamp to HypothesisNodeRoot bounding box + 200px padding — source: ADR-0008 §4
+- **Gamepad CitationDrop two-step**: A on LibraryPane card (mark pending) → A on DeskPane node (attach) → B cancel; FROZEN state auto-cancels pending — source: ADR-0008 §5
+- **Brief Editor data lifecycle**: BriefEditorData is single-owner Resource owned by transient SaveLoadService (boot path) → BriefEditor scene receives via `active_case_recovered` signal; never accessed via direct NodePath before signal arrival — source: ADR-0001 amend-2
+- **Brief Editor IMPORTING transition**: ≤150ms from `workspace_state_changed(ACTIVE, FROZEN)` arrival to `brief_editor.state == IMPORTING` — source: ADR-0001 amend-2 + TR-brief-001
+- **Submit confirmation dialog (Pillar 3 anchor)**: KrDialog `popup_exclusive=true`, default focus = [취소] (NOT [제출]) — source: Workspace cycle 3 Decision 2, ADR-0008 amend-2 §D2
+- **EvaluationService submission pipeline**: `submit(submission: PlayerSubmission)` validates schema → calls grading algorithm → emits `evaluation_completed(result: EvaluationResult)` typed signal — source: ADR-0007 §Decision. *(Corrected 2026-05-23, TD-001: prior text said `submit(chain_data: Dictionary)`, which is insufficient — the grading algorithm scores `player_disposition` + `player_citations` (Set ops vs correct/missed/redundant), neither of which is in `chain_data`. `PlayerSubmission` bundles `case_id` + `player_disposition` + `player_citations` + `chain_data` + `submission_time_ms`. ADR-0007 §Decision is authoritative; the manifest had misquoted it. No version bump — correction to match the cited source, not a new rule.)*
+- **IME composition detection (cross-platform)**: `_gui_input` override + analyze `InputEventKey` `unicode == 0 AND keycode == 0` pattern for composition state — source: ADR-0008 amend-4 §F3 (`docs/engine-reference/godot/modules/input.md`)
+- **TextEdit signal handling**: 4.6 stable signals are `caret_changed / gutter_added / gutter_clicked / gutter_removed / lines_edited_from / text_changed / text_set`; `set_text()` and `clear()` fire `text_set` only (VR-D3 PASS) — source: ADR-0008 amend-4 §F5 + VR-D3 prototype 2026-05-17
+- **`_text_changed_guard` defensive flag**: retain in TextEdit subscribers as zero-cost protection against future engine behavior changes — source: ADR-0008 amend-4 §F5
+- **Project Settings lock**: `display/window/subwindows/embed_subwindows = true` (4.6 default — verified VR-D1 PASS) + `project.godot` explicit lock as defense-in-depth — source: ADR-0008 amend-2 §D2, `docs/engine-reference/godot/current-best-practices.md`
+
+### Forbidden Approaches
+
+- **Never include ephemeral fields in chain_data**: forbidden field names include `memo_text`, `chain_data_internal`, `__debug_payload`, `evaluator_hint`, `cached_score`. Pattern: `chain_data_include_ephemeral_field` — source: ADR-0008 amend-1 §A6, AC-52
+- **Never include Resource or Object value in chain_data Dictionary** — Pattern: `chain_data_include_resource_or_object_value` — source: ADR-0007 amend-1
+- **Never modify chain_data from Brief Editor** — chain_data is Workspace-owned, Brief receives read-only copy. Pattern: `brief_editor_modify_chain_data`
+- **Never extend disposition enum in case content** (e.g. case .tres declares `disposition: "OVERRULE"`) — case content is consumer of enum, not authority. Pattern: `disposition_enum_extension_in_case_content`
+- **Never extend disposition enum at runtime** — Pattern: `disposition_enum_runtime_extension`
+- **Never add a 5th disposition enum prematurely (before v1+ playtest data)** — Pattern: `premature_disposition_enum_extension`
+- **Never start a 2nd `EvaluationService.submit()` while previous is in flight** — Pattern: `submit_during_active_evaluation`
+- **Never override per-case verdict thresholds in case files** — thresholds are global. Pattern: `per_case_verdict_threshold_override`
+- **Never cache EvaluationResult by case_id** in EvaluationService — fresh evaluation per submit. Pattern: `evaluation_caching_by_case_id`
+- **Never let Library subsystem observe drop result** — Library is data source only, never observer of UI events. Pattern: `library_subsystem_observe_drop_result`
+- **Never mutate PackedArray value inside Dict value in-place** — Godot Dict values are copies for primitives but PackedArray inside Dict requires explicit reassignment. Pattern: `dict_value_packed_array_inplace_mutation`
+- **Never duplicate allow-list validator logic across multiple call sites** — single canonical `WorkspaceData.validate_chain_data()` function. Pattern: `chain_data_schema_allow_list_duplication`
+- **Never access BriefEditorData via direct NodePath** — use `active_case_recovered` signal subscriber. Pattern: `brief_editor_data_direct_node_path_access`
+- **Never access BriefEditorData before the `brief_editor_data_recovered` signal arrives** — Pattern: `brief_editor_data_pre_signal_access`
+- **Never let Brief Editor `popup_exclusive` Window become a native OS window** (`embed_subwindows` lockdown). Pattern: `brief_editor_window_native_os_mode` — source: ADR-0008 amend-2 §D2
+
+### Performance Guardrails
+
+- **EvaluationService.submit() pipeline**: < 50ms for typical chain_data (~10 nodes × 3 evidence) — source: ADR-0007 §Performance
+- **Workspace freeze cascade**: ≤16ms from submit_confirmed click to FROZEN state (UI tween 별도) — source: ADR-0008 §Performance + ADR-0001 amend-2
+- **Brief IMPORTING handoff**: ≤150ms from workspace_state_changed FROZEN to brief.state == IMPORTING — source: ADR-0001 amend-2 + TR-brief-001
+- **Workspace 60fps target with 5 root × 3 deep × 5 evidence (~117 nodes)** — source: AC-49 (stub test until VR-OQ-W10 ratify per gdunit4 v5.x skip parameter)
+- **MemoPanel A↔B fade transition**: 0.15s opacity tween (Reduced Motion → instant) — source: ADR-0008 §3 + amend-1 §A4
+
+---
+
+## Presentation Layer Rules
+
+*Applies to: rendering pipeline, UI Theme application, AccessKit role assignment, audio cue mixing, dual focus ring composite, drag preview visuals.*
+
+### Required Patterns
+
+- **KrCustomControl `_apply_access_kit_role()` override hook**: each subclass overrides to set `accessibility_role` after `super._ready()` — source: ADR-0010 §Decision
+- **Use corrected AccessibilityRole mapping (amend-4 §F1 + amend-1 §G1)**:
+  - KrPane → `ROLE_PANEL` (=6)
+  - KrHeader → `ROLE_STATIC_TEXT` (=4)
+  - KrCard base → `ROLE_PANEL` (=6); subclasses override (LibraryCard → ROLE_LIST_ITEM=30, HypothesisNode → ROLE_TREE_ITEM=28, EnvelopeCard → ROLE_BUTTON=7, GroundsCard → ROLE_CHECK_BOX=9)
+  - KrDialog → `ROLE_DIALOG` (=44)
+  - KrButton → `ROLE_BUTTON` (=7)
+  - KrSlider → `ROLE_SLIDER` (=15)
+  - KrRadioGroup → `ROLE_PANEL` (=6); children → `ROLE_RADIO_BUTTON` (=10)
+  - KrCheckBox → `ROLE_CHECK_BOX` (=9, two-word)
+  - KrDropdown → `ROLE_LIST_BOX` (=31)
+  - KrLineEdit → `ROLE_TEXT_FIELD` (=18, single-line)
+  - KrTextEdit → `ROLE_MULTILINE_TEXT_FIELD` (=19)
+  - KrBanner family (ReadOnlyBanner / CriticalBanner / ToastBanner) → `ROLE_STATIC_TEXT` (=4) + `UIService.announce_text` mandatory
+- **`accessibility_name` populated for each Control** with semantically meaningful text (e.g. HypothesisNode = "label (증거 N개)") — distinguishes elements with same role — source: ADR-0010 amend-1 §R3 Risk mitigation
+- **Dual focus ring composite**: inner 2px solid 잉크블랙 (fixed) + outer dashed 1-4px (from `accessibility.focus_indicator_thickness_px` setting); implement via Control `_draw()` override + custom dashed line routine (ADR-0010 R8 option 2) — source: ADR-0010 §Dual Focus Ring Composite + R8
+- **Drag preview**: 70% transparent KrCard ghost via `set_drag_preview(duplicate())` in `_get_drag_data` — source: ADR-0008 §2 drag preview pattern
+- **HypothesisNode bottom evidence rule**: discrete steps (cap=5 → 6 ρ values {0.0, 0.2, 0.4, 0.6, 0.8, 1.0}); 200×48 hero shape; rule length = ρ × 184px (inner padding) drawn via Control `_draw()` — source: ADR-0008 §1, GDD §8.1.1.b
+- **Audio cues via `AudioService.play(event_name)` autoload**: 21-event catalog per GDD §8.2 (e.g. `weight-stamp` for evidence attach, `paper-blocked` for invalid drop, `ink-pen-mark` for memo char) — source: GDD §8.2 audio-director catalog (no dedicated ADR yet — pending ADR-0012 Audio Cue Registry per delta report)
+
+### Forbidden Approaches
+
+- **Never use deprecated rendering APIs** (per `deprecated-apis.md` Patterns table): manual post-process viewport chains (use Compositor instead), Texture2D in shader params (use Texture base type), GodotPhysics3D for new projects (Jolt is 4.6 default) — source: `docs/engine-reference/godot/deprecated-apis.md`
+- **Never assume `AccessibilityServer` is a standalone class** — it's not; AccessKit is exposed via `DisplayServer.accessibility_*` 76 methods. Source: VR-UI6 dump 2026-05-17, `docs/engine-reference/godot/modules/ui.md`
+- **Never assume `StyleBoxFlat` supports native dashed borders** — it doesn't; choose ADR-0010 R8 option (_draw override, overlap StyleBox, or shader). Source: ADR-0010 §Risk R8
+- **Never animate without checking Reduced Motion** — always route through `UIService.tween_property()` gateway. Pattern: `direct_create_tween_bypassing_reduced_motion` (also Foundation-layer)
+
+### Performance Guardrails
+
+- **Drag preview render**: < 1ms per mouse motion event — source: ADR-0008 §2 + Performance
+- **Theme cascade on `text_scale` change**: < 50ms for ~21 KrCustomControl scene (VR-UI1 PASS, automatic) — source: ADR-0010 §Performance
+- **UIService.announce_text call**: < 0.5ms per call (1 API call; fallback +2 calls for focus-shift if VR-UI6 had failed — fallback NOT used post-VR-UI6 PASS) — source: ADR-0010 amend-1 §Performance
+
+---
+
+## Global Rules (All Layers)
+
+### Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Classes | PascalCase | `PlayerController`, `WorkspaceData`, `HypothesisNode` |
+| Variables | snake_case | `move_speed`, `chain_data_snapshot`, `pending_citation` |
+| Signals / Events | snake_case past tense | `health_changed`, `enemy_defeated`, `workspace_state_changed`, `citation_drag_started` |
+| Files | snake_case matching class | `player_controller.gd`, `workspace_data.gd`, `hypothesis_node.gd` |
+| Scenes / Prefabs | PascalCase matching root node | `PlayerController.tscn`, `DeskPane.tscn` |
+| Constants | UPPER_SNAKE_CASE | `MAX_HEALTH`, `EVIDENCE_CAP`, `MAX_DEPTH` |
+| Theme type variations | `&"PascalCase"` StringName | `&"HypothesisNode"`, `&"MemoEdit"`, `&"CourtHeadline"` |
+
+Source: `.claude/docs/technical-preferences.md` §Naming Conventions
+
+### Performance Budgets
+
+| Target | Value |
+|--------|-------|
+| Framerate | 60 fps |
+| Frame budget | 16.6 ms total (~11 ms CPU / ~5 ms GPU starting split) |
+| Draw calls | < 2000 per frame (Forward+ desktop) |
+| Memory ceiling | 2 GB working set (initial target — refine when target hardware fixed) |
+
+Source: `.claude/docs/technical-preferences.md` §Performance Budgets
+
+### Approved Libraries / Addons
+
+- **gdunit4** v5.0+ — GDScript test framework (Godot 4.4+ ready). Approved 2026-05-09. Skip API uses **function signature parameter pattern** (`_do_skip := true, _skip_reason := "..."`); imperative `skip("reason")` call is NOT supported in GDScript (only C# variant). Source: `.claude/docs/technical-preferences.md` §Allowed Libraries + reasoning-workspace AC-49 stub pattern
+
+### Forbidden APIs (Godot 4.6)
+
+These APIs are deprecated or unverified for Godot 4.6. Use the right column instead:
+
+| Deprecated | Use Instead | Since |
+|------------|-------------|-------|
+| `TileMap` | `TileMapLayer` | 4.3 |
+| `VisibilityNotifier2D` / `VisibilityNotifier3D` | `VisibleOnScreenNotifier2D` / `VisibleOnScreenNotifier3D` | 4.0 |
+| `YSort` | `Node2D.y_sort_enabled` property | 4.0 |
+| `Navigation2D` / `Navigation3D` | `NavigationServer2D` / `NavigationServer3D` | 4.0 |
+| `EditorSceneFormatImporterFBX` | `EditorSceneFormatImporterFBX2GLTF` | 4.3 |
+| `yield()` | `await signal` | 4.0 |
+| `connect("signal", obj, "method")` | `signal.connect(callable)` | 4.0 |
+| `instance()` / `PackedScene.instance()` | `instantiate()` | 4.0 |
+| `get_world()` | `get_world_3d()` | 4.0 |
+| `OS.get_ticks_msec()` | `Time.get_ticks_msec()` | 4.0 |
+| `duplicate()` for nested resources | `duplicate_deep()` | 4.5 (for Resource trees only; primitive Variant containers can still use `.duplicate(true)`) |
+| `Skeleton3D bone_pose_updated` signal | `skeleton_updated` | 4.3 |
+| `AnimationPlayer.method_call_mode` | `AnimationMixer.callback_mode_method` | 4.3 |
+| `AnimationPlayer.playback_active` | `AnimationMixer.active` | 4.3 |
+| `TextEdit.composition_finished` signal | **does not exist** — use `_gui_input` `InputEventKey` analysis | 4.6 (sprint VR-D2 FAIL — never existed) |
+| Hallucinated AccessibilityRole names | Use corrected mapping (see Foundation + Presentation rules) | 4.6 (sprint VR-UI2 FAIL — never existed) |
+
+Source: `docs/engine-reference/godot/deprecated-apis.md` + `verification-sprint-2026-05-17.md` corrections
+
+### Cross-Cutting Constraints
+
+- **Engine version**: project pinned to Godot 4.6 — do not introduce features requiring Godot 4.7+ (none anticipated for MVP)
+- **Knowledge cutoff awareness**: LLM training data ~Godot 4.3; ALWAYS check `docs/engine-reference/godot/` snapshots before suggesting any 4.4/4.5/4.6 API. If snapshot is silent, WebFetch official docs (`https://docs.godotengine.org/en/stable/`) before committing
+- **Trunk-based development**: changes go to `main` directly (with PR review for non-trivial changes). No long-lived feature branches
+- **Tests are blocking CI gate**: never disable or skip failing tests to make CI pass; fix the underlying issue. gdunit4 skip API uses function-signature parameter pattern for *stub* tests pending VR closure — not for hiding failures
+- **All gameplay values data-driven**: balance numbers, formulas, caps from external config (entities.yaml, ADR-registered constants) — never hardcoded magic numbers
+- **All public methods must be unit-testable**: prefer dependency injection over singleton direct calls (exception: autoload services accessed via typed signal subscribe)
+- **Commits must reference relevant design document or task ID** (story ID, ADR number, or GDD section)
+- **Verification-driven development**: write tests first for Logic stories; verify UI changes with screenshots; compare expected output to actual before marking work complete
+- **Korean text in user-facing strings**: all user-facing text in Korean (project is `config/name="파기"`, Korean appellate court simulation). Code identifiers + comments may be English
+- **Custom mouse cursor**: `Input.set_custom_mouse_cursor(image: Resource, shape: CursorShape = 0, hotspot: Vector2 = Vector2(0, 0))` — `image` must be `Texture2D` (Resource); pass `CURSOR_DRAG` shape when grab/grabbing cursor active. Source: ADR-0008 amend-1 §A2, `docs/engine-reference/godot/modules/input.md`
+
+---
+
+## Manifest Regeneration Triggers
+
+Re-run `/create-control-manifest` (full regeneration) when:
+
+- Any new ADR transitions Proposed → Accepted
+- Any existing Accepted ADR is revised (amendment added)
+- `docs/registry/architecture.yaml` forbidden_patterns / api_decisions / interfaces section changes
+- `.claude/docs/technical-preferences.md` Performance Budgets / Approved Libraries / Naming Conventions changes
+- `docs/engine-reference/godot/` is updated (new deprecated APIs surface or post-cutoff API rules added)
+- Engine version pin changes (Godot 4.6 → 4.7)
+
+When regenerating, increment `Manifest Version` to the new date. Stories created with the old `Manifest Version` will be flagged by `/story-readiness` as stale — author must re-confirm rules apply or re-decompose.

--- a/docs/registry/architecture.yaml
+++ b/docs/registry/architecture.yaml
@@ -29,8 +29,8 @@
 #   All forbidden patterns: Grep pattern="^  - pattern:" (forbidden_patterns section)
 #   Superseded entries:     Grep pattern="status: superseded"
 
-version: 1
-last_updated: ""
+version: 2
+last_updated: 2026-05-07
 
 # ─── STATE OWNERSHIP ─────────────────────────────────────────────────────────
 # Who is the authoritative owner of each piece of shared game state.
@@ -43,7 +43,57 @@ last_updated: ""
 # interface: how other systems access this state (read-only property, method call,
 #   signal, shared resource, etc.) — this is the contract other ADRs depend on.
 
-state_ownership: []
+state_ownership:
+  - state: library_entries
+    status: active
+    owner_system: library-service
+    adr: docs/architecture/adr-0001-library-storage-format.md
+    interface: |
+      LibraryService.get_entry(id: String) -> LibraryEntry (read-only).
+      LibraryService.get_holding(synthesized_id: String) -> LibraryHolding (read-only).
+      LibraryService.search(query: String, filters: Dictionary) -> Array[LibraryEntry] (read-only).
+      All entries are Godot Resource subclasses cached by ResourceLoader.
+    write_access: library-service-only
+    referenced_by:
+      - docs/architecture/adr-0001-library-storage-format.md
+    added: 2026-05-04
+    revised: ""
+
+  - state: evaluation_state
+    status: active
+    owner_system: evaluation-service
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    interface: |
+      EvaluationService.current_state -> State enum (read-only externally).
+      Values: IDLE | VALIDATING | COMPUTING | REPORTING | DONE.
+      External systems (#5 Browser, #7 Editor) inspect to gate UI affordances
+      (e.g., Submit 버튼 disable when current_state != IDLE) but never write.
+    write_access: evaluation-service-only
+    referenced_by:
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+    revised: ""
+
+  - state: case_entries
+    status: active
+    owner_system: case-service
+    adr: docs/architecture/adr-0003-case-data-storage-format.md
+    interface: |
+      CaseService.get_case(id: String) -> CaseFile (read-only).
+      CaseService.case_count() -> int (read-only — also used as heuristic guard
+      by EvaluationService._ready() to skip await on pre-fired cases_loaded signal).
+      CaseService._cases is the authoritative store; CaseService._disabled tracks
+      cases that failed validation (per ADR-0003 fault isolation, Library EC-5 mirror).
+      All cases are CaseFile Resource instances loaded via ResourceLoader at boot.
+    write_access: case-service-only
+    referenced_by:
+      - docs/architecture/adr-0003-case-data-storage-format.md
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+    revised: ""
+    notes: |
+      Originally should have been registered when ADR-0003 was Accepted (2026-05-05)
+      but was missed. Registered retroactively during architecture-review 2026-05-06.
 
 # Example:
 #
@@ -71,7 +121,120 @@ state_ownership: []
 #
 # pattern options: signal | direct_call | event_bus | shared_resource | rpc | none
 
-interfaces: []
+interfaces:
+  - contract: library_loaded
+    status: active
+    pattern: signal
+    producer: library-service
+    consumers:
+      - case-service                # waits for signal before validating case correct_citations
+    adr: docs/architecture/adr-0001-library-storage-format.md
+    signal_signature: "library_loaded(entry_count: int)"
+    referenced_by:
+      - docs/architecture/adr-0001-library-storage-format.md
+    added: 2026-05-04
+    revised: ""
+
+  - contract: evaluation_completed
+    status: active
+    pattern: signal
+    producer: evaluation-service
+    consumers:
+      - case-file-browser           # transitions to VerdictArrived state
+      - verdict-reveal-sequence     # #10 — envelope + 인장 연출 trigger
+      - career-progression          # #11 — EvaluationResult persistence
+      - retrospective-replay        # #14 — subscores + matched/missed/redundant 시각화
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    signal_signature: "evaluation_completed(result: EvaluationResult)"
+    referenced_by:
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+    revised: ""
+
+  - contract: submission_rejected
+    status: active
+    pattern: signal
+    producer: evaluation-service
+    consumers:
+      - brief-editor                # #7 — display rejection reason, return to edit
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    signal_signature: "submission_rejected(reason: String)"
+    referenced_by:
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+    revised: ""
+
+  - contract: cases_loaded
+    status: active
+    pattern: signal
+    producer: case-service
+    consumers:
+      - evaluation-service          # waits for signal (or uses case_count() heuristic guard)
+      - case-file-browser           # #5 — Catalog 초기 빌드 트리거
+    adr: docs/architecture/adr-0003-case-data-storage-format.md
+    signal_signature: "cases_loaded(case_count: int)"
+    referenced_by:
+      - docs/architecture/adr-0003-case-data-storage-format.md
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+    revised: ""
+    notes: |
+      Originally should have been registered when ADR-0003 was Accepted (2026-05-05)
+      but was missed. Registered retroactively during architecture-review 2026-05-06.
+      Pattern mirrors library_loaded (ADR-0001 §IG #6).
+
+  - contract: citation_drag_started
+    status: active
+    pattern: signal
+    producer: library-service
+    consumers:
+      - reasoning-workspace          # #6 — DeskPane drop zone hint 활성 (FROZEN/READ_ONLY 시 비활성)
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    signal_signature: "citation_drag_started(library_id: String)"
+    referenced_by:
+      - docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    revised: ""
+    notes: |
+      ADR-0008 §2 hybrid topology — LibraryService autoload single emitter (Gate ③
+      invariant 1 exactly-once 보장). Native drop은 별개 path (`_drop_data` callback);
+      본 시그널은 *drag-start hint 활성* 전용. ADR-0001 amendment trigger — LibraryService에
+      신규 signal 추가 의무.
+
+  - contract: workspace_handoff_started
+    status: active
+    pattern: signal
+    producer: case-file-browser
+    consumers:
+      - reasoning-workspace          # #6 — INACTIVE → ACTIVE 전이 + DeskPane 통제권 위임
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    signal_signature: "workspace_handoff_started(case_id: String)"
+    referenced_by:
+      - docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    revised: ""
+    notes: |
+      Reasoning Workspace GDD §3.3 ↔ Case File Browser §3.6 cross-link. ADR-0008
+      §1 Control hierarchy lock 후 본 contract 등록 — Browser FactsOpen → WorkspaceHandoff
+      전이 시 emit.
+
+  - contract: workspace_handoff_ended
+    status: active
+    pattern: signal
+    producer: reasoning-workspace
+    consumers:
+      - case-file-browser            # #5 — SubmissionPending 또는 WorkspaceHandoff 유지 판단
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    signal_signature: 'workspace_handoff_ended(case_id: String, reason: String)'  # reason ∈ {"submitted", "paused"}
+    referenced_by:
+      - docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    revised: ""
+    notes: |
+      reason = "submitted" → Browser SubmissionPending 전이; reason = "paused" → Browser
+      WorkspaceHandoff 유지 (재진입 가능). Reasoning Workspace cycle 2 game-designer
+      IMPORTANT carry-over (이탈 trigger 명시) — UI Foundation epic이 Browser CatalogIdle
+      back-navigation 시점 emit 결정 의무.
 
 # Example:
 #
@@ -100,7 +263,74 @@ interfaces: []
 # Register a budget when an ADR explicitly claims a frame time allocation.
 # The registry lets /architecture-review verify the total doesn't exceed the target.
 
-performance_budgets: []
+performance_budgets:
+  - system: legal-reference-library
+    status: active
+    budget_type: load_time            # not per-frame; this system only loads at boot
+    load_time_budget_ms_mvp: 500      # MVP 30 entries (AC-17)
+    load_time_budget_ms_v1: 2000      # v1+ 300 entries (AC-17)
+    memory_budget_mb: 80              # ResourceLoader cache cap (Library GDD Section 7.4)
+    adr: docs/architecture/adr-0001-library-storage-format.md
+    notes: |
+      Load-time budget only — Library entries are eager-loaded at boot, then resident in
+      ResourceLoader cache. Per-frame cost is near-zero after boot (Dictionary lookup).
+      Memory cap 80MB applies to total ResourceLoader cache size for Library entries.
+    referenced_by:
+      - docs/architecture/adr-0001-library-storage-format.md
+    added: 2026-05-04
+    revised: ""
+
+  - system: evaluation-service
+    status: active
+    budget_type: per_call             # per-evaluation, not per-frame
+    per_call_budget_ms: 50            # GDD AC-21 — average case (correct 6 + player 6 citations)
+    memory_kb_avg_per_call: 256       # GDD AC-22 — averaged via OS.get_static_memory_usage() over 100 iterations
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    notes: |
+      Per-call budget triggered by EvaluationService.submit() — not a per-frame cost.
+      Memory measurement uses OS.get_static_memory_usage() baseline + 100-iteration averaging
+      because Performance.get_monitor() suffers from GC defer + monitor-tick noise that makes
+      single-call delta unreliable (godot-specialist verification 2026-05-06, ADR-0007 Risk 6).
+      No caching — every submit() recomputes (AC-23 byte-identical determinism enables this).
+    referenced_by:
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+    revised: ""
+
+  - system: case-data
+    status: active
+    budget_type: load_time            # not per-frame; Case data is eager-loaded at boot like Library
+    load_time_budget_ms_mvp: 100      # MVP 30 cases (AC-6 — release build)
+    memory_budget_mb: 1               # MVP 30 cases meta memory (AC-7 — case_meta_memory_budget_kb)
+    adr: docs/architecture/adr-0003-case-data-storage-format.md
+    notes: |
+      Eager load at boot (after LibraryService.library_loaded), then resident.
+      Per-frame cost near-zero after boot (Dictionary lookup via CaseService.get_case).
+      First seed case 1차 측정 PASSED 2026-05-05 — 30 추정 release 22 ms / 748 KB
+      meta memory. Originally should have been registered when ADR-0003 was Accepted
+      but was missed. Registered retroactively during architecture-review 2026-05-06.
+    referenced_by:
+      - docs/architecture/adr-0003-case-data-storage-format.md
+    added: 2026-05-06
+    revised: ""
+
+  - system: ui-fonts
+    status: active
+    budget_type: gpu_resident         # GPU texture memory for font atlases + cached glyph cache
+    bonmyeongjo_msdf_atlas_mb: 14     # 본명조 MSDF Hangul-only at 32×32 cells, BC7-compressed
+    total_fonts_resident_mb: 50       # all 3 families (본명조 MSDF + Pretendard TTF + Plex Mono TTF) cap
+    adr: docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    notes: |
+      MSDF atlas is pre-generated at editor time and committed as .tres — no runtime
+      generation cost. BC7 / ETC2 GPU compression on Forward+ reduces resident size by ~4×.
+      Pretendard + Plex Mono TTF use Godot's dynamic glyph cache; first-paint of each
+      glyph triggers small CPU + GPU upload (~1 ms amortised). Memory cap separate from
+      Library ResourceLoader cache (80 MB) — font assets sit in their own ResourceLoader
+      slot. Verification: gdunit4 or manual evidence at tests/integration/font-rendering/.
+    referenced_by:
+      - docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    added: 2026-05-06
+    revised: ""
 
 # Example:
 #
@@ -131,7 +361,221 @@ performance_budgets: []
 # Register an API decision when the choice is non-obvious and other ADRs might
 # make a different choice for the same purpose without knowing this was decided.
 
-api_decisions: []
+api_decisions:
+  - purpose: legal_reference_storage
+    status: active
+    api: "Godot custom Resource (.tres) via ResourceLoader.load(); LibraryEntry / LibraryLawEntry / LibraryPrecedentEntry / LibraryHolding classes"
+    not: "external YAML, Markdown + YAML front-matter, JSON, FileAccess.get_file_as_string + manual parse"
+    adr: docs/architecture/adr-0001-library-storage-format.md
+    reason: |
+      Static typing catches schema drift at parse time; ResourceLoader provides cache,
+      hot reload, thread safety; .tres is text format → git diff friendly; no external
+      dependency (GDScript ships JSON and Resource only — YAML would require an addon).
+    referenced_by:
+      - docs/architecture/adr-0001-library-storage-format.md
+    added: 2026-05-04
+    revised: ""
+
+  - purpose: library_holding_id_synthesis
+    status: active
+    api: "LibraryService.get_holding(synthesized_id: String) — single source of truth for case+holding ID concatenation and parsing"
+    not: "ad-hoc string concatenation in callers (e.g., '%s/holding-%d' % [case_id, n])"
+    adr: docs/architecture/adr-0001-library-storage-format.md
+    reason: |
+      Synthesis rule (delimiter, sub-holding nesting) may evolve. Centralising in
+      LibraryService.get_holding() means future format changes touch one function,
+      not every #6 evidence array or #7 brief editor token rendering site.
+    referenced_by:
+      - docs/architecture/adr-0001-library-storage-format.md
+    added: 2026-05-04
+    revised: ""
+
+  - purpose: submission_evaluation_storage
+    status: active
+    api: "Godot custom Resource (.tres) via class_name + extends Resource + @export — PlayerSubmission / EvaluationResult / CommentTemplates classes under src/data/"
+    not: "Dictionary I/O between EvaluationService and consumers (#7/#10/#11/#14); inline schema in script files"
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    reason: |
+      Mirrors ADR-0001 (Library) and ADR-0003 (Case Data) — static typing catches
+      schema drift at parse time across 4 downstream consumers (#7 Brief Editor,
+      #10 Verdict Reveal, #11 Career Progression, #14 Retrospective Replay).
+      Dictionary I/O would lose autocomplete, refactor safety, and create silent
+      key-typo bugs that only surface at the 4-consumer integration boundary.
+    referenced_by:
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+    revised: ""
+
+  - purpose: verdict_threshold_storage
+    status: active
+    api: "design/registry/entities.yaml `constants:` section (`submission_verdict_thresholds: {pagi: 0.7, low: 0.3}`) loaded once via EvaluationService._ready()"
+    not: "per-case override in case .tres scoring_weights or case-level fields; const inline in evaluation_service.gd"
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    reason: |
+      verdict thresholds are global by Pillar 1 design (모든 케이스가 동일 평가 룰).
+      Per-case override would create 'easy mode' cases that destroy 변별력. Inline
+      const requires code change for tuning — playtest sprint cycle penalty.
+      entities.yaml lets designers tune without touching .gd files (mirror ADR-0003
+      scoring_weights externalisation).
+    referenced_by:
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+    revised: ""
+
+  - purpose: citation_drop_signal_topology_hybrid
+    status: active
+    api: "Hybrid: Godot 4.6 native drag-drop API (`Control._get_drag_data` / `_can_drop_data` / `_drop_data` callbacks) for drop completion + LibraryService autoload signal `citation_drag_started(library_id)` for drop-zone hint activation. Application-level `WorkspaceData.pending_citation: String` for KB Space-mark/Space-attach path (mirror of pointer drag)."
+    not: "Pure signal topology (drag_completed signal — no native API leverage); pure native API (no signal — drop-zone hint cannot activate during drag); dual emitter from both LibraryService and LibraryPane (Gate ③ invariant 1 violation — exactly-once not guaranteed)"
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    reason: |
+      Native drag-drop API is best for drop validation (`_can_drop_data` provides
+      Workspace State guard at the engine level) but does not emit a "drag started"
+      event — only `_get_drag_data` is called once at drag init. Drop-zone hint
+      activation requires an explicit signal. Hybrid topology uses each channel
+      where it fits: native callbacks for the drop, LibraryService signal for the
+      hint. KB path reuses the same signal path (Space-mark also emits
+      citation_drag_started) — single emitter ensures Gate ③ invariant 1.
+    referenced_by:
+      - docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    revised: ""
+
+  - purpose: chain_data_schema_single_source
+    status: active
+    api: "`src/data/chain_data_schema.gd` defines `const SCHEMA_V1_ALLOWED_FIELDS` (top-level keys) + `const SCHEMA_V1_NODE_FIELDS` (per-node keys). Both Workspace builder (#6) and EvaluationService Pre-evaluation Gate (#9) import this file."
+    not: "Inline const definitions in workspace builder + evaluation_service (Gate § 3.1.2 dual-layer guard fails the moment one drifts); Dictionary keys in entities.yaml (runtime parse cost + loose typing); hardcoded keys in test fixtures (test/prod drift)"
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    reason: |
+      Reasoning Workspace GDD §3.1 Rule 6 establishes a dual-layer schema guard
+      for Pillar 1 silent regression defense. Dual-layer requires both layers to
+      validate against the same allow-list. Single source of truth via const file
+      makes drift impossible — any modification triggers compile-time import
+      failure in the consumer that lags. Forbidden_pattern
+      `chain_data_schema_allow_list_duplication` enforces this.
+    referenced_by:
+      - docs/architecture/adr-0008-workspace-layout.md
+      - docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-07
+    revised: ""
+
+  - purpose: workspace_pending_citation_application_state
+    status: active
+    api: "`WorkspaceData.pending_citation: String` (empty = no pending; non-empty = library_id awaiting attach). Set by LibraryPane on KB Space-mark or LB pane-switcher → A button. Cleared by Workspace on Space-attach success or Esc/B cancel."
+    not: "LibraryService autoload pending_citation (LibraryService is observation-free per Gate ③ invariant 4); Per-LibraryPane local state (pane switching loses pending — KB workflow broken)"
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    reason: |
+      KB CitationDrop spans pane focus changes (LibraryPane → DeskPane via Tab).
+      Per-pane state would clear on Tab. WorkspaceData ownership is correct because
+      pending_citation is a *Workspace-side* concept (drop validation is Workspace's
+      Rule 4 responsibility per Gate ③ invariant 4); LibraryPane is just the focus
+      origin. Native drag (Pointer) and KB pending are mutually exclusive — guard
+      enforced via `WorkspaceData.pending_citation == ""` precondition for native
+      drag start.
+    referenced_by:
+      - docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    revised: ""
+
+  - purpose: tree_panning_camera2d
+    status: active
+    api: "DeskCanvas (SubViewportContainer + SubViewport) hosts `HypothesisNodeRoot` (Node2D) with a Camera2D for panning. Mouse middle-drag pans 1:1; gamepad right-stick analog at 600 px/s; D-pad/Tab/Arrow auto-center on focused node (0.2s lerp). Camera position clamped to HypothesisNodeRoot bounding box + 200px padding."
+    not: "ScrollContainer with internal Node2D (loses analog stick + auto-center); manual translate on HypothesisNodeRoot (no clamp + no smooth lerp); Camera2D on root scene (other panes panned simultaneously)"
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    reason: |
+      4-deep tree (4 × 200px ≈ 900px wide) at 1366×768 floor (DeskPane ≈ 566px)
+      requires horizontal panning. Auto-center on KB/gamepad focus traversal keeps
+      focused node visible without manual scroll. SubViewport isolates the
+      Camera2D from other UI (CatalogPane, LibraryPane don't pan). Clamping
+      prevents player from panning into infinite empty space (UX disorientation).
+    referenced_by:
+      - docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    revised: ""
+
+  - purpose: memo_panel_inline_fallback_threshold
+    status: active
+    api: "MemoPanel position: (A) inline next to selected node = primary; (B) DeskPane bottom-right 320×220px fixed = fallback. Trigger: DeskPane.size.x < 720 OR (selected_node.global_position.x + selected_node.size.x + 16 + 320 > DeskPane.global_position.x + DeskPane.size.x). Reflow on `_on_node_selected(node)` or `_on_resize()`."
+    not: "(A) only with no fallback (overflow at floor resolution); (B) fixed always (loses spatial node-memo coupling — Pillar 1 weakened); (C) modal (Pillar 3 contemplative flow violation per cycle 1 reject)"
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    reason: |
+      GDD §9.3 cycle 1 recommendation (A) primary + (B) fallback was missing
+      trigger threshold — cycle 2 ux-designer IMPORTANT closure. 720px boundary
+      derives from 1366×768 floor (DeskPane ≈ 566 < 720 → (B) is default at floor;
+      1080p Wide DeskPane > 720 → (A) primary). 16px gap + 320px memo width covers
+      ~24-char RichTextLabel display.
+    referenced_by:
+      - docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    revised: ""
+
+  - purpose: gamepad_pane_switcher_lb_rb
+    status: active
+    api: "LB / RB shoulder buttons cycle pane focus (CatalogPane ↔ LibraryPane ↔ DeskPane). Within each pane, D-pad / left-stick traverses focusable elements (cards / nodes / buttons)."
+    not: "Single D-pad handles both pane switch + element navigate (modal confusion); per-button assignment for pane direct jump (button budget over-spend on 3-pane layout)"
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    reason: |
+      Gamepad CitationDrop two-step (OQ-W9 closure) requires player to navigate
+      LibraryPane → DeskPane mid-flow. LB/RB cycle is the standard 3-pane gamepad
+      idiom (mirrors Steam/console UI navigation). D-pad reserved for in-pane
+      element traversal (more frequent operation). Reasoning Workspace GDD §9.4.3
+      did not specify pane switcher — ADR-0008 §5 fills the gap.
+    referenced_by:
+      - docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    revised: ""
+
+  - purpose: font_msdf_hangul_only
+    status: active
+    api: "본명조 (Korean serif): MSDF FontFile (multichannel_signed_distance_field=true, msdf_size=32, msdf_pixel_range=6) covering Hangul precomposed only (U+AC00-U+D7A3, ~11,172 glyphs). Hanja (U+4E00-U+9FFF) handled via FontFile.fallbacks → NotoSerifCJK TTF (non-MSDF)."
+    not: "Full-glyph MSDF including Hanja (~13,500 glyphs at 64×64 cell ≈ 220 MB GPU resident — 4× the 50 MB budget); MSDF-only without TTF fallback (silent OS-font fallback for missing Hanja → cross-machine inconsistency)"
+    adr: docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    reason: |
+      Korean serif strokes alias badly at small sizes (11–14pt body) — MSDF gives
+      crisp scaling. But naive full-glyph MSDF blows the GPU memory budget by 4×.
+      Hangul-only MSDF + Hanja TTF fallback keeps body-size 본명조 crisp where
+      it matters, while accepting Hanja anti-aliasing at 14pt+ display sizes
+      (Hanja appears mainly in headlines like "大法院"/"破棄"/"棄却").
+      32×32 atlas cell + BC7 GPU compression = ~14 MB resident — fits the
+      50 MB total font asset budget comfortably.
+    referenced_by:
+      - docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    added: 2026-05-06
+    revised: ""
+
+  - purpose: font_subpixel_screen_optimised
+    status: active
+    api: "Pretendard (Korean sans-serif): TTF FontFile + subpixel_positioning = SUBPIXEL_POSITIONING_ONE_QUARTER + antialiasing = ANTIALIASING_LCD + hinting = HINTING_LIGHT. IBM Plex Mono KR (mono): TTF FontFile + subpixel_positioning = SUBPIXEL_POSITIONING_DISABLED + antialiasing = ANTIALIASING_GRAYSCALE + hinting = HINTING_NORMAL."
+    not: "MSDF for screen-optimised fonts (negates Pretendard/Plex Mono's screen design); SUBPIXEL_POSITIONING_AUTO for Pretendard 11–14pt (settles on ONE_HALF — measurably less sharp than ONE_QUARTER); subpixel positioning enabled for monospace (breaks pixel-grid alignment)"
+    adr: docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    reason: |
+      Pretendard is Korean sans-serif designed screen-native — MSDF would
+      coarsen sub-pixel stroke detail. ONE_QUARTER subpixel + LIGHT hinting
+      gives Korean body 11–14pt vertical-stroke alignment that AUTO does not
+      guarantee. Plex Mono KR is fundamentally pixel-grid-aligned (mono
+      design intent) — subpixel positioning destroys the grid. Per-family
+      rendering matched to font design intent, not one-size-fits-all.
+    referenced_by:
+      - docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    added: 2026-05-06
+    revised: ""
+
+  - purpose: ui_theme_type_variations
+    status: active
+    api: "Single default Theme at assets/data/themes/default.tres with 12–15 type variations (e.g., &\"BodyLabel\", &\"CaptionLabel\", &\"CourtHeadline\", &\"HeroLabel\", &\"CodeLabel\", &\"CommentLabel\"). Controls set theme_type_variation property to select. Weight changes use Control.add_theme_font_override(\"font\", weight_resource) at instance level."
+    not: "Per-Control inline font/size assignment without type variations (defeats Theme reuse + makes global tuning impossible); separate Theme per screen (breaks i18n adaptation — one Theme update propagates to all screens)"
+    adr: docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    reason: |
+      Art Bible §6 specifies 8 document types each with distinct family+size
+      combinations. Type variations let one Theme express all of them, so a
+      tuning change (e.g., Pretendard body size 14→15) propagates to every
+      affected Control without touching scenes. Per-screen Themes would force
+      duplicate updates and i18n size adjustments would scale linearly with
+      screen count. Type variation pattern is the idiomatic Godot 4.6
+      approach for this scale (godot-specialist verification 2026-05-06).
+    referenced_by:
+      - docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    added: 2026-05-06
+    revised: ""
 
 # Example:
 #
@@ -157,7 +601,329 @@ api_decisions: []
 # Register a pattern when an ADR explicitly bans it AND other ADRs might
 # unknowingly use it (i.e., it's a tempting but wrong approach for this project).
 
-forbidden_patterns: []
+forbidden_patterns:
+  - pattern: library_data_load_via_FileAccess
+    status: active
+    description: |
+      Library data files (.tres) must be loaded via ResourceLoader.load() or load().
+      Direct FileAccess.get_file_as_string() + manual parsing is forbidden for any
+      file under assets/data/library/.
+    why: |
+      Bypasses Godot's resource cache (memory waste + duplicate parsing), loses
+      static typing (LibraryEntry subclass safety), breaks hot reload, and forces
+      reimplementation of UTF-8 + nested SubResource handling that ResourceLoader
+      already provides. Also breaks the 4.4 FileAccess.store_* bool-return contract.
+    adr: docs/architecture/adr-0001-library-storage-format.md
+    added: 2026-05-04
+
+  - pattern: library_holding_id_synthesis_in_callers
+    status: active
+    description: |
+      Concatenating <case_id> + '/holding-' + N to form a holding ID outside
+      LibraryService is forbidden. All synthesis and parsing of holding IDs
+      must go through LibraryService.get_holding(synthesized_id).
+    why: |
+      Synthesis rule may evolve (different delimiter, sub-holding nesting,
+      escape rules for unusual case numbers). Centralising in one function means
+      a future change updates one location instead of every consumer
+      (#6 Reasoning Workspace evidence, #7 Brief Editor cite token rendering).
+    adr: docs/architecture/adr-0001-library-storage-format.md
+    added: 2026-05-04
+
+  - pattern: library_runtime_external_api_call
+    status: active
+    description: |
+      Game runtime code (anything under src/) must NEVER call external Korean
+      law APIs (e.g., 국가법령정보센터 Open API, korean-law-mcp MCP server,
+      glaw.scourt.go.kr scrapers, or any other live legal-data fetch) to
+      populate Library entries or to validate citations at play time.
+      All Library data is statically loaded from .tres files at boot
+      (LibraryService Autoload). External API tools are permitted ONLY in
+      content-authoring tools (under tools/ or production/consultations/),
+      where their fetched data is manually reviewed and committed as .tres
+      seeds.
+    why: |
+      (1) Violates ADR-0001 "외부 의존성 0" — game runtime depends only on
+      engine-built-in features. (2) Violates Pillar 4 "끝나도 따라온다" —
+      game must work without internet, or the player can't take the
+      "reading muscle" home with them. (3) Open API rate limits / outages
+      would brick the game. (4) Library content must be reviewed by lawyer
+      consultants before reaching players — raw API fetch bypasses that
+      gate. Tools like korean-law-mcp belong in lawyer-prep workflows and
+      seed-content authoring scripts, never in src/.
+    adr: docs/architecture/adr-0001-library-storage-format.md
+    added: 2026-05-04
+
+  - pattern: per_case_verdict_threshold_override
+    status: active
+    description: |
+      Case .tres files MUST NOT contain verdict_threshold_* fields, scoring_weights
+      keys named verdict_threshold_*, or any case-level mechanism that overrides
+      the global verdict thresholds. The thresholds (pagi: 0.7, low: 0.3) live in
+      design/registry/entities.yaml `constants:` section as a single global source
+      of truth. EvaluationService loads them once at _ready() and never accepts
+      per-case overrides at runtime.
+    why: |
+      Pillar 1 (Truth Is Weighted) demands that all cases be evaluated under the
+      same rule set — per-case threshold override would create de facto 'easy
+      mode' cases by lowering the bar to 파기 cutoff, destroying the verdict's
+      meaning as a *weighted truth* signal. Per-case scoring_weights tuning
+      (which IS allowed by ADR-0003) provides legitimate per-case difficulty
+      adjustment via subscore weight redistribution. Threshold override is the
+      Anti-Pillar shortcut.
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+
+  - pattern: evaluation_caching_by_case_id
+    status: active
+    description: |
+      EvaluationService MUST NOT cache EvaluationResult instances keyed by
+      case_id, player_disposition, or any submission-derived hash. Every
+      submit() call recomputes from scratch — even when the same case_id has
+      been evaluated before in this session. External callers (#11 Career
+      Progression, #14 Retrospective Replay) MUST NOT cache returned
+      EvaluationResult and re-emit it later as a substitute for re-evaluation.
+    why: |
+      AC-23 byte-identical determinism makes caching algorithmically unnecessary
+      (same input → same output). Caching introduces stale-data risk: when
+      designers tune scoring_weights in entities.yaml or case .tres files,
+      a cached EvaluationResult from a prior run would not reflect the change
+      until invalidation. Always-recompute is simpler, deterministic, and
+      ensures playtest tuning takes effect immediately without explicit cache
+      busts.
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+
+  - pattern: autoload_order_violation_evaluation
+    status: active
+    description: |
+      EvaluationService MUST be registered THIRD in project.godot [autoload]
+      section — after LibraryService (FIRST) and CaseService (SECOND). Moving
+      it to FIRST or SECOND, or registering it before either of those services,
+      is forbidden.
+    why: |
+      Godot autoloads initialize synchronously in registration order. By the
+      time EvaluationService._ready() runs, LibraryService and CaseService
+      have already emitted their *_loaded signals. EvaluationService uses
+      heuristic guards (`LibraryService.entry_count() > 0`,
+      `CaseService.case_count() > 0`) to decide whether to await — this works
+      ONLY if the predecessors have actually completed. If EvaluationService
+      runs before either, the guards return 0 and `await` will hang forever
+      until the predecessor's _ready() completes — but in a chain inversion,
+      the predecessor's _ready() may itself await something that depends on
+      EvaluationService, creating a deadlock or boot fail. The THIRD-position
+      requirement is a precondition for the heuristic guard pattern (Risk 3
+      in ADR-0007) to work correctly.
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+
+  - pattern: text_server_simple_for_korean
+    status: active
+    description: |
+      project.godot MUST set [rendering] text_server/backend = "TextServerAdvanced"
+      explicitly. Relying on the default or allowing TextServerSimple is forbidden
+      for any project shipping Korean text. The Compatibility renderer can silently
+      downgrade to TextServerSimple — that downgrade is forbidden for this project.
+    why: |
+      Korean text requires HarfBuzz shaping for Hangul jamo composition (Unicode
+      Hangul Syllable Algorithm) and Hanja correctness. TextServerSimple does not
+      ship HarfBuzz — it produces broken Korean rendering (missing jamo composition,
+      incorrect Hanja shaping, no bidi support). The bug is silent: text appears
+      but is malformed. This must be locked at project-setting level, not relied on
+      as a default, because Compatibility renderer toggles can downgrade silently.
+    adr: docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    added: 2026-05-06
+
+  - pattern: font_msdf_full_glyph_set
+    status: active
+    description: |
+      MSDF atlases for fonts covering full CJK glyph sets (~13K+ glyphs including
+      Hangul + Hanja + Latin) at 64×64 cell sizes are forbidden. Restrict MSDF to
+      either (a) Hangul-only (~11K glyphs) at 32×32 cells with GPU compression,
+      or (b) explicit smaller subset with documented memory budget.
+    why: |
+      13K glyphs × 64×64 cells × 4 bytes/pixel ≈ 220 MB GPU resident — 4× the
+      50 MB font asset budget and roughly 10% of the 2 GB memory ceiling. The
+      coverage was originally proposed in ADR-0004 draft and rejected after
+      godot-specialist verification (2026-05-06) — actual atlas memory is far
+      higher than the original 30–50 MB estimate. Hangul-only at 32×32 + BC7
+      compression keeps it at ~14 MB. Hanja gets TTF fallback (still legible at
+      headline sizes where Hanja appears).
+    adr: docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    added: 2026-05-06
+
+  - pattern: label_for_long_body_text
+    status: active
+    description: |
+      Using `Label` (Godot built-in single-line/multi-line text Control) for long
+      body text (≥10 lines, e.g., #20 Library full_opinion or #5 Browser DeskPane
+      4–8 paragraph 본문) is forbidden. Long body text MUST use `RichTextLabel`
+      with `scroll_active = true` inside a `ScrollContainer` parent for visual
+      virtualization (off-screen lines not rendered).
+    why: |
+      Label renders the entire text to a single draw call regardless of scroll
+      position. 500 lines of Korean text in a Label triggers a frame-budget spike
+      every render — typically dropping below 60fps target on the #20 Library
+      full_opinion view. RichTextLabel with scroll_active virtualizes off-screen
+      content, keeping per-frame cost bounded by visible line count regardless
+      of total document length. This is a hard requirement for the 60fps + 16.6ms
+      frame budget specified in technical-preferences.md.
+    adr: docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    added: 2026-05-06
+
+  - pattern: inline_theme_override_without_type_variation
+    status: active
+    description: |
+      Setting font + font_size on a Control via `add_theme_font_override("font", ...)`
+      AND `add_theme_font_size_override("font_size", ...)` simultaneously WITHOUT
+      using a Theme type variation (theme_type_variation property) is forbidden for
+      Controls following Art Bible §6 document types. Type variations are the
+      authoritative pattern; instance overrides are reserved for weight changes
+      within an existing type variation.
+    why: |
+      Per-Control inline font + size assignment defeats Theme reuse — a global
+      tuning change (e.g., Pretendard body 14→15pt) cannot propagate to every
+      affected Control without touching every scene. Type variations centralize
+      family + size choices in default.tres, leaving instance-level overrides for
+      genuinely instance-specific adjustments (e.g., bold weight on a single
+      heading within a paragraph). Mixed usage produces inconsistent rendering
+      and breaks i18n adaptation, where one Theme update should cover all screens.
+    adr: docs/architecture/adr-0004-korean-text-rendering-msdf-font.md
+    added: 2026-05-06
+
+  - pattern: dict_value_packed_array_inplace_mutation
+    status: active
+    description: |
+      Storing a `PackedStringArray` (or any other Packed* typed array) as a
+      Dictionary value, then attempting in-place mutation via dict[key].append()
+      or dict[key].push_back() is forbidden. PackedStringArray is a *value type*
+      with copy-on-write semantics — Dictionary returns a copy, not a reference.
+      Use `Array` (reference type) as the Dictionary value type, OR explicit
+      copy-mutate-write-back pattern: `var arr := dict[key]; arr.append(x);
+      dict[key] = arr`.
+    why: |
+      The bug is silent: `dict[key].append(x)` succeeds without warning but
+      mutates a temporary copy that is discarded. Operator-side semantics
+      (PackedStringArray as value type) differ from `Array` (reference type)
+      and the GDScript surface looks identical. Surfaced during ADR-0002
+      Library Search Index development (n-gram inverted index) — all search
+      queries returned 0 results because every postings list mutation was
+      silently lost. Documented in ADR-0002 §11 Implementation Lesson.
+    adr: docs/architecture/adr-0002-library-search-index-format.md
+    added: 2026-05-06
+    notes: |
+      Carry-over candidate from architecture-review 2026-05-05 (post-ADR-0003).
+      Registered retroactively during architecture-review 2026-05-06. Future
+      ADRs that store collections as Dictionary values must reference this
+      pattern when justifying Array vs Packed* choice.
+
+  - pattern: class_name_collides_with_autoload_name
+    status: active
+    description: |
+      Registering a `class_name` identifier in a script that is *also* used as
+      the autoload name in `project.godot [autoload]` section is forbidden.
+      Autoload-bound services (LibraryService, CaseService, EvaluationService)
+      MUST omit `class_name` from their script — they are accessed exclusively
+      through the autoload global, not as a class. Resource subclasses
+      (LibraryEntry, CaseFile, PlayerSubmission, EvaluationResult, etc.) keep
+      their `class_name` as those are *types*, not autoload singletons.
+    why: |
+      Godot 4.x stores autoload names and class_name identifiers in the same
+      global namespace. Registering both for the same identifier creates a
+      duplicate-definition warning at editor parse time AND a runtime ambiguity
+      where script reload may bind the identifier to the script type rather
+      than the autoload instance — breaking `LibraryService.entry_count()`
+      style calls intermittently. Surfaced during LibraryService autoload
+      registration (ADR-0001 §IG #3) and reconfirmed during CaseService
+      (ADR-0003) and EvaluationService (ADR-0007) — all three services follow
+      the no-class_name pattern.
+    adr: docs/architecture/adr-0001-library-storage-format.md
+    added: 2026-05-06
+    notes: |
+      Carry-over candidate from architecture-review 2026-05-05 (post-ADR-0003).
+      Applies to all 3 autoload services (LibraryService FIRST + CaseService
+      SECOND + EvaluationService THIRD per `autoload_order_violation_evaluation`).
+      Registered retroactively during architecture-review 2026-05-06.
+
+  - pattern: submit_during_active_evaluation
+    status: active
+    description: |
+      Calling `EvaluationService.submit(submission)` while
+      `EvaluationService.current_state` is in {VALIDATING, COMPUTING, REPORTING}
+      is forbidden. The service rejects the second call with `push_warning` and
+      no signal emission — but external callers (#5 Browser, #7 Brief Editor)
+      MUST proactively gate the Submit button via `current_state != IDLE` rather
+      than relying on the defensive guard. The guard is a safety net, not a
+      contract for repeated submission attempts.
+    why: |
+      Distinct from `autoload_order_violation_evaluation` (which is about
+      registration order in project.godot) — this pattern guards *runtime
+      reentrant calls*. Without external UI gating, players can spam the
+      Submit button during the ~50ms evaluation window, generating
+      noise warnings and making subscore breakdowns harder to debug.
+      The forbidden pattern documents the *external contract* that consumers
+      must respect, not just the internal state guard. ADR-0007 §EC-7 + AC-18
+      define the rejection behaviour; this pattern formalises the consumer
+      obligation.
+    adr: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+    added: 2026-05-06
+    notes: |
+      New candidate surfaced during architecture-review 2026-05-06 from
+      session-state Pri 4 carry-over. Browser/Editor implementations must
+      disable Submit button when current_state != IDLE — this is the primary
+      enforcement; defensive guard is secondary.
+
+  - pattern: chain_data_schema_allow_list_duplication
+    status: active
+    description: |
+      The chain_data schema_version=1 allow-list (top-level fields + node
+      fields) MUST be defined exactly once in `src/data/chain_data_schema.gd`
+      as `const SCHEMA_V1_ALLOWED_FIELDS` and `const SCHEMA_V1_NODE_FIELDS`.
+      Both Workspace builder (in #6 Reasoning Workspace) and EvaluationService
+      Pre-evaluation Gate (in #9 Submission & Evaluation) must `import` or
+      reference the same const — neither may inline its own copy.
+    why: |
+      ADR-0007 §3.1.2 + Reasoning Workspace GDD §3.1 Rule 6 establish a
+      dual-layer schema guard for Pillar 1 silent regression defense. The
+      guard fails the moment one layer's allow-list drifts from the other —
+      a schema_version=1 violation could pass the builder check but fail
+      Pre-evaluation Gate, or vice versa. Single source of truth makes drift
+      impossible. Inline duplication in either consumer is the *anti-pattern*
+      that the dual-layer architecture is designed to prevent — duplication
+      defeats the structural defense.
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    notes: |
+      Surfaced during reasoning-workspace 2026-05-07 cycle 2 design-review —
+      cross-concurrence by game-designer + godot-specialist (B-NEW-2 + Item 7).
+      Workspace Layout ADR-0008 §1 Migration Plan creates the const file.
+
+  - pattern: library_subsystem_observe_drop_result
+    status: active
+    description: |
+      LibraryService autoload (and any LibraryPane scene node) MUST NOT
+      observe or query the result of CitationDrop hit-test (drop accept /
+      reject). LibraryService emits `citation_drag_started(library_id)` only;
+      drop completion + Rule 4 validation (cap, duplicate, type) is solely
+      Workspace's responsibility. If LibraryService needs telemetry on
+      drop outcomes, Workspace must call an explicit notification method
+      (e.g., `LibraryService.notify_citation_attached(library_id, node_id)`)
+      after the fact — polling is forbidden.
+    why: |
+      Reasoning Workspace GDD §3.3 Gate ③ invariant 4 — separation of
+      concerns between Library Subsystem (citation source emit) and Workspace
+      (drop validation + side effects). Polling violations create coupling
+      where LibraryService becomes implicitly aware of Workspace's Rule 4
+      cap policy, hit-test geometry, and Workspace State guards. This makes
+      LibraryService's behavior dependent on Workspace's internal state —
+      the exact opposite of the contract established by Gate ③.
+    adr: docs/architecture/adr-0008-workspace-layout.md
+    added: 2026-05-07
+    notes: |
+      Reasoning Workspace cycle 2 BLOCKING #8 closure context. Native
+      drag-drop API + LibraryService signal hybrid topology requires this
+      pattern to be explicitly forbidden because both channels could be
+      tempted to query drop result.
 
 # Example:
 #

--- a/docs/tech-debt-register.md
+++ b/docs/tech-debt-register.md
@@ -13,13 +13,6 @@ description, origin, and recommended repayment trigger. Maintained via `/tech-de
 
 ## Open
 
-### TD-001 — EvaluationService.submit() signature conflict (ADR-0007 vs control-manifest)
-- **Logged**: 2026-05-23
-- **Severity**: HIGH (blocks story #9 / submission-evaluation epic)
-- **Description**: `ADR-0007 §Decision` specifies `EvaluationService.submit(submission: PlayerSubmission)` where `PlayerSubmission` is a typed Resource carrying `case_id` / `player_disposition` / `player_citations` / `chain_data` / `submission_time_ms`. The `control-manifest.md` Feature Layer rule specifies `submit(chain_data: Dictionary)`. These signatures are incompatible.
-- **Origin**: Surfaced during story-007 data-layer implementation (2026-05-23). EvaluationService does not exist yet, so the conflict is currently harmless. A forward-claim comment in `src/data/workspace_data.gd` `submit()` flags it.
-- **Repayment trigger**: MUST reconcile before story #9 (submission-evaluation) begins. Resolution requires an explicit decision (ADR-0007 amendment OR control-manifest correction) — do not resolve by guessing. PlayerSubmission's `player_disposition` + `player_citations` come from the Brief Editor submit dialog, which informs which signature is correct.
-
 ### TD-002 — Untyped `Array` in WorkspaceData (static-typing standard)
 - **Logged**: 2026-05-23
 - **Severity**: LOW (standards hygiene; no runtime correctness impact)
@@ -52,4 +45,7 @@ description, origin, and recommended repayment trigger. Maintained via `/tech-de
 
 ## Resolved
 
-_(none yet)_
+### TD-001 — EvaluationService.submit() signature conflict (ADR-0007 vs control-manifest) — RESOLVED 2026-05-23
+- **Was**: `ADR-0007 §Decision` specifies `submit(submission: PlayerSubmission)` (Resource carrying `case_id` / `player_disposition` / `player_citations` / `chain_data` / `submission_time_ms`); `control-manifest.md` said `submit(chain_data: Dictionary)`. Incompatible.
+- **Resolution**: `submit(submission: PlayerSubmission)` is canonical. Decisive grounds: ADR-0007's grading algorithm scores `player_disposition` + `player_citations` (Set ops vs correct/missed/redundant sets — ADR-0007 §Performance line 279), neither of which is in `chain_data` (which is MVP-empty; chain_coherence subscore is v1+). `submit(chain_data: Dictionary)` literally cannot evaluate. The control-manifest had misquoted its own cited source (ADR-0007 §Decision). Not a trade-off — one option was simply wrong.
+- **Actions taken**: corrected control-manifest line 135 to `submit(submission: PlayerSubmission)` with a dated TD-001 note (no version bump — correction to match source, not a new rule); updated forward-claim comments in `src/data/workspace_data.gd` `submit()` and `src/services/save_load_service.gd` `_on_evaluation_completed`. EvaluationService implementation (Submission/Evaluation epic) can now proceed against the clear contract.

--- a/docs/tech-debt-register.md
+++ b/docs/tech-debt-register.md
@@ -1,0 +1,55 @@
+# Tech Debt Register
+
+Tracked technical debt across the codebase. Each entry: ID, date logged, severity,
+description, origin, and recommended repayment trigger. Maintained via `/tech-debt`.
+
+| Severity | Meaning |
+|----------|---------|
+| HIGH | Will block or break a near-term story if unaddressed |
+| MEDIUM | Causes drift/risk; address within the milestone |
+| LOW | Cosmetic / standards hygiene; address opportunistically |
+
+---
+
+## Open
+
+### TD-001 — EvaluationService.submit() signature conflict (ADR-0007 vs control-manifest)
+- **Logged**: 2026-05-23
+- **Severity**: HIGH (blocks story #9 / submission-evaluation epic)
+- **Description**: `ADR-0007 §Decision` specifies `EvaluationService.submit(submission: PlayerSubmission)` where `PlayerSubmission` is a typed Resource carrying `case_id` / `player_disposition` / `player_citations` / `chain_data` / `submission_time_ms`. The `control-manifest.md` Feature Layer rule specifies `submit(chain_data: Dictionary)`. These signatures are incompatible.
+- **Origin**: Surfaced during story-007 data-layer implementation (2026-05-23). EvaluationService does not exist yet, so the conflict is currently harmless. A forward-claim comment in `src/data/workspace_data.gd` `submit()` flags it.
+- **Repayment trigger**: MUST reconcile before story #9 (submission-evaluation) begins. Resolution requires an explicit decision (ADR-0007 amendment OR control-manifest correction) — do not resolve by guessing. PlayerSubmission's `player_disposition` + `player_citations` come from the Brief Editor submit dialog, which informs which signature is correct.
+
+### TD-002 — Untyped `Array` in WorkspaceData (static-typing standard)
+- **Logged**: 2026-05-23
+- **Severity**: LOW (standards hygiene; no runtime correctness impact)
+- **Description**: In `src/data/workspace_data.gd`: `const ALLOWED_NODE_FIELDS: Array` should be `Array[String]`; `_roots()` and `_children_of()` return untyped `-> Array` (could be `-> Array[HypothesisNodeData]`). technical-preferences.md requires typed arrays everywhere.
+- **Origin**: Pre-existing code from story-002 / story-003a. Flagged by godot-gdscript-specialist during story-007 code review (MINOR-3/MINOR-4); not introduced by story-007.
+- **Repayment trigger**: Opportunistic — fold into the next WorkspaceData-touching story, or a dedicated typing-hygiene pass.
+
+### TD-003 — engine-reference ui.md line 94 AccessKit role API may be inaccurate
+- **Logged**: 2026-05-23
+- **Severity**: MEDIUM (misleads UI Foundation / accessibility stories)
+- **Description**: `docs/engine-reference/godot/modules/ui.md` line 94 states `DisplayServer.AccessibilityRole` is "set via `Control.set_accessibility_role()`" (marked "Verified ... 2026-05-17"). Runtime investigation during story-002 (UI Foundation) found Godot 4.6 `Control` has **no `accessibility_role` property and no `set_accessibility_role()` method**; the working API is `DisplayServer.accessibility_update_set_role(rid, role)` with `rid = Control.get_accessibility_element()`, callable only inside `NOTIFICATION_ACCESSIBILITY_UPDATE` (=3000). The Kr* classes were implemented against the working API (tests pass).
+- **Origin**: story-002 implementation (godot-gdscript-specialist runtime finding, 2026-05-23).
+- **Repayment trigger**: Verify against actual Godot 4.6 source/docs. If confirmed, correct ui.md line 94 + the AccessibilityRole section's "set via" sentence so future stories use the RID + notification pattern from the start. If `set_accessibility_role()` does exist as a convenience wrapper, document both. Until resolved, follow the working pattern in `src/ui/kr_pane.gd`.
+
+### TD-004 — current-best-practices.md atomic-write snippet uses an invalid temp extension
+- **Logged**: 2026-05-23
+- **Severity**: MEDIUM (would silently break any atomic save built from the snippet)
+- **Description**: `docs/engine-reference/godot/current-best-practices.md` (§File I/O — Atomic Write Pattern, ~line 132) writes the temp file as `"user://settings.tres.tmp"`. `ResourceSaver.save()` selects its format from the file EXTENSION, and a bare `.tmp` extension yields `ERR_FILE_UNRECOGNIZED` (error 15) — the save fails and the atomic write never works. Verified during story-001 (Save/Load) implementation: the temp path must keep a recognized extension. `SaveLoadService._save_resource_atomic` uses `name.tres` → `name.tmp.tres` instead.
+- **Origin**: story-001 (Save/Load) implementation + test, 2026-05-23.
+- **Repayment trigger**: Correct the snippet in current-best-practices.md to insert `.tmp` before the extension (e.g. `settings.tmp.tres`) so future code copied from it works. Low effort, do opportunistically.
+
+### TD-005 — CI must regenerate the global class cache before gdunit4 runs
+- **Logged**: 2026-05-23
+- **Severity**: MEDIUM (green locally, would fail CI for any new class_name used in autoload code)
+- **Description**: New `class_name` scripts are not registered in `.godot/global_script_class_cache.cfg` until an editor scan runs. When an AUTOLOAD (parsed at boot, before any test preload) references a brand-new `class_name` as a type (e.g. `SaveLoadService` referencing `ActiveCaseSaveData`), the autoload fails to parse in a headless test run and every test errors. Worked around locally by running `godot --headless --import` once to regenerate the cache. The project CI command (`godot --headless --script tests/gdunit4_runner.gd`) does NOT pre-import, so it would hit this on a clean checkout (`.godot/` is typically gitignored).
+- **Origin**: story-003 (Save/Load) — `SaveLoadService._active_case: ActiveCaseSaveData`, 2026-05-23.
+- **Repayment trigger**: Add a `godot --headless --import` (or `--editor --quit`) step to the CI workflow BEFORE the gdunit4 run so global class names resolve. Verify the gdunit4 GitHub Action does this; if not, add it. Until then, run `--import` after adding any new `class_name` referenced by autoload code.
+
+---
+
+## Resolved
+
+_(none yet)_

--- a/production/epics/index.md
+++ b/production/epics/index.md
@@ -7,7 +7,7 @@ Engine: Godot 4.6 (4.6.1.stable.official.14d19694e runtime confirmed 2026-05-17)
 |------|-------|--------|-----|---------|--------|
 | [Reasoning Workspace](reasoning-workspace/EPIC.md) | Feature (Gameplay) | #6 Reasoning Workspace | [reasoning-workspace.md](../../design/gdd/reasoning-workspace.md) | 12 (5 Complete: 001+002+003a + 007-data-layer + 012-subset; remainder blocked on UI Foundation / SaveLoadService / EvaluationService) | In Progress |
 | [UI Foundation](ui-foundation/EPIC.md) | Foundation (Core) | #2 UI Foundation | [ui-foundation.md](../../design/gdd/ui-foundation.md) | 5 (3 Complete: 001 UIService + 002 KrCustomControl + 004 tween gateway; 003 blocked on MSDF fonts, 005 pending) | In Progress |
-| [Submission & Evaluation](submission-evaluation/EPIC.md) | Feature (Gameplay) / Core | #9 Submission & Evaluation | [submission-evaluation.md](../../design/gdd/submission-evaluation.md) | 5 (3 Complete: 001 Resources/autoload + 002 scoring + 003 verdict — deterministic core; 004 state machine + 005 comments remain) | In Progress |
+| [Submission & Evaluation](submission-evaluation/EPIC.md) | Feature (Gameplay) / Core | #9 Submission & Evaluation | [submission-evaluation.md](../../design/gdd/submission-evaluation.md) | 5 (4 Complete: 001 Resources + 002 scoring + 003 verdict + 004 submit pipeline [keystone]; 005 comments remain) | In Progress |
 | [Save/Load](save-load/EPIC.md) | Core / Foundation | #3 Save/Load | [save-load.md](../../design/gdd/save-load.md) | 8/8 implementable cores Complete (001-004+007+008 full; 005/006 core+contract done, EvaluationService/controller end-to-end deferred — TD-001) | In Progress (epic gated on EvaluationService) |
 
 ## Pending epic creation (Implementation-ready systems)

--- a/production/epics/index.md
+++ b/production/epics/index.md
@@ -1,0 +1,24 @@
+# Epics Index
+
+Last Updated: 2026-05-23
+Engine: Godot 4.6 (4.6.1.stable.official.14d19694e runtime confirmed 2026-05-17)
+
+| Epic | Layer | System | GDD | Stories | Status |
+|------|-------|--------|-----|---------|--------|
+| [Reasoning Workspace](reasoning-workspace/EPIC.md) | Feature (Gameplay) | #6 Reasoning Workspace | [reasoning-workspace.md](../../design/gdd/reasoning-workspace.md) | 12 (5 Complete: 001+002+003a + 007-data-layer + 012-subset; remainder blocked on UI Foundation / SaveLoadService / EvaluationService) | In Progress |
+| [UI Foundation](ui-foundation/EPIC.md) | Foundation (Core) | #2 UI Foundation | [ui-foundation.md](../../design/gdd/ui-foundation.md) | 5 (3 Complete: 001 UIService + 002 KrCustomControl + 004 tween gateway; 003 blocked on MSDF fonts, 005 pending) | In Progress |
+| [Save/Load](save-load/EPIC.md) | Core / Foundation | #3 Save/Load | [save-load.md](../../design/gdd/save-load.md) | 8 (5 Complete: 001 atomic write + 002 Resource classes + 003 autosave + 004 boot load/recovery + 007 anti-pillar guards; 005/006 partially deferred on EvaluationService, 008 close-flush remain) | In Progress |
+
+## Pending epic creation (Implementation-ready systems)
+
+- **#7 Brief Editor** — blocked on Day 2 GDD Scope Reduction pass (§1·§2·§4·§8·§10 재포지셔닝 + 35 AC → ~20 AC + RC-D/E closure) + cycle 5 lean verification. Run `/create-epics brief-editor` after.
+- **#4 Settings & Accessibility** — Core epic (SettingsService autoload + 5 카테고리 17 settings + ConfigFile persist + 5-step cascade + SettingsScreen UI). ADR-0009 Accepted 2026-05-18. Run `/create-epics settings-accessibility`.
+- ~~#3 Save/Load~~ — **epic created 2026-05-23** (`save-load/EPIC.md`). Run `/create-stories save-load`.
+
+## Pending design completion (NOT implementation-ready)
+
+- #5 Case File Browser — Designed Provisional, Browser Layout ADR pending
+- #8 Investigation Slots — Not Started
+- #9 Submission & Evaluation — Designed + ADR-0007 Accepted, epic creation cascade after dependency systems
+- #10 Verdict Reveal Sequence — Not Started
+- (Other systems — see `design/gdd/systems-index.md`)

--- a/production/epics/index.md
+++ b/production/epics/index.md
@@ -7,6 +7,7 @@ Engine: Godot 4.6 (4.6.1.stable.official.14d19694e runtime confirmed 2026-05-17)
 |------|-------|--------|-----|---------|--------|
 | [Reasoning Workspace](reasoning-workspace/EPIC.md) | Feature (Gameplay) | #6 Reasoning Workspace | [reasoning-workspace.md](../../design/gdd/reasoning-workspace.md) | 12 (5 Complete: 001+002+003a + 007-data-layer + 012-subset; remainder blocked on UI Foundation / SaveLoadService / EvaluationService) | In Progress |
 | [UI Foundation](ui-foundation/EPIC.md) | Foundation (Core) | #2 UI Foundation | [ui-foundation.md](../../design/gdd/ui-foundation.md) | 5 (3 Complete: 001 UIService + 002 KrCustomControl + 004 tween gateway; 003 blocked on MSDF fonts, 005 pending) | In Progress |
+| [Submission & Evaluation](submission-evaluation/EPIC.md) | Feature (Gameplay) / Core | #9 Submission & Evaluation | [submission-evaluation.md](../../design/gdd/submission-evaluation.md) | 5 (3 Complete: 001 Resources/autoload + 002 scoring + 003 verdict — deterministic core; 004 state machine + 005 comments remain) | In Progress |
 | [Save/Load](save-load/EPIC.md) | Core / Foundation | #3 Save/Load | [save-load.md](../../design/gdd/save-load.md) | 8/8 implementable cores Complete (001-004+007+008 full; 005/006 core+contract done, EvaluationService/controller end-to-end deferred — TD-001) | In Progress (epic gated on EvaluationService) |
 
 ## Pending epic creation (Implementation-ready systems)

--- a/production/epics/index.md
+++ b/production/epics/index.md
@@ -7,7 +7,7 @@ Engine: Godot 4.6 (4.6.1.stable.official.14d19694e runtime confirmed 2026-05-17)
 |------|-------|--------|-----|---------|--------|
 | [Reasoning Workspace](reasoning-workspace/EPIC.md) | Feature (Gameplay) | #6 Reasoning Workspace | [reasoning-workspace.md](../../design/gdd/reasoning-workspace.md) | 12 (5 Complete: 001+002+003a + 007-data-layer + 012-subset; remainder blocked on UI Foundation / SaveLoadService / EvaluationService) | In Progress |
 | [UI Foundation](ui-foundation/EPIC.md) | Foundation (Core) | #2 UI Foundation | [ui-foundation.md](../../design/gdd/ui-foundation.md) | 5 (3 Complete: 001 UIService + 002 KrCustomControl + 004 tween gateway; 003 blocked on MSDF fonts, 005 pending) | In Progress |
-| [Save/Load](save-load/EPIC.md) | Core / Foundation | #3 Save/Load | [save-load.md](../../design/gdd/save-load.md) | 8 (5 Complete: 001 atomic write + 002 Resource classes + 003 autosave + 004 boot load/recovery + 007 anti-pillar guards; 005/006 partially deferred on EvaluationService, 008 close-flush remain) | In Progress |
+| [Save/Load](save-load/EPIC.md) | Core / Foundation | #3 Save/Load | [save-load.md](../../design/gdd/save-load.md) | 8/8 implementable cores Complete (001-004+007+008 full; 005/006 core+contract done, EvaluationService/controller end-to-end deferred — TD-001) | In Progress (epic gated on EvaluationService) |
 
 ## Pending epic creation (Implementation-ready systems)
 

--- a/production/epics/index.md
+++ b/production/epics/index.md
@@ -7,7 +7,7 @@ Engine: Godot 4.6 (4.6.1.stable.official.14d19694e runtime confirmed 2026-05-17)
 |------|-------|--------|-----|---------|--------|
 | [Reasoning Workspace](reasoning-workspace/EPIC.md) | Feature (Gameplay) | #6 Reasoning Workspace | [reasoning-workspace.md](../../design/gdd/reasoning-workspace.md) | 12 (5 Complete: 001+002+003a + 007-data-layer + 012-subset; remainder blocked on UI Foundation / SaveLoadService / EvaluationService) | In Progress |
 | [UI Foundation](ui-foundation/EPIC.md) | Foundation (Core) | #2 UI Foundation | [ui-foundation.md](../../design/gdd/ui-foundation.md) | 5 (3 Complete: 001 UIService + 002 KrCustomControl + 004 tween gateway; 003 blocked on MSDF fonts, 005 pending) | In Progress |
-| [Submission & Evaluation](submission-evaluation/EPIC.md) | Feature (Gameplay) / Core | #9 Submission & Evaluation | [submission-evaluation.md](../../design/gdd/submission-evaluation.md) | 5 (4 Complete: 001 Resources + 002 scoring + 003 verdict + 004 submit pipeline [keystone]; 005 comments remain) | In Progress |
+| [Submission & Evaluation](submission-evaluation/EPIC.md) | Feature (Gameplay) / Core | #9 Submission & Evaluation | [submission-evaluation.md](../../design/gdd/submission-evaluation.md) | 5/5 Complete (Resources + scoring + verdict + submit pipeline + comments; comment_templates.tres content pending) | Complete (impl) |
 | [Save/Load](save-load/EPIC.md) | Core / Foundation | #3 Save/Load | [save-load.md](../../design/gdd/save-load.md) | 8/8 implementable cores Complete (001-004+007+008 full; 005/006 core+contract done, EvaluationService/controller end-to-end deferred — TD-001) | In Progress (epic gated on EvaluationService) |
 
 ## Pending epic creation (Implementation-ready systems)

--- a/production/epics/reasoning-workspace/EPIC.md
+++ b/production/epics/reasoning-workspace/EPIC.md
@@ -1,0 +1,120 @@
+# Epic: Reasoning Workspace
+
+> **Layer**: Feature (Gameplay — depends on Foundation #2 UI Foundation + #3 Save/Load + Core #4 Settings & Accessibility + Foundation #20 Library + #1 Case Data Schema)
+> **GDD**: `design/gdd/reasoning-workspace.md`
+> **Architecture Module**: DeskPane (Kr3PaneLayout center pane) + DeskCanvas (SubViewportContainer + SubViewport + HypothesisNodeRoot Node2D) + HypothesisNode × N (KrCard subclass per ADR-0010 §Architecture Diagram) + MemoPanel + SubmitButton + FreezeOverlay + ReadOnlyIndicator
+> **Status**: Ready
+> **Stories**: 12 created 2026-05-18 (run `/story-readiness` → `/dev-story` per story to implement)
+> **Created**: 2026-05-18
+
+## Stories
+
+| # | Story | Type | Status | ADR |
+|---|-------|------|--------|-----|
+| 001 | [WorkspaceData Resource + 4-state machine](story-001-workspace-state-machine.md) | Logic | **Complete (2026-05-18)** | ADR-0008 §1 |
+| 002 | [chain_data Variant-only schema + 5 derivation formulas + BFS canonical ordering](story-002-chain-data-schema.md) | Logic | **Complete (2026-05-18)** | ADR-0007 amend-1 + ADR-0008 amend-1 §A6 |
+| 003 | [HypothesisNode KrCard subclass + tree construction](story-003-hypothesis-node-tree-construction.md) | Logic (data-layer) / UI (deferred) | **Complete data-layer (2026-05-18)** / UI scene → story-003b (UI Foundation epic prerequisite) | ADR-0008 §1 + ADR-0010 KrCard |
+| 004 | [Citation drop pipeline (mouse + KB + Gamepad)](story-004-citation-drop-pipeline.md) | Integration | Ready | ADR-0008 §2 + amend-1 §A3/A5 + amend-3 §E1/E3 |
+| 005 | [MemoPanel layout (A inline + B fixed) + 0.15s fade](story-005-memo-panel.md) | UI + Visual/Feel | Ready | ADR-0008 §3 + amend-1 §A4 |
+| 006 | [Tree panning Camera2D](story-006-tree-panning-camera.md) | UI | Ready | ADR-0008 §4 |
+| 007 | [Freeze + submit cascade](story-007-freeze-submit-cascade.md) | Integration | Ready | ADR-0008 §1 + ADR-0007 + ADR-0001 amend-2 |
+| 008 | [READ_ONLY state + ReadOnlyIndicator + crash recovery cascade](story-008-read-only-crash-recovery.md) | Integration | Ready | ADR-0008 §1 + ADR-0011 |
+| 009 | [Settings subscription cascade — UIService auto-subscribe](story-009-settings-subscription.md) | Integration | Ready | ADR-0010 + amend-1 + ADR-0009 |
+| 010 | [AccessKit roles per amend-4 §F1 corrected mapping + live-region announce cascade](story-010-accesskit-roles.md) | Logic + UI | Ready | ADR-0008 amend-4 §F1 + ADR-0010 amend-1 §G3 |
+| 011 | [Visual + audio polish](story-011-visual-audio-polish.md) | Visual/Feel | Ready | ADR-0004 + amend-1 + ADR-0008 + ADR-0010 R8 |
+| 012 | [Edge cases + performance gates](story-012-edge-cases-performance.md) | Logic + Visual/Feel | Ready | ADR-0008 §6 + amend-1 §A6 + ADR-0010 R6 |
+
+## Overview
+
+The Reasoning Workspace is the variable's *thinking desk* — the central gameplay system where the lawyer drags evidence (LibraryPane → DeskPane) to construct a hypothesis tree (max depth 3, max evidence-per-node 5), authors persistent memos per node, and freezes the snapshot to commit to a submission. The workspace is a 4-state machine (INACTIVE / ACTIVE / FROZEN / READ_ONLY) with strict ownership semantics: state mutates only via typed signal cascades, chain_data exports only Variant primitives (no Resource references), and the workspace's frozen snapshot is the canonical input to the Brief Editor and EvaluationService submission pipeline.
+
+This epic implements all 10 GDD sections (Core Rules / States / Interactions / 5 formula categories / 24 edge cases / 7 sub-categories of tuning knobs / 8 visual+audio requirements / 9 UI requirements / 56 acceptance criteria) using the KrCustomControl tree (ADR-0010) + Theme type variations (ADR-0004 amend-1) + native Godot 4.6 drag-drop callbacks (VR-D6 confirmed cross-viewport dispatch). Implementation is unblocked: 14 ADR transactional bundle Accepted 2026-05-17 + ADR-0009 Accepted 2026-05-18.
+
+## Governing ADRs
+
+| ADR | Decision Summary | Engine Risk |
+|-----|-----------------|-------------|
+| ADR-0008: Workspace Layout | DeskPane Control hierarchy + CitationDrop hybrid signal topology (native callbacks + LibraryService signal + WorkspaceData.pending_citation) + Tree panning (Camera2D middle-drag/right-stick/auto-center) + Gamepad CitationDrop two-step | LOW |
+| ADR-0008 amend-1: Cycle 3·4 Carry-over Closure | AccessibilityRole pre-implementation verification gate (4 confirmed: ROLE_TREE/TREE_ITEM/DIALOG/BUTTON) + Cursor grab asset spec + chain_data hit-test tie-break + typed `.emit()` pattern + chain_data_include_ephemeral_field forbidden | LOW (sprint confirmed) |
+| ADR-0008 amend-2: Brief Editor Godot 4.6 API + AccessKit 7-Enum | Dictionary.duplicate(true) Variant-only contract + AccessKit 7-enum gate (retroactively corrected in amend-4 §F1) | LOW (post-amend-4) |
+| ADR-0008 amend-3: Architecture Review Cascade Closure | Drop target state guard scope + typed `.emit()` cascade + VR-D6 SubViewport drag-drop verification (now PASS) + 17-enum gate consolidation | LOW (VR-D6 CLOSED) |
+| ADR-0008 amend-4: Verification Sprint FAIL Closure | AccessibilityRole 7 enum corrected mapping (ROLE_REGION→ROLE_PANEL etc.) + IME Path A removed + Path B-cross redesigned (_gui_input pattern) + VR-D3 guard policy lock | LOW |
+| ADR-0001 amend-2: BriefEditorData Resource Lifecycle | workspace freeze export → BriefEditor IMPORTING (workspace_state_changed signal cascade) | LOW |
+| ADR-0004: Korean Text Rendering MSDF Font | 3-font family lock (본명조 court_title + Pretendard body_sans + IBM Plex Mono code_mono) | LOW |
+| ADR-0004 amend-1: Component Type Variations Expansion | 17 Theme type variations (Pane/Header/Card/HypothesisNode/MemoLabel/CommentLabel/CourtHeadline/CaptionLabel/Banner family 등) + text_scale runtime reload single-emit cascade | LOW (VR-UI1 PASS) |
+| ADR-0007: Submission Evaluation Algorithm | EvaluationService autoload FOURTH + submit() pipeline contract | LOW |
+| ADR-0007 amend-1: chain_data Variant Primitives Only | chain_data Dictionary는 String/int/float/bool/Array/Dict primitives only — no Resource refs | LOW |
+| ADR-0007 amend-2: Disposition Enum MVP Scope Lock | 4-enum disposition (ACCEPT/REJECT/PARTIAL_ACCEPT/REMAND) + v1+ deferred extension policy | LOW |
+| ADR-0010: UI Foundation Architecture | UIService autoload SECOND + KrCustomControl 21 클래스 트리 + Theme runtime reload + Reduced Motion gateway + dual focus ring composite | LOW (VR-UI1/UI2/UI4/UI6 CLOSED) |
+| ADR-0010 amend-1: KrCustomControl Role Corrections + Live-Region | 7 enum corrected mapping (KrPane→ROLE_PANEL etc.) + UIService.announce_text(source, message, priority) API (VR-UI6 PASS path) | LOW |
+| ADR-0011: Save/Load Storage Format | workspace_state_changed signal trigger + atomic write (write-to-temp + DirAccess.rename_absolute) + crash recovery cascade | LOW |
+| ADR-0009: Settings Storage Format | reduced_motion + text_scale + focus_indicator_thickness signal subscribers (KrCustomControl auto-subscribe via UIService) | LOW |
+
+## GDD Requirements
+
+### Architectural TR coverage (5/5)
+
+| TR-ID | Requirement (summary) | ADR Coverage |
+|-------|----------------------|--------------|
+| TR-WORKSPACE-LAYOUT-001 | DeskPane Control hierarchy 잠금 (DeskCanvas SubViewportContainer + HypothesisNode × N + MemoPanel + SubmitButton + FreezeOverlay + ReadOnlyIndicator) | ADR-0008 §1 ✅ |
+| TR-WORKSPACE-LAYOUT-002 | CitationDrop hybrid signal topology (native drag-drop + LibraryService signal + pending_citation Variant) | ADR-0008 §2 + amend-1 §A3/A5 ✅ |
+| TR-WORKSPACE-LAYOUT-003 | MemoPanel layout (B) fixed bottom-right default + (A) inline opt-in (root_count ≤ 2 + DeskPane.size.x ≥ 720) + 0.15s fade | ADR-0008 §3 + amend-1 §A4 ✅ |
+| TR-WORKSPACE-LAYOUT-004 | Tree panning Camera2D (middle-drag 1:1 + right-stick 600 px/s + D-pad/Tab auto-center 0.2s + scroll wheel + clamp) | ADR-0008 §4 ✅ |
+| TR-WORKSPACE-LAYOUT-005 | Gamepad CitationDrop discrete two-step (A→A attach + B cancel, FROZEN auto-cancel pending) | ADR-0008 §5 ✅ |
+
+### Design-level requirements (story-decomposition scope)
+
+GDD documents 56 Acceptance Criteria across 12 sub-categories (Core Behavior / Tree Construction / Citation Drop / Memo Authoring / Freeze + Submit / Read-Only Recovery / Settings Subscription / AccessKit / Visual + Audio / Gamepad / Edge Cases / Performance), 24 Edge Cases across 7 categories, 5 newly registered constants in `entities.yaml v8`:
+
+- `workspace_max_tree_depth` = 3
+- `workspace_evidence_per_node_cap` = 5
+- `workspace_node_label_char_limit` = 60 chars
+- `workspace_node_memo_char_limit` = 500 chars (UTF-8 codepoints)
+- `workspace_delete_confirmation_subtree_threshold` = 0 (always show)
+
+These map to story-level acceptance gates — decomposed in `/create-stories reasoning-workspace`.
+
+### Untraced (carry-over OQs — not implementation blockers)
+
+| OQ | Disposition |
+|---|---|
+| OQ-W3 (chain_data memo_text v1+) | Deferred to schema_version 2 bump |
+| OQ-W4 (autosave 빈도 정책) | Already covered by ADR-0011 workspace_state_changed signal trigger — implementation cycle confirms cadence |
+| OQ-W7 (AccessKit Godot 4.6 검증) | Partially closed via VR-UI6 dump + VR-S1 (settings) — fully resolved at implementation entry |
+| OQ-W9 (gamepad CitationDrop discrete 대안) | Implementation cycle prototype (LB/RB pane switcher candidate per ADR-0008 §5) |
+| OQ-W10 (tree canvas panning) | Closed by ADR-0008 §4 |
+| OQ-W11 / OQ-W12 (≥10분 BGM / 비음성 사운드 시각 지시자) | v1+ playtest scope — out of MVP |
+| OQ-QA-1 (AC-46 advisory gamepad CitationDrop) | Subsumed by OQ-W9 |
+| OQ-QA-2 (AC-49 60fps Control class blocked) | Resolved by ADR-0010 KrCustomControl tree — implementation cycle measures actual fps |
+
+## Definition of Done
+
+This epic is complete when:
+
+- All stories are implemented, reviewed, and closed via `/story-done`
+- All 56 acceptance criteria from `design/gdd/reasoning-workspace.md` §10 are verified (story-level + integration-level)
+- All 24 edge cases (`design/gdd/reasoning-workspace.md` §5) are tested or documented as deferred
+- All Logic stories (chain_data derivations, tree invariants, evaluation_density formula, freeze snapshot semantics) have passing test files in `tests/unit/workspace/`
+- All Integration stories (LibraryService citation_drag_started ↔ DeskPane drop, workspace_state_changed → SaveLoadService autosave, freeze export → BriefEditor IMPORTING) have passing test files in `tests/integration/workspace/`
+- All Visual/Feel stories (KrCard hover/focus rings, MemoPanel fade transition, FreezeOverlay opacity, ReadOnlyIndicator pulse, drag preview, ToastBanner 등) have evidence docs with art-director + ux-designer sign-off in `production/qa/evidence/`
+- All UI stories (KB shortcut catalog, gamepad two-step CitationDrop, MemoPanel A/B layout transition, Submit confirmation dialog focus default) have manual walkthrough docs or interaction tests in `production/qa/evidence/`
+- VR-D7 (cross-platform IME) result documented (PASS lock or amend-5 platform branch cascade) — required for Brief Editor #7 implementation prerequisite confirmation (this epic itself does not block on VR-D7)
+- entities.yaml v8 5 constants verified used in code (no magic numbers)
+
+## Next Step
+
+Run `/create-stories reasoning-workspace` to break this epic into implementable stories.
+
+Recommended story-decomposition order (Logic → Integration → Visual/UI):
+1. **State machine + workspace data primitives** (WorkspaceData Resource + 4-state machine + chain_data Variant-only schema + 5 derivation formulas)
+2. **Tree construction** (HypothesisNode KrCard subclass + parent/child link + max depth=3 + max evidence=5 + label/memo char limits)
+3. **Citation drop pipeline** (LibraryService signal subscribe + native drag-drop callbacks + KB Space-mark/attach + Gamepad A→A two-step)
+4. **Memo authoring** (MemoPanel A/B layout + 0.15s fade + char cap + Reduced Motion snap)
+5. **Tree panning camera** (Camera2D + middle-drag + right-stick + auto-center lerp + scroll wheel + clamp)
+6. **Freeze + submit cascade** (workspace_state_changed signal + chain_data export Dictionary.duplicate(true) + EvaluationService.submit() + BriefEditor IMPORTING handoff)
+7. **Read-only recovery** (READ_ONLY state + ReadOnlyIndicator + crash recovery from SaveLoadService)
+8. **Settings subscription** (KrCustomControl auto-subscribe via UIService — reduced_motion + text_scale + focus_indicator_thickness)
+9. **AccessKit roles** (KrPane ROLE_PANEL + HypothesisNode ROLE_TREE_ITEM + DeskCanvas ROLE_TREE per amend-4 §F1 corrected mapping)
+10. **Visual + audio polish** (art-director 7 sub-categories + audio-director 21-event catalog)
+11. **Gamepad full-path traversal** (focus walk + LB/RB pane switcher + OQ-W9 fallback)
+12. **Edge case + performance gates** (24 EC + AC-49 60fps with 5 root × 3 deep × 5 evidence)

--- a/production/epics/reasoning-workspace/story-001-workspace-state-machine.md
+++ b/production/epics/reasoning-workspace/story-001-workspace-state-machine.md
@@ -1,0 +1,123 @@
+# Story 001: WorkspaceData Resource + 4-state machine
+
+> **Epic**: Reasoning Workspace
+> **Status**: Complete
+> **Layer**: Feature (Gameplay)
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimate**: 3 hours (M) — single Resource class + 4-state enum + 3 transition functions + 7 AC unit tests
+> **Performance**: No expected impact — state transitions are event-driven (signal-emit only, not `_process`/`_physics_process`); called < 10x per session (case start, freeze, evaluation arrival). No frame budget allocation needed.
+> **Completed**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§3.2 States and Transitions, §10.3 State Machine)
+**Requirement**: `TR-WORKSPACE-LAYOUT-001`
+*(Requirement text in `docs/architecture/tr-registry.yaml` — read fresh at review time.)*
+
+**ADR Governing Implementation**: ADR-0008 Workspace Layout (Accepted 2026-05-17)
+**ADR Decision Summary**: DeskPane Control hierarchy + WorkspaceData Resource owns the 4-state machine (INACTIVE / ACTIVE / FROZEN / READ_ONLY). State mutation only via typed signal cascades.
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: Resource class + Variant primitives in storage fields (per ADR-0007 amend-1). No post-cutoff API specifics required for state machine itself.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.3 State Machine (AC-17 ~ AC-23).
+
+- [ ] AC-17 — Initial state INACTIVE on case load; ACTIVE on first DeskPane interaction (first root added or first drag-drop)
+- [ ] AC-18 — ACTIVE → FROZEN only via explicit submit() call; FROZEN state irreversible within the same session except via crash recovery cascade
+- [ ] AC-19 — FROZEN → READ_ONLY on EvaluationResult arrival; tree visible, no mutations possible
+- [ ] AC-20 — All state transitions emit `workspace_state_changed(old, new)` typed signal
+- [ ] AC-21 — Direct `WorkspaceData.state = X` assignment (bypassing transition functions) is forbidden — only `_transition_to_active()` / `_transition_to_frozen()` / `_transition_to_read_only()` allowed
+- [ ] AC-22 — Crash recovery: SaveLoadService re-instantiates WorkspaceData with persisted state on session resume
+- [ ] AC-23 — INACTIVE state allows no chain_data export (returns empty Dictionary)
+
+---
+
+## Implementation Notes
+
+Per ADR-0008 §1 + ADR-0001 amend-2 lifecycle:
+
+- `WorkspaceData extends Resource` — fields: `state: WorkspaceState` enum, `nodes: Array[HypothesisNodeData]`, `pending_citation: String`, `chain_data_snapshot: Dictionary` (built at freeze)
+- WorkspaceState enum: `INACTIVE = 0`, `ACTIVE = 1`, `FROZEN = 2`, `READ_ONLY = 3`
+- Transition functions are *only* public state-change API. Assert legal transition graph: INACTIVE→ACTIVE, ACTIVE→FROZEN, FROZEN→READ_ONLY (other transitions: push_error + no change).
+- Typed signal: `signal workspace_state_changed(old: int, new: int)` on WorkspaceData. Subscribers (SaveLoadService FIFTH per ADR-0011, BriefEditor for FROZEN handoff per ADR-0001 amend-2) connect via `WorkspaceData.workspace_state_changed.connect(_on_state_changed)`.
+- ADR-0008 amend-3 §E1 — drop target state guard scope: DeskPane drop only blocked in non-ACTIVE; Brief Editor CitationPanel uses independent guard.
+
+---
+
+## Out of Scope
+
+- Story 002: chain_data Variant-only schema + derivation formulas (this story only defines `chain_data_snapshot: Dictionary` field, not builders)
+- Story 003: HypothesisNode KrCard subclass (this story defines `HypothesisNodeData` Resource only)
+- Story 007: Freeze + submit cascade (this story defines `_transition_to_frozen()` skeleton only)
+- Story 008: Crash recovery cascade implementation (this story only verifies state can be restored from persisted Resource)
+
+---
+
+## QA Test Cases
+
+- **AC-17**: Given new case load, when WorkspaceData instantiated, then `state == INACTIVE` and `add_first_node()` transitions to ACTIVE
+- **AC-18**: Given ACTIVE, when `_transition_to_frozen()` called, then state=FROZEN and signal emitted; subsequent `_transition_to_*` calls assert legal-only
+- **AC-19**: Given FROZEN, when EvaluationResult arrives via signal, then `_transition_to_read_only()` fires and state=READ_ONLY
+- **AC-20**: Connect test listener to `workspace_state_changed`; verify emission on every legal transition with correct (old, new) args
+- **AC-21**: Direct `workspace_data.state = WorkspaceState.FROZEN` assignment must `push_error` and revert (or guard via private setter)
+- **AC-22**: Save WorkspaceData to .tres → load → verify state field preserved
+- **AC-23**: Given INACTIVE, when `build_chain_data()` called, then returns `{}` (empty Dict)
+
+Edge cases: invalid transitions (READ_ONLY → ACTIVE), null state, missing nodes array on instantiation.
+
+---
+
+## Test Evidence
+
+**Story Type**: Logic
+**Required**: `tests/unit/workspace/workspace_state_machine_test.gd` — must exist and pass (gdunit4)
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: None (foundational story)
+- Unlocks: Stories 002, 003, 007, 008
+
+---
+
+## Completion Notes
+
+**Completed**: 2026-05-18
+**Criteria**: 7/7 passing (AC-17 / AC-18 / AC-19 / AC-20 / AC-21 / AC-22 / AC-23 — all auto-verified via 27/27 gdunit4 PASS, 187ms)
+
+**Files delivered**:
+- `src/data/workspace_data.gd` (8.2KB → ~8.6KB post-fix) — `class_name WorkspaceData extends Resource` + 4-state enum + private `_state` + read-only public `state` property (Option C guard with push_error setter) + 3 transition functions (`_transition_to_active` / `_to_frozen` / `_to_read_only`) + `add_first_root_node` with null + FROZEN/READ_ONLY guards + `build_chain_data` stub + `workspace_state_changed(old: int, new: int)` typed signal
+- `src/data/hypothesis_node_data.gd` (1.3KB) — minimal Resource scaffold (5 @export fields; full structure deferred to story 003)
+- `tests/unit/workspace/workspace_state_machine_test.gd` (~18KB) — 27 test functions covering 7 AC + edge cases + 6 regression guards
+
+**Test evidence**: `tests/unit/workspace/workspace_state_machine_test.gd` — 27/27 PASS via `bash addons/gdUnit4/runtest.sh --godot_binary $(which godot) -a tests/unit/workspace/workspace_state_machine_test.gd` (gdunit4 v5.x, Godot 4.6.1.stable.official.14d19694e, 187ms)
+
+**Deviations**: None (all out-of-scope items deferred to declared follow-up stories — chain_data builder to story 002, full HypothesisNode invariants to story 003, freeze cascade to story 007, crash recovery cascade to story 008)
+
+**Scope**: All changes within stated boundary (src/data/ + tests/unit/workspace/). 0 files outside scope touched.
+
+**Code review** (lean mode):
+- godot-gdscript-specialist: workspace_data.gd MINOR ISSUES → CLEAN post-fix (W1 assert→push_error / W2 add guard / W3 keys()→find_key) / hypothesis_node_data.gd CLEAN / test file MINOR → CLEAN post-fix (W4 typed Array[Array])
+- qa-tester: GAPS (1 BUG-CANDIDATE + 4 WARNING + 2 NICE-TO-HAVE) → 6 fixes in-pass; AC-19 mutation guard added to `add_first_root_node` closing data-layer behavioral gap; 6 regression tests added (FROZEN/READ_ONLY append rejection + null guard + direct assignment from FROZEN/READ_ONLY + READ_ONLY chain_data return)
+
+**Deferred (acknowledged out-of-scope, NICE-TO-HAVE)**:
+- Test naming convention `test_workspace_data_*` prefix (cosmetic, gdunit4 미 enforce)
+- AC-21 out-of-range int assignment test (setter always rejects regardless of value)
+- I4 reflection bypass via `Object.set("_state", ...)` — Option C inherent 한계, ADR-acknowledged
+- Test file release-stale check — release builds strip `assert` but story 001 uses `push_error` exclusively (post-W1 fix)
+
+**Unlocks**:
+- Story 002 chain_data Variant-only schema + 5 derivation formulas + BFS canonical ordering (next ready story — depends only on story 001 WorkspaceData Resource definition)
+- Story 003 HypothesisNode KrCard subclass + tree construction (depends on story 001 HypothesisNodeData scaffold)
+- Story 007 Freeze + submit cascade (depends on story 001 state machine + story 002 chain_data builder)
+- Story 008 READ_ONLY + crash recovery (depends on story 001 + story 007)

--- a/production/epics/reasoning-workspace/story-002-chain-data-schema.md
+++ b/production/epics/reasoning-workspace/story-002-chain-data-schema.md
@@ -1,0 +1,176 @@
+# Story 002: chain_data Variant-only schema + 5 derivation formulas + BFS canonical ordering
+
+> **Epic**: Reasoning Workspace
+> **Status**: Complete
+> **Layer**: Feature (Gameplay)
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimate**: 4 hours (M-L) — `build_chain_data` Dictionary builder + 5 derivation formulas (depth/max_depth_reached/total_evidence_count/child_count/evidence_count) + BFS canonical ordering + allow-list validator with 7 ALLOWED_NODE_FIELDS + 12 AC unit tests including 5-name fuzz
+> **Performance**: No expected impact — `build_chain_data` called only at freeze (< 1x per session) + validator runs synchronously on small Dictionary (5-30 nodes). BFS traversal O(N) for N ≤ ~30 (AC-49 worst-case 5 root × 3 deep × 5 evidence) — sub-millisecond. No `_process` allocation.
+> **Completed**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§3.1 Rule 5/6 chain_data, §4.1 5 derivation formulas, §4.2 tree invariants, §10.1 chain_data Export, §10.10 Pillar 1 guard)
+**Requirement**: `TR-WORKSPACE-LAYOUT-001` (chain_data is part of WorkspaceData export contract)
+
+**ADR Governing Implementation**: ADR-0007 amend-1 (chain_data Variant Primitives Only) + ADR-0008 amend-1 §A6 (forbidden chain_data ephemeral field) + ADR-0008 §1 (canonical ordering) + ADR-0007 §1 (chain_data schema lock)
+**ADR Decision Summary**: chain_data Dictionary contains ONLY Variant primitives (String/int/float/bool/Array/Dict) — NO Resource references. New dict literal construction with explicit `.duplicate()` on Array fields. nodes[] array follows BFS canonical ordering (lexicographic root sort → BFS depth-first within each subtree).
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: `Dictionary.duplicate(true)` (4.0+ stable, deprecation-untouched per ADR-0008 amend-2 §D3). `JSON.stringify(data, indent, sort_keys, full_precision)` 4.6 — AC-24 protocol uses `indent=""`, `sort_keys=true`.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.1 chain_data Export (AC-1 ~ AC-11b) — 11 AC.
+
+- [ ] AC-1 — chain_data Dictionary contains: `nodes` Array, `edges` Array, `total_evidence_count`, `max_depth_reached`, `submission_timestamp_unix`, `schema_version=1`
+- [ ] AC-2 — Each node dict has: `node_id`, `label`, `parent_id`, `evidence` (Array[String]), `depth`, `child_count`, `evidence_count` — no other fields
+- [ ] AC-3 — Each edge dict has: `parent_id`, `child_id` — no other fields
+- [ ] AC-4 — `total_evidence_count` formula: sum of all nodes' `evidence_count` (= sum of `len(node.evidence)`)
+- [ ] AC-5 — `max_depth_reached` formula: max(depth) over all nodes; empty tree returns 0
+- [ ] AC-6 — `depth` formula: 0 for roots, parent.depth + 1 for children
+- [ ] AC-7 — `child_count` formula: count of nodes where `parent_id == this.node_id`
+- [ ] AC-8 — `evidence_count` formula: `len(node.evidence)`
+- [ ] AC-9 — chain_data is *fully constructed new Dictionary* (§3.1 Rule 6 normative) — no live reference to WorkspaceData fields
+- [ ] AC-10 — memo body excluded from chain_data (Pillar 1 guard); allow-list validator rejects `memo_text` injection with `push_error` + `submission_rejected("schema_violation")`
+- [ ] AC-11 — schema_version=1 lock; future v2+ bump must trigger explicit migration ADR
+- [ ] AC-11b — nodes[] array BFS canonical ordering: roots sorted by `node_id` lexicographic, then BFS within each root subtree with children sorted by `node_id` at each depth level
+- [ ] AC-52 — Pillar 1 fuzz test: 5 forbidden field names (`memo_text`, `chain_data_internal`, `__debug_payload`, `evaluator_hint`, `cached_score`) all rejected
+
+---
+
+## Implementation Notes
+
+Per ADR-0007 amend-1 + ADR-0008 §1 normative:
+
+```gdscript
+# WorkspaceData.build_chain_data() — returns brand-new Dictionary
+func build_chain_data() -> Dictionary:
+    var sorted_roots := _roots().duplicate()  # Array[HypothesisNodeData]
+    sorted_roots.sort_custom(func(a, b): return a.node_id < b.node_id)
+    var bfs_ordered: Array = []
+    for root in sorted_roots:
+        _bfs_collect(root, bfs_ordered)
+    var nodes_dict_array: Array = []
+    var edges_array: Array = []
+    var total_ev := 0
+    var max_depth := 0
+    for n: HypothesisNodeData in bfs_ordered:
+        nodes_dict_array.append({
+            "node_id": n.node_id,
+            "label": n.label,
+            "parent_id": n.parent_id,
+            "evidence": n.evidence.duplicate(),  # MANDATORY explicit .duplicate() per §3.1 Rule 6
+            "depth": n.depth,
+            "child_count": _children_of(n.node_id).size(),
+            "evidence_count": n.evidence.size(),
+        })
+        if n.parent_id != "":
+            edges_array.append({"parent_id": n.parent_id, "child_id": n.node_id})
+        total_ev += n.evidence.size()
+        max_depth = max(max_depth, n.depth)
+    return {
+        "schema_version": 1,
+        "nodes": nodes_dict_array,
+        "edges": edges_array,
+        "total_evidence_count": total_ev,
+        "max_depth_reached": max_depth,
+        "submission_timestamp_unix": int(Time.get_unix_time_from_system()),
+    }
+
+# Allow-list validator — runs on submit before EvaluationService call
+const ALLOWED_NODE_FIELDS := ["node_id", "label", "parent_id", "evidence", "depth", "child_count", "evidence_count"]
+func validate_chain_data(cd: Dictionary) -> bool:
+    for n: Dictionary in cd.get("nodes", []):
+        for k in n.keys():
+            if not ALLOWED_NODE_FIELDS.has(k):
+                push_error("chain_data schema_version=1 violation: forbidden field %s" % k)
+                submission_rejected.emit("schema_violation")
+                return false
+    return true
+```
+
+- ADR-0008 amend-1 §A6 forbidden_pattern `chain_data_include_ephemeral_field` registered already.
+- ADR-0007 amend-1 — `nodes[]` Array literal construction (not `.duplicate()` shorthand).
+- §3.1 Rule 6 BFS canonical: deterministic — same workspace state → byte-identical `JSON.stringify(cd, "", true)` output.
+
+---
+
+## Out of Scope
+
+- Story 001: WorkspaceData state machine (this story builds chain_data, doesn't transition state)
+- Story 007: Freeze + submit cascade (this story builds chain_data; story 007 calls `build_chain_data()` at freeze)
+- v1+ chain_coherence subscore (GDD §4.3 forward declaration)
+- evidence_density UI metric (GDD §4.4 — NOT exported; story 011 visual polish)
+
+---
+
+## QA Test Cases
+
+- **AC-1~3**: Build chain_data from fixture tree (3 roots, varying depth/evidence); assert exact field set per node/edge/top-level
+- **AC-4**: 5-node tree with [2, 1, 0, 3, 1] evidence → total_evidence_count=7
+- **AC-5**: depth-3 tree → max_depth_reached=2 (0-indexed); empty tree → 0
+- **AC-6**: Multi-level traversal → root.depth==0, child.depth==parent.depth+1
+- **AC-9**: After build, mutate `workspace_data.nodes[0].evidence.append("X")` → chain_data["nodes"][0]["evidence"] unchanged
+- **AC-10**: Inject `memo_text` field via test helper → validator returns false + emits `submission_rejected("schema_violation")`
+- **AC-11b**: Insertion order `[root-B, root-A]` with children in reverse `node_id` order → chain_data['nodes'][0]['node_id'] == 'root-A' (lex sort) and children appear sorted within each depth
+- **AC-52 fuzz**: 5 distinct forbidden field names — all caught, no EvaluationService call
+
+Edge cases: empty tree (no nodes), single-node tree, max-depth tree (3-deep × 5 root × 5 evidence-per-node), insertion-order matches lex order (insertion-by-chance vs lex-by-spec) — separate test function with explicit assertion documenting spec source is lex sort.
+
+---
+
+## Test Evidence
+
+**Story Type**: Logic
+**Required**: `tests/unit/workspace/chain_data_test.gd` — must exist and pass (gdunit4); functions per AC ID
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (WorkspaceData Resource + state machine) ✅ Complete
+- Unlocks: Stories 007 (freeze export), 008 (crash recovery cascade verifies chain_data bytes-equal), 012 (Pillar guard fuzz tests)
+
+---
+
+## Completion Notes
+
+**Completed**: 2026-05-18
+**Criteria**: 12/12 passing (AC-1 ~ AC-11b + AC-52 fuzz, all auto-verified via 25/25 chain_data_test.gd PASS, 183ms)
+
+**Files delivered**:
+- `src/data/workspace_data.gd` (extended) — added `ALLOWED_NODE_FIELDS` constant (7-entry), `submission_rejected(reason: String)` typed signal, full `build_chain_data()` BFS builder (replaces story-001 stub), `validate_chain_data(cd)` allow-list per-key check, 3 private BFS helpers (`_roots()` / `_bfs_collect()` / `_children_of()`)
+- `tests/unit/workspace/chain_data_test.gd` (NEW) — 25 test functions: AC-1~11 + AC-11b (4 BFS ordering variants including cycle 4 IMP-6 insertion=lex case) + AC-52 fuzz (5 forbidden names) + edge cases (empty / single-node / max-tree 5×3×5)
+- `tests/unit/workspace/workspace_state_machine_test.gd` (extended) — 2 tests updated to expect new chain_data shape (`test_active_state_returns_chain_data_snapshot_field` + `test_read_only_state_returns_chain_data_snapshot_field`)
+
+**Test evidence**:
+- `tests/unit/workspace/chain_data_test.gd` — 25/25 PASS in 183ms
+- `tests/unit/workspace/workspace_state_machine_test.gd` — 27/27 PASS (0 regression from story-001)
+- Total workspace suite: **52/52 PASS in 378ms** via `bash addons/gdUnit4/runtest.sh --godot_binary $(which godot) -a tests/unit/workspace/`
+
+**Deviations**: None
+- chain_data Dictionary 신규 literal construction ✓ (no live WorkspaceData refs per §3.1 Rule 6 normative)
+- evidence Array explicit `.duplicate()` ✓ (cycle 4 godot-specialist IMPORTANT-1)
+- BFS canonical (lex root sort + lex children at each depth) ✓ deterministic
+- 7-field allow-list validator ✓ (forbidden_pattern `chain_data_include_ephemeral_field` enforced)
+- INACTIVE state still returns `{}` ✓ (AC-23 regression preserved)
+- ADR-0007 amend-1 Variant primitives only ✓ (story 007 validator runtime check)
+
+**Scope**: All changes within stated boundary (`src/data/workspace_data.gd` extension + `tests/unit/workspace/chain_data_test.gd` NEW). State machine + Option C guard + story-001 behavior untouched.
+
+**Code review** (lean mode — implicit via test pass + agent self-report):
+- agent confirmed: typed Array[Array] pattern (W4 fix from story-001 carry), manual signal connect+counter for submission_rejected, ADR cross-ref in doc comments, one-function-one-scenario rule
+- No specialist sub-review spawned (lean mode + story-001 patterns established)
+
+**Unlocks**:
+- Story 007 freeze cascade (workspace_state_changed + chain_data export Dictionary.duplicate(true) + EvaluationService.submit handoff)
+- Story 008 crash recovery (auto-resubmit uses chain_data_snapshot bytes-equality per AC-27b)
+- Story 012 Pillar 1 fuzz tests cross-link (AC-52 ↔ story-012 AC-52b settings fuzz)

--- a/production/epics/reasoning-workspace/story-003-hypothesis-node-tree-construction.md
+++ b/production/epics/reasoning-workspace/story-003-hypothesis-node-tree-construction.md
@@ -1,0 +1,126 @@
+# Story 003: HypothesisNode KrCard subclass + tree construction
+
+> **Epic**: Reasoning Workspace
+> **Status**: Complete (data-layer scope, 2026-05-18) / UI scene wrapping deferred to story-003b (UI Foundation epic prerequisite)
+> **Layer**: Feature (Gameplay)
+> **Type**: Logic (data-layer) / UI (deferred)
+> **Manifest Version**: 2026-05-18
+> **Estimate**: 4 hours (M-L) data-layer scope
+> **Performance**: No expected impact — user-event triggered (< 100x/session), O(D≤3) depth check + O(N≤30) BFS cycle detection — sub-millisecond
+> **Completed (data-layer)**: 2026-05-18
+> **Scope split**: AC-12/13/14/15/16 invariants implemented as WorkspaceData mutation API + HypothesisNodeData `memo` field. AC-13b (UI ease-back) + `class_name HypothesisNode extends PanelContainer` (KrCard composition) + `theme_type_variation = &"HypothesisNode"` + AccessKit role assignment deferred to story-003b after UI Foundation epic.
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§3.1 Core Rules, §4.2 tree structural invariants, §5.2 tree-structural violations, §10.2 Tree Structural Invariants, entities.yaml v8 constants)
+**Requirement**: `TR-WORKSPACE-LAYOUT-001`
+
+**ADR Governing Implementation**: ADR-0008 §1 (DeskPane Control hierarchy) + ADR-0010 KrCard subclass (HypothesisNode → ROLE_TREE_ITEM per amend-1 §G1) + ADR-0008 amend-3 §E3 (HypothesisNode redefine to KrCard inheritance)
+**ADR Decision Summary**: HypothesisNode is a `KrCard` subclass (per ADR-0010 §Architecture Diagram + amend-3 §E3) with explicit limits enforced at construction/mutation time: max tree depth 3, evidence cap 5 per node, label ≤ 60 chars, memo ≤ 500 UTF-8 codepoints. Cycle detection blocks self-or-ancestor reparenting.
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: KrCard uses composition + static helper pattern (godot-specialist 2026-05-17 — multiple-inheritance bypass per ADR-0010 §Decision Note). `theme_type_variation = &"HypothesisNode"` per ADR-0004 amend-1.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.2 Tree Structural Invariants (AC-12 ~ AC-16, AC-13b) — 5 AC + AC-13b sub.
+
+- [ ] AC-12 — Max tree depth = `workspace_max_tree_depth` (=3, entities.yaml v8). Attempted child add at depth=3 rejected with `push_error("max tree depth 3 exceeded")` + hint "이 분기는 더 깊이 추론할 수 없습니다 (최대 3단계)"
+- [ ] AC-13 — Cycle detection: `reparent(B, A)` where A is descendant of B rejected; tree state unchanged; emits `tree_invariant_violation("cycle")`
+- [ ] AC-13b — Cycle detection UI integration: plain drag of parent node A onto child B → drag controller rejects + ease-back animation + hint "노드를 자신의 하위 노드로 이동할 수 없습니다"
+- [ ] AC-14 — Evidence cap: each node holds at most `workspace_evidence_per_node_cap` (=5) evidence_ids. Attempted 6th drop rejected with hint "이 노드에는 인용을 5개까지만 첨부할 수 있습니다"
+- [ ] AC-15 — Label char limit: `workspace_node_label_char_limit` (=60) — input truncated at 60 chars with hint "노드 레이블은 60자까지만"
+- [ ] AC-16 — Memo char limit: `workspace_node_memo_char_limit` (=500 UTF-8 codepoints) — TextEdit enforces via cross-platform IME pattern (per ADR-0008 amend-4 §F3 — VR-D7 pending for IME composition handling)
+
+---
+
+## Implementation Notes
+
+Per ADR-0008 §1 + ADR-0010 §Decision + amend-3 §E3:
+
+```gdscript
+# HypothesisNode — KrCard subclass via composition+helper per ADR-0010 §Decision Note
+class_name HypothesisNode extends PanelContainer  # KrCard base = PanelContainer
+
+const MAX_DEPTH := 3              # entities.yaml workspace_max_tree_depth
+const EVIDENCE_CAP := 5           # entities.yaml workspace_evidence_per_node_cap
+const LABEL_CHAR_LIMIT := 60      # entities.yaml workspace_node_label_char_limit
+const MEMO_CHAR_LIMIT := 500      # entities.yaml workspace_node_memo_char_limit
+
+@export var data: HypothesisNodeData
+
+func _ready() -> void:
+    theme_type_variation = &"HypothesisNode"
+    KrControlHelper.setup(self)   # auto-subscribe settings + accessibility_role
+    accessibility_role = AccessibilityRole.ROLE_TREE_ITEM   # =28 per amend-4 §F1
+
+func add_child_hypothesis(child_label: String) -> bool:
+    if data.depth >= MAX_DEPTH:
+        push_error("max tree depth %d exceeded" % MAX_DEPTH)
+        UIService.announce_text(self, "이 분기는 더 깊이 추론할 수 없습니다 (최대 %d단계)" % MAX_DEPTH, UIService.AnnouncePriority.POLITE)
+        return false
+    # ... create child node, depth = self.depth + 1
+    return true
+
+func can_add_evidence() -> bool:
+    return data.evidence.size() < EVIDENCE_CAP
+
+func reparent_to(new_parent: HypothesisNode) -> bool:
+    if _is_descendant_of(new_parent):
+        push_error("cycle detected: cannot reparent to descendant")
+        WorkspaceData.tree_invariant_violation.emit("cycle")
+        return false
+    # ... perform reparent
+    return true
+```
+
+- entities.yaml v8 5 constants — load via SettingsService or const file; no magic numbers in story 003 code
+- HypothesisNode label uses `KrLineEdit` (`ROLE_TEXT_FIELD` = 18 per amend-1 §G1) with `LABEL_CHAR_LIMIT`
+- Memo uses `KrTextEdit` (`ROLE_MULTILINE_TEXT_FIELD` = 19 per amend-1 §G1 — corrected from earlier ROLE_TEXT_FIELD) with `MEMO_CHAR_LIMIT` and amend-4 §F3 cross-platform IME `_gui_input` pattern (VR-D7 confirms; non-blocking)
+- Drag-drop attachment is story 004 scope; this story only defines HypothesisNode structure + invariant enforcement
+
+---
+
+## Out of Scope
+
+- Story 001: WorkspaceData state machine + Resource definition
+- Story 002: chain_data export (this story builds tree; story 002 serializes)
+- Story 004: CitationDrop pipeline (this story enforces evidence cap but doesn't handle drag-drop)
+- Story 005: MemoPanel layout (this story enforces memo cap but doesn't lay out the panel)
+- Story 010: AccessKit role assignment is partially in this story (HypothesisNode = ROLE_TREE_ITEM) but cross-cutting role audit is story 010
+- Story 012: Edge cases beyond AC-12~16 (this story covers structural invariants only)
+
+---
+
+## QA Test Cases
+
+- **AC-12**: Build tree to depth 3, attempt add at depth 3 → false + error + hint emitted
+- **AC-13**: Tree A→B→C; attempt `reparent(B, C)` → rejected + `tree_invariant_violation` signal emitted
+- **AC-13b**: Manual UI walkthrough — drag parent onto child → ease-back animation + hint
+- **AC-14**: Add 5 evidence to node; attempt 6th → `can_add_evidence()` false + hint
+- **AC-15**: Try to set label to 65-char string → truncated to 60 + hint
+- **AC-16**: TextEdit `text` setter input 600 chars → truncated at 500; verify with composition (Korean IME compose mid-string — defers cap check until composition complete per amend-4 §F3)
+
+Edge cases: depth=0 root, single-child tree, reparent root to its own descendant via deep chain.
+
+---
+
+## Test Evidence
+
+**Story Type**: Logic (with UI verification for AC-13b)
+**Required**:
+- `tests/unit/workspace/tree_invariants_test.gd` — gdunit4 logic tests for AC-12/13/14/15/16
+- `tests/integration/workspace/tree_invariants_test.gd::test_cycle_detection_ui_path` — AC-13b UI path
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (WorkspaceData Resource + HypothesisNodeData type)
+- Unlocks: Stories 004 (CitationDrop), 005 (MemoPanel), 010 (AccessKit role audit), 011 (visual polish), 012 (edge cases)

--- a/production/epics/reasoning-workspace/story-004-citation-drop-pipeline.md
+++ b/production/epics/reasoning-workspace/story-004-citation-drop-pipeline.md
@@ -1,0 +1,127 @@
+# Story 004: Citation drop pipeline (mouse + KB + Gamepad)
+
+> **Epic**: Reasoning Workspace
+> **Status**: Ready
+> **Layer**: Feature (Gameplay)
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§3.3 Interactions, §5.3 Evidence drop edge cases, §9.4.2 Space-mark/attach KB, §9.4.3 Gamepad A→A two-step, §10.5 CitationDrop)
+**Requirement**: `TR-WORKSPACE-LAYOUT-002` (CitationDrop hybrid signal topology) + `TR-WORKSPACE-LAYOUT-005` (Gamepad two-step)
+
+**ADR Governing Implementation**: ADR-0008 §2 (CitationDrop hybrid signal topology) + amend-1 §A3 (hit-test tie-break) + amend-1 §A5 (typed `.emit()`) + amend-3 §E1 (drop target state guard scope to DeskPane only) + amend-3 §E3 (VR-D6 CLOSED — native cross-viewport dispatch confirmed)
+**ADR Decision Summary**: Hybrid signal topology — Godot 4.6 native drag-drop callbacks (`_get_drag_data` / `_can_drop_data` / `_drop_data`) + LibraryService autoload signal `citation_drag_started(library_id)` (typed) + application-level `WorkspaceData.pending_citation: String` for KB Space-mark/attach + Gamepad A→A two-step. State guard: drop blocked when `state != ACTIVE`.
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: VR-D6 prototype confirmed cross-viewport dispatch (4/4 drags PASS). `_can_drop_data` / `_drop_data` fire on root viewport target from SubViewport-internal drag source. DragManager fallback UNUSED.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.5 CitationDrop (AC-28 ~ AC-32) — 5 AC.
+
+- [ ] AC-28 — Mouse drag from LibraryPane card onto DeskPane HypothesisNode attaches evidence_id; `citation_drag_started(library_id)` signal emits at drag start; `_drop_data` resolves on node hit
+- [ ] AC-29 — KB Space on focused LibraryPane card → `WorkspaceData.pending_citation = library_id` + status bar "[library_id] 인용 대기 중. 노드 포커스 후 Space로 첨부" + 좌상단 floating 배지
+- [ ] AC-30 — Evidence cap reached, 6th drop rejected with "이 노드에는 인용을 5개까지만 첨부할 수 있습니다" hint (UI path mirror of AC-14)
+- [ ] AC-31 — Mouse drag threshold = `input.mouse_drag_threshold_px` (default 8, range [4,32] per ADR-0009 TR-settings-004) — drag starts only when cursor moves ≥ threshold from press point
+- [ ] AC-32 — Hit-test tie-break (overlapping nodes): topmost node (highest z-index then latest add) receives drop per ADR-0008 amend-1 §A3
+- [ ] AC-46 — Gamepad CitationDrop discrete two-step (A on LibraryPane → A on DeskPane node → attach, B → cancel; FROZEN auto-cancels pending) — ADVISORY per OQ-W9 carry-over
+
+---
+
+## Implementation Notes
+
+Per ADR-0008 §2 + amend-1 §A3/A5 + amend-3 §E1/E3:
+
+```gdscript
+# LibraryPane card — drag source
+class_name LibraryCard extends PanelContainer
+@export var library_id: String
+
+func _get_drag_data(_pos: Vector2) -> Variant:
+    LibraryService.citation_drag_started.emit(library_id)  # typed .emit() per amend-1 §A5
+    var preview := _build_drag_preview()
+    set_drag_preview(preview)
+    return {"type": "citation", "library_id": library_id}
+
+# DeskPane HypothesisNode — drop target (within SubViewport — VR-D6 confirmed dispatch)
+func _can_drop_data(_pos: Vector2, data: Variant) -> bool:
+    if WorkspaceData.state != WorkspaceState.ACTIVE:
+        return false   # DeskPane drop only — Brief CitationPanel is independent guard (amend-3 §E1)
+    return data is Dictionary and data.get("type") == "citation"
+
+func _drop_data(_pos: Vector2, data: Variant) -> void:
+    var library_id: String = data["library_id"]
+    if not _hypothesis_data.can_add_evidence():
+        UIService.announce_text(self, "이 노드에는 인용을 5개까지만 첨부할 수 있습니다", UIService.AnnouncePriority.POLITE)
+        return
+    _hypothesis_data.evidence.append(library_id)
+    AudioService.play("weight-stamp")
+    WorkspaceData.pending_citation = ""
+
+# KB Space pattern (Workspace LibraryPane focused)
+func _input(event: InputEvent) -> void:
+    if event.is_action_pressed("workspace_citation_pending"):
+        if _is_library_card_focused():
+            WorkspaceData.pending_citation = _focused_library_id()
+            UIService.show_status_bar("%s 인용 대기 중. 노드 포커스 후 Space로 첨부" % WorkspaceData.pending_citation)
+        elif _is_hypothesis_node_focused() and WorkspaceData.pending_citation != "":
+            _attach_pending_to_focused_node()
+
+# Gamepad A→A pattern mirror KB (FROZEN auto-cancel)
+func _on_workspace_state_changed(_old: int, new: int) -> void:
+    if new == WorkspaceState.FROZEN:
+        WorkspaceData.pending_citation = ""
+```
+
+- Native cross-viewport dispatch confirmed by VR-D6 (4/4 PASS) — no DragManager autoload needed
+- LibraryService autoload FIRST per ADR-0008 §2 — `citation_drag_started` typed signal subscriber chain
+- ADR-0008 amend-3 §E2 typed `.emit()` cascade — string-keyed `emit_signal` forbidden
+- Gamepad two-step: button mapping defers to ADR-0008 §5 + OQ-W9 prototype (UI Foundation epic). AC-46 ADVISORY until OQ-W9 ratify.
+
+---
+
+## Out of Scope
+
+- Story 003: Tree structure invariants (AC-12 max depth, AC-14 evidence cap — this story triggers cap rejection via call, doesn't re-enforce limit)
+- Story 005: MemoPanel (separate from CitationDrop)
+- Story 006: Tree panning camera (focus management is story 011)
+- Story 008: Crash recovery cascade (pending_citation auto-clear on FROZEN is here but auto-resubmit is story 008)
+- Story 009: Settings subscription for `mouse_drag_threshold_px` — this story consumes the value, story 009 wires the subscriber
+- Story 010: AccessKit role for LibraryCard (= ROLE_LIST_ITEM per amend-1 §G1)
+
+---
+
+## QA Test Cases
+
+- **AC-28 Integration**: Spawn LibraryCard + HypothesisNode, simulate `_get_drag_data` + `_drop_data` programmatically, verify `citation_drag_started` signal fired + evidence array updated
+- **AC-29**: Press `workspace_citation_pending` action with LibraryCard focused → `WorkspaceData.pending_citation == library_id`; press again with HypothesisNode focused → evidence attached, pending cleared
+- **AC-30**: Node with 5 evidence; simulate drop → `can_add_evidence()` false → hint announced via UIService.announce_text
+- **AC-31**: Settings `input.mouse_drag_threshold_px = 16`; mouse press + move 12px → no drag; move 18px → drag starts
+- **AC-32**: Two overlapping nodes; drop on overlap region → topmost (highest z-index then latest add) receives drop
+- **AC-46 Manual**: Gamepad A on LibraryPane → A on DeskPane node → attached + audio cue + pending badge cleared; B → cancel
+
+Edge cases: drag in non-ACTIVE state (rejected), drop on empty DeskPane (no node hit → silent), pending_citation set then state→FROZEN (auto-clear).
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**:
+- `tests/integration/workspace/citation_drop_test.gd` — AC-28/29/30/31/32 (gdunit4)
+- `production/qa/evidence/workspace-gamepad-citation-drop.md` — AC-46 manual walkthrough (ADVISORY status per OQ-W9)
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (WorkspaceData state), Story 003 (HypothesisNode + can_add_evidence)
+- Unlocks: Story 011 (focus + visual feedback for drag preview), Story 012 (edge cases — evidence drop in non-ACTIVE state)

--- a/production/epics/reasoning-workspace/story-005-memo-panel.md
+++ b/production/epics/reasoning-workspace/story-005-memo-panel.md
@@ -1,0 +1,112 @@
+# Story 005: MemoPanel layout (A inline + B fixed) + 0.15s fade transition
+
+> **Epic**: Reasoning Workspace
+> **Status**: Ready
+> **Layer**: Feature (Gameplay)
+> **Type**: UI + Visual/Feel (UI primary)
+> **Manifest Version**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§9.3 Memo Panel Position, §10.7 UI Visual / Interaction partial)
+**Requirement**: `TR-WORKSPACE-LAYOUT-003`
+
+**ADR Governing Implementation**: ADR-0008 §3 (MemoPanel layout) + amend-1 §A4 (default reframe to B fixed bottom-right) + ADR-0010 KrPane (panel root role = ROLE_PANEL per amend-1 §G1)
+**ADR Decision Summary**: MemoPanel default position = (B) fixed bottom-right. (A) inline next to selected node enabled when `root_count ≤ 2 AND DeskPane.size.x ≥ 720`. 0.15s opacity fade transition; Reduced Motion → immediate snap. Memo TextEdit enforces char cap per story 003.
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: `UIService.tween_property()` gateway for fade (Reduced Motion check inside per ADR-0010). `theme_type_variation = &"MemoLabel"` / `&"MemoEdit"` per ADR-0004 amend-1.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.7 UI Visual / Interaction (MemoPanel-related ACs).
+
+- [ ] AC-33 — MemoPanel default position (B) fixed bottom-right of DeskPane viewport; min 320×240px
+- [ ] AC-34 — (A) inline mode activated when `WorkspaceData.roots().size() ≤ 2 AND DeskPane.size.x ≥ 720`; panel anchored next to selected HypothesisNode, top edge aligned to node
+- [ ] AC-35 — Transition between A↔B layouts: 0.15s opacity fade via `UIService.tween_property()`; Reduced Motion (settings) → immediate snap
+- [ ] AC-36 — Selected node deselected → MemoPanel fade out (0.15s); new node selected → fade in to new position
+- [ ] AC-38 — Memo TextEdit type variation `&"MemoEdit"` applied (per ADR-0004 amend-1); char cap enforcement delegated to story 003 HypothesisNode invariant
+- [ ] AC-40 — `display.reduced_motion = true` → all opacity fades replaced with instant set (verifies UIService.tween_property gateway path)
+
+---
+
+## Implementation Notes
+
+Per ADR-0008 §3 + amend-1 §A4 + ADR-0010 UIService gateway:
+
+```gdscript
+class_name MemoPanel extends PanelContainer
+
+@onready var _memo_edit: TextEdit = $MemoEdit
+var _current_node: HypothesisNode = null
+var _is_inline_eligible: bool:
+    get: return WorkspaceData.roots().size() <= 2 and DeskPane.size.x >= 720
+
+func _ready() -> void:
+    theme_type_variation = &"Pane"
+    accessibility_role = AccessibilityRole.ROLE_PANEL   # =6 per amend-1 §G1
+    _memo_edit.theme_type_variation = &"MemoEdit"
+    _memo_edit.accessibility_role = AccessibilityRole.ROLE_MULTILINE_TEXT_FIELD   # =19
+    WorkspaceData.node_selected.connect(_on_node_selected)
+    WorkspaceData.node_deselected.connect(_on_node_deselected)
+
+func _on_node_selected(node: HypothesisNode) -> void:
+    _current_node = node
+    if _is_inline_eligible:
+        _position_inline_next_to(node)
+    else:
+        _position_fixed_bottom_right()
+    _fade_in()
+
+func _fade_in() -> void:
+    modulate.a = 0.0
+    visible = true
+    UIService.tween_property(self, "modulate:a", 1.0, 0.15)  # Reduced Motion gateway inside
+
+func _fade_out() -> void:
+    UIService.tween_property(self, "modulate:a", 0.0, 0.15).finished.connect(func(): visible = false)
+```
+
+- `UIService.tween_property` ADR-0010 §Decision returns null when reduced_motion → set immediately (no tween created)
+- MemoPanel root = KrPane (ROLE_PANEL per amend-1 §G1 corrected mapping)
+- 720px threshold + 2-root threshold from amend-1 §A4 reframe — magic numbers NOT in code; use entities.yaml constants if registered or local consts referencing amend-1 §A4 comment
+
+---
+
+## Out of Scope
+
+- Story 003: Memo char cap enforcement (HypothesisNode invariant — this story doesn't re-enforce)
+- Story 009: Settings subscription wiring (UIService subscribe; this story consumes `display.reduced_motion` via UIService.tween_property gateway only)
+- Story 010: AccessKit role audit (this story applies KrPane + MemoEdit roles inline; cross-cutting audit is story 010)
+- Story 011: Visual polish for fade animation curve (this story only sets duration; bezier curve + easing in story 011)
+
+---
+
+## QA Test Cases
+
+- **AC-33 Manual**: Open Workspace, no node selected → MemoPanel not visible. Select node → MemoPanel appears at bottom-right (B mode) with min 320×240
+- **AC-34 Manual**: Workspace with 1 root, DeskPane width ≥ 720px → MemoPanel anchored inline next to selected node; widen window → toggle to inline mode
+- **AC-35 Manual**: Transition between A and B (e.g., delete a root to drop below 3) → 0.15s opacity fade observable; check `production/qa/evidence/` screenshot
+- **AC-36 Manual**: Click node → fade in; click empty area → fade out (0.15s each)
+- **AC-38 Manual**: Inspect MemoPanel scene tree → `theme_type_variation == &"Pane"`; MemoEdit `== &"MemoEdit"`
+- **AC-40 Manual**: Set `display.reduced_motion = true` in Settings, repeat AC-35 → no fade animation (instant set)
+
+---
+
+## Test Evidence
+
+**Story Type**: UI + Visual/Feel
+**Required**: `production/qa/evidence/workspace-memo-panel-evidence.md` — manual walkthrough screenshots + sign-off (ux-designer + art-director)
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (WorkspaceData), Story 003 (HypothesisNode), Story 009 (Settings subscription via UIService)
+- Unlocks: Story 011 (visual polish curve + easing tuning)

--- a/production/epics/reasoning-workspace/story-006-tree-panning-camera.md
+++ b/production/epics/reasoning-workspace/story-006-tree-panning-camera.md
@@ -1,0 +1,126 @@
+# Story 006: Tree panning Camera2D (mouse + gamepad + KB + scroll wheel)
+
+> **Epic**: Reasoning Workspace
+> **Status**: Ready
+> **Layer**: Feature (Gameplay)
+> **Type**: UI
+> **Manifest Version**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§9.7 Tree Panning, §9.4.3 Gamepad, §10.7 UI Visual / Interaction partial)
+**Requirement**: `TR-WORKSPACE-LAYOUT-004`
+
+**ADR Governing Implementation**: ADR-0008 §4 (Tree panning Camera2D)
+**ADR Decision Summary**: Camera2D inside DeskCanvas SubViewport. Mouse middle-drag 1:1 pan, gamepad right-stick analog 600 px/s, D-pad/Tab/Arrow auto-center on focused node (0.2s lerp), scroll wheel vertical pan. Position clamped to HypothesisNodeRoot bounding box + 200px padding.
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: `Camera2D.position_smoothing_enabled` for 0.2s lerp; `SubViewport.canvas_transform` for cross-viewport coordinate mapping. Settings `input.gamepad_stick_deadzone` (default 0.15, range [0.0, 0.5] per TR-settings-004).
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.7 UI Visual / Interaction (Tree panning subset).
+
+- [ ] AC-41 — Mouse middle-drag pans canvas 1:1 (cursor moves 100px → canvas moves 100px in opposite direction)
+- [ ] AC-42 — Gamepad right-stick pan velocity 600 px/s at full deflection; respects `input.gamepad_stick_deadzone` setting (default 0.15)
+- [ ] AC-43 — Focus move via D-pad / Tab / Arrow keys auto-centers focused node within 0.2s lerp; verify lerp duration consistent with `display.reduced_motion` setting (instant snap when reduced)
+- [ ] AC-44 — Scroll wheel vertical pan (configurable distance per scroll; default 80px per tick)
+- [ ] AC-50 — Camera position clamped to HypothesisNodeRoot bounding box + 200px padding (can't pan into empty space beyond tree extent)
+- [ ] AC-51 — 1366×768 floor + 4-deep + 3+ root tree fits viewport (panning + auto-center together cover full tree)
+
+---
+
+## Implementation Notes
+
+Per ADR-0008 §4:
+
+```gdscript
+# DeskCanvas — SubViewportContainer + SubViewport + HypothesisNodeRoot Node2D + Camera2D
+class_name DeskCanvas extends SubViewportContainer
+
+@onready var _camera: Camera2D = $SubViewport/Camera2D
+@onready var _node_root: Node2D = $SubViewport/HypothesisNodeRoot
+
+const PAN_VELOCITY_PX_PER_SEC := 600.0   # gamepad right-stick at full deflection
+const AUTO_CENTER_LERP_SEC := 0.2
+const CLAMP_PADDING_PX := 200.0
+const SCROLL_WHEEL_TICK_PX := 80.0
+
+func _process(delta: float) -> void:
+    # Gamepad right-stick pan
+    var stick := Input.get_vector("look_left", "look_right", "look_up", "look_down")
+    var deadzone: float = SettingsService.get("input.gamepad_stick_deadzone", 0.15)
+    if stick.length() > deadzone:
+        var pan := stick * PAN_VELOCITY_PX_PER_SEC * delta
+        _camera.position += pan
+    _clamp_camera_to_bounds()
+
+func _gui_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton:
+        if event.button_index == MOUSE_BUTTON_MIDDLE:
+            _middle_drag_active = event.pressed
+        elif event.button_index == MOUSE_BUTTON_WHEEL_UP:
+            _camera.position.y -= SCROLL_WHEEL_TICK_PX
+        elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
+            _camera.position.y += SCROLL_WHEEL_TICK_PX
+    elif event is InputEventMouseMotion and _middle_drag_active:
+        _camera.position -= event.relative   # 1:1 pan opposite cursor direction
+    _clamp_camera_to_bounds()
+
+func auto_center_on(node: HypothesisNode) -> void:
+    var target := node.position
+    if SettingsService.get("display.reduced_motion", false):
+        _camera.position = target
+    else:
+        var tween := UIService.tween_property(_camera, "position", target, AUTO_CENTER_LERP_SEC)
+        # UIService gateway handles Reduced Motion null-tween case internally
+
+func _clamp_camera_to_bounds() -> void:
+    var bounds := _compute_node_root_bounding_box().grow(CLAMP_PADDING_PX)
+    _camera.position = _camera.position.clamp(bounds.position, bounds.end)
+```
+
+- Uses ADR-0010 `UIService.tween_property` gateway (Reduced Motion uniform handling)
+- Settings `input.gamepad_stick_deadzone` per ADR-0009 — story 009 wires subscriber (this story consumes via `SettingsService.get`)
+- Auto-center triggered by focus events (D-pad/Tab/Arrow handled in story 011 focus traversal); this story exposes `auto_center_on()` API only
+- Clamp box: `_compute_node_root_bounding_box` iterates all HypothesisNode positions → Rect2 + padding
+
+---
+
+## Out of Scope
+
+- Story 003: HypothesisNode position (this story pans Camera, not nodes)
+- Story 009: Settings subscription wiring
+- Story 011: Focus traversal D-pad/Tab/Arrow — triggers `auto_center_on()` (this story exposes the call site)
+- Story 012: Performance test (60fps with 30 nodes — AC-49) — this story doesn't enforce fps gate
+
+---
+
+## QA Test Cases
+
+- **AC-41 Manual**: Middle-click + drag 100px → canvas pans 100px opposite direction; verify cursor stays fixed at screen position
+- **AC-42 Manual**: Push right-stick fully right for 1 second → camera position += ~600px to right (with deadzone 0.15 default); test at deadzone=0.5 — small stick deflection ignored
+- **AC-43 Manual**: D-pad navigate from node A to node B → camera lerps to B's position over 0.2s. Toggle reduced_motion ON → instant snap
+- **AC-44 Manual**: Scroll wheel up/down → camera.y −= / += 80px per tick
+- **AC-50 Manual**: Try to pan beyond rightmost node + 200px → camera clamps
+- **AC-51 Manual**: Build worst-case tree (3 roots × 3 deep × 5 evidence per node) on 1366×768 → pan + auto-center together can reach all nodes
+
+---
+
+## Test Evidence
+
+**Story Type**: UI
+**Required**: `production/qa/evidence/workspace-tree-panning-evidence.md` — manual walkthrough with screenshots / video (ux-designer sign-off)
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (WorkspaceData), Story 003 (HypothesisNode positions), Story 009 (Settings subscription)
+- Unlocks: Story 011 (focus traversal triggers auto_center_on), Story 012 (performance test uses panning at worst-case tree)

--- a/production/epics/reasoning-workspace/story-007-freeze-submit-cascade.md
+++ b/production/epics/reasoning-workspace/story-007-freeze-submit-cascade.md
@@ -1,0 +1,134 @@
+# Story 007: Freeze + submit cascade
+
+> **Epic**: Reasoning Workspace
+> **Status**: Complete (data-layer scope, 2026-05-23) / UI dialog + BriefEditor integration deferred to story-007b (UI Foundation epic prerequisite)
+> **Layer**: Feature (Gameplay)
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 4-5h (M)
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§3.2 ACTIVE→FROZEN transition, §3.3 cycle 3 Decision 2 submit confirmation, §10.4 Freeze Forward-Constraint, §10.11 Cross-System Interaction)
+**Requirement**: `TR-WORKSPACE-LAYOUT-001` (state machine FROZEN) + ADR-0007 §1 (submit pipeline)
+
+**ADR Governing Implementation**: ADR-0008 §1 (workspace_state_changed signal cascade) + ADR-0007 (EvaluationService.submit) + ADR-0007 amend-1 (chain_data Variant primitives) + ADR-0001 amend-2 (BriefEditorData lifecycle — workspace freeze → BriefEditor IMPORTING transition) + ADR-0011 (SaveLoadService SIXTH atomic write on signal cascade)
+**ADR Decision Summary**: `_transition_to_frozen()` snapshots chain_data via `build_chain_data()` (story 002), assigns to `chain_data_snapshot` field, emits `workspace_state_changed(ACTIVE, FROZEN)`. Subscribers: SaveLoadService → atomic write of WorkspaceData.tres; BriefEditor → INACTIVE→IMPORTING auto-transition (per ADR-0001 amend-2). Submit confirmation dialog blocks freeze pending Pillar 3 commit anchor.
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: `Dictionary.duplicate(true)` 4.0+ stable; per ADR-0008 amend-2 §D3 disambiguation, deep-copy semantics on Variant primitives only (no Resource refs). KrDialog (`ROLE_DIALOG` = 44 per amend-1 §G1) for confirmation dialog.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.4 Freeze Forward-Constraint (AC-24 ~ AC-27d) + §10.11 partial.
+
+- [x] AC-24 — chain_data immutable post-freeze: 4-step verification (JSON.stringify deep-equality + reference identity option + mutation blocking + instance distinctness) — **DONE** (`freeze_contract_test.gd`; step 1 timestamp-stripped deterministic compare)
+- [ ] AC-25 — Submit confirmation dialog (KrDialog) blocks freeze pending. Default focus = [취소] (Pillar 3 commit anchor — cycle 3 Decision 2). Esc/취소 → ACTIVE retained; 제출 → FROZEN transition — **DEFERRED → story-007b** (KrDialog = UI Foundation epic)
+- [x] AC-26 — `workspace_state_changed(ACTIVE, FROZEN)` signal emits exactly once on submit; subscribers (SaveLoadService, BriefEditor IMPORTING auto-trigger) receive — **DONE (emit exactly-once)** (`freeze_contract_test.gd`); subscriber receipt (SaveLoadService/BriefEditor) deferred to integration story-007b
+- [ ] AC-27 — BriefEditor INACTIVE→IMPORTING auto-transition completes within 150ms of FROZEN signal per ADR-0001 amend-2 + TR-brief-001 — **DEFERRED → story-007b** (BriefEditor epic dependency)
+- [x] AC-27b — Crash recovery preserved snapshot bytes-equality: auto-resubmit uses chain_data byte-identical to pre-crash snapshot (JSON.stringify equality verify mirror AC-24 protocol) — **DONE** (`freeze_recovery_test.gd::test_auto_resubmit_snapshot_byte_equality`)
+- [ ] AC-27c — Esc from submit-confirm cancels (no state change, tree re-editable) — Pillar 3 cancel branch KB-only verified — **DEFERRED → story-007b** (KrDialog manual)
+- [ ] AC-27d — Confirmation dialog opens via Ctrl+Enter KB shortcut; close (Esc or 취소 button) returns focus to last-focused node before dialog opened — **DEFERRED → story-007b** (KrDialog manual)
+
+---
+
+## Implementation Notes
+
+Per ADR-0008 §1 + ADR-0007 + ADR-0001 amend-2:
+
+```gdscript
+# WorkspaceData
+signal workspace_state_changed(old: int, new: int)
+signal submission_rejected(reason: String)
+var chain_data_snapshot: Dictionary = {}   # populated at freeze
+
+func request_submit() -> void:
+    if state != WorkspaceState.ACTIVE:
+        push_error("submit requires ACTIVE state")
+        return
+    _show_submit_confirmation_dialog()   # KrDialog popup_exclusive
+
+func _on_submit_confirmed() -> void:
+    chain_data_snapshot = build_chain_data()        # story 002 — returns new Dict
+    if not validate_chain_data(chain_data_snapshot):   # allow-list validator
+        return                                       # submission_rejected already emitted
+    _transition_to_frozen()
+    # SaveLoadService (signal subscriber per ADR-0011) auto-persists
+    # BriefEditor (signal subscriber per ADR-0001 amend-2) auto-transitions to IMPORTING
+    EvaluationService.submit(chain_data_snapshot)
+
+func _transition_to_frozen() -> void:
+    var old := state
+    state = WorkspaceState.FROZEN
+    workspace_state_changed.emit(old, state)   # typed emit per amend-1 §A5
+```
+
+- AC-24 verification: 4-step protocol with `JSON.stringify(snapshot, "", true)` and `JSON.stringify(submitted.chain_data, "", true)` (sort_keys=true; empty-string indent) — per GDD §10.4 cycle 3 indent collision risk closure
+- AC-25 KrDialog: `popup_exclusive=true` per ADR-0008 amend-2 §D2; default focus = [취소] button (NOT [제출]) — cycle 3 Decision 2 Pillar 3 commit anchor
+- AC-27b: Crash recovery cascade — SaveLoadService loads persisted WorkspaceData.tres → `chain_data_snapshot` field intact → auto-resubmit uses snapshot directly (no rebuild). bytes-equality verifies snapshot integrity round-trip.
+- ADR-0008 amend-3 §E2 typed `.emit()` cascade — `EvaluationService.evaluation_completed.emit(...)` etc.
+- **Performance budget**: signal cascade is debounce-free direct emit (synchronous subscriber dispatch, no per-frame polling); KrDialog `popup_exclusive` opens via native window <50ms; no frame budget impact — this is a non-gameplay UI transition, not a 60fps hot path. AC-27 BriefEditor handoff ≤150ms is the only timed contract.
+
+---
+
+## Out of Scope
+
+- Story 001: state machine (this story implements ACTIVE→FROZEN transition specifically; story 001 defines the transition function skeleton)
+- Story 002: chain_data construction (this story calls `build_chain_data()`)
+- Story 008: READ_ONLY transition + ReadOnlyIndicator + crash recovery scene loading (this story only handles freeze-time persistence trigger, not READ_ONLY state)
+- Story 010: KrDialog AccessKit role (this story applies; cross-cutting audit is story 010)
+- BriefEditor IMPORTING internals (story is in Brief Editor epic, not this epic)
+
+---
+
+## QA Test Cases
+
+- **AC-24 Logic**: Build chain_data, freeze, attempt `workspace_data.add_node(...)` → blocked + `submission_rejected("schema_violation")` emitted; 4-step JSON.stringify protocol passes
+- **AC-25 Manual**: Click Submit button → dialog opens, default focus on [취소]; press Esc → dialog closes + state ACTIVE
+- **AC-26 Logic**: Connect test listener to `workspace_state_changed`; complete submit → exactly one emit with (ACTIVE, FROZEN)
+- **AC-27 Integration**: Workspace freeze → measure time until BriefEditor.state == IMPORTING; assert ≤150ms
+- **AC-27b Logic**: Save WorkspaceData (with chain_data_snapshot populated) → load → JSON.stringify of loaded `chain_data_snapshot` == JSON.stringify of original snapshot
+- **AC-27c Manual**: Submit confirmation dialog open → Esc → state remains ACTIVE, tree editable
+- **AC-27d Manual**: Focus on node A → Ctrl+Enter → dialog opens; Esc → dialog closes + focus returns to node A
+
+Edge cases: submit with INACTIVE state (rejected), submit with empty tree (empty chain_data — schema_version=1 with nodes=[]), schema_violation injection (story 002 fuzz test cross-link).
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**:
+- `tests/unit/workspace/freeze_contract_test.gd` — AC-24, AC-26 (gdunit4)
+- `tests/integration/workspace/freeze_submit_test.gd` — AC-27 BriefEditor handoff (gdunit4)
+- `tests/unit/workspace/freeze_recovery_test.gd::test_auto_resubmit_snapshot_byte_equality` — AC-27b
+- `production/qa/evidence/workspace-submit-confirmation-dialog.md` — AC-25, AC-27c, AC-27d manual
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (state machine), Story 002 (chain_data builder + validator), Story 009 (UIService for KrDialog if it uses Theme/announce)
+- Unlocks: Story 008 (READ_ONLY + crash recovery cascade extends freeze persistence), Story 010 (KrDialog AccessKit role audit), Story 012 (Pillar compliance verification)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23 (data-layer scope)
+**Criteria**: 3/3 in-scope passing (AC-24, AC-26 emit-side, AC-27b). Deferred → story-007b: AC-25, AC-27, AC-27c, AC-27d (KrDialog submit dialog + BriefEditor IMPORTING handoff — both UI Foundation epic dependent).
+**Scope split rationale**: KrDialog belongs to UI Foundation epic (design-phase); ADR-0007 `PlayerSubmission` (submit handoff) requires `player_disposition` + `player_citations` captured by the deferred Brief Editor dialog. Mirrors story-003 data-layer/UI split precedent.
+**Files**:
+- `src/data/workspace_data.gd` — `submit() -> bool` (build_chain_data → validate → snapshot 할당 → `_transition_to_frozen`); `_transition_to_frozen()` placeholder 갱신. EvaluationService.submit() handoff = forward-claim comment (no stub created by design).
+- `tests/unit/workspace/freeze_contract_test.gd` (10 tests — AC-24/26 + state-guard branches + empty-tree edge case)
+- `tests/unit/workspace/freeze_recovery_test.gd` (1 test — AC-27b)
+**Test Evidence**: workspace suite 98/98 PASS, 0 flaky, exit 0 (independently re-run). Integration test (`tests/integration/workspace/freeze_submit_test.gd` AC-27) + manual evidence (`production/qa/evidence/workspace-submit-confirmation-dialog.md` AC-25/27c/27d) = deferred to story-007b.
+**Code Review**: Complete (godot-gdscript-specialist + qa-tester, 2026-05-23). Initial CHANGES REQUIRED → all closed: line-177 flaky time-dependent assertion fixed (timestamp-stripped compare), + Gap B/D/E/F coverage added. Final APPROVED.
+**Deviations (ADVISORY, logged as tech debt)**:
+1. ADR-0007 `submit(PlayerSubmission)` vs control-manifest `submit(chain_data: Dictionary)` signature conflict — must reconcile before story #9 (submission-evaluation).
+2. `ALLOWED_NODE_FIELDS` / `_roots()` / `_children_of()` untyped `Array` (story 002/003a pre-existing static-typing debt).

--- a/production/epics/reasoning-workspace/story-008-read-only-crash-recovery.md
+++ b/production/epics/reasoning-workspace/story-008-read-only-crash-recovery.md
@@ -1,0 +1,119 @@
+# Story 008: READ_ONLY state + ReadOnlyIndicator + crash recovery cascade
+
+> **Epic**: Reasoning Workspace
+> **Status**: Ready
+> **Layer**: Feature (Gameplay)
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§3.2 READ_ONLY transition, §5.4 Lifecycle, §10.4 AC-27, §10.6 Persistence)
+**Requirement**: `TR-WORKSPACE-LAYOUT-001`
+
+**ADR Governing Implementation**: ADR-0008 §1 (READ_ONLY state) + ADR-0011 (Save/Load atomic write + crash recovery cascade: `active_case_recovered` signal) + ADR-0008 amend-1 §A6 (chain_data_include_ephemeral_field forbidden)
+**ADR Decision Summary**: READ_ONLY state activates on EvaluationResult arrival; tree visible + ReadOnlyIndicator banner shown; no mutations allowed. Crash recovery: SaveLoadService boot detects FROZEN snapshot in active_case.tres → auto-resubmits chain_data (bytes-equal per AC-27b) → on success transitions WorkspaceData to READ_ONLY.
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: ReadOnlyIndicator = KrBanner subclass (ROLE_STATIC_TEXT per amend-1 §G1; live-region announce via UIService.announce_text per amend-1 §G3). SaveLoadService crash recovery cascade per ADR-0011 §3.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.4 partial (AC-27 family crash recovery) + §10.6 Persistence.
+
+- [ ] AC-19 (extends story 001) — `_transition_to_read_only()` triggered by `EvaluationService.evaluation_completed` signal arrival; tree visible, all mutations blocked
+- [ ] AC-39 — ReadOnlyIndicator banner displays "평가 완료 — 읽기 전용" + verdict summary; KrBanner subclass with priority=POLITE announce via UIService.announce_text
+- [ ] AC-40b — In READ_ONLY, attempted mutation (add node, drop evidence, edit memo) → silent reject + announce "읽기 전용 상태에서 변경할 수 없습니다" (POLITE)
+- [ ] AC-27 (extends story 007) — Crash recovery: boot with active_case.tres containing FROZEN snapshot → SaveLoadService detects → emits `active_case_recovered(case_id, snapshot)` → auto-resubmit cascade fires (verified via AC-27b bytes-equality)
+- [ ] AC-27e — Crash recovery cascade completes → WorkspaceData.state == READ_ONLY (or FROZEN if EvaluationResult still in flight) within 500ms of boot
+- [ ] AC-27f — Crash recovery on schema_version mismatch → `submission_rejected("schema_version_mismatch")` + CriticalBanner via UIService.announce_text(priority=ASSERTIVE) + WorkspaceData reset to INACTIVE (case 재시작 권장 path)
+
+---
+
+## Implementation Notes
+
+Per ADR-0008 §1 + ADR-0011 §3:
+
+```gdscript
+# WorkspaceData
+func _transition_to_read_only() -> void:
+    var old := state
+    state = WorkspaceState.READ_ONLY
+    workspace_state_changed.emit(old, state)
+    _show_read_only_indicator()
+
+# All mutation entry points
+func add_node(...) -> bool:
+    if state == WorkspaceState.READ_ONLY:
+        UIService.announce_text(self, "읽기 전용 상태에서 변경할 수 없습니다", UIService.AnnouncePriority.POLITE)
+        return false
+    # ... rest of add logic
+
+# ReadOnlyIndicator KrBanner subclass
+class_name ReadOnlyIndicator extends PanelContainer
+func _ready() -> void:
+    theme_type_variation = &"ReadOnlyBanner"
+    accessibility_role = AccessibilityRole.ROLE_STATIC_TEXT   # =4 per amend-1 §G1
+    super._ready()
+    UIService.announce_text(self, text, UIService.AnnouncePriority.POLITE)
+
+# Boot path — SaveLoadService active_case_recovered signal subscriber
+# (registered in workspace bootstrap autoload or scene tree root)
+func _on_active_case_recovered(case_id: String, snapshot: Dictionary) -> void:
+    workspace_data = SaveLoadService.load_workspace(case_id)
+    if workspace_data.state == WorkspaceState.FROZEN:
+        # Auto-resubmit cascade — AC-27b bytes-equal verified
+        EvaluationService.submit(workspace_data.chain_data_snapshot)
+```
+
+- ADR-0011 §3 — `active_case_recovered` signal is single entry point for both Workspace FROZEN auto-resubmit + Brief SUBMITTING auto-resubmit cascades
+- AC-27f schema mismatch → ASSERTIVE announce (per amend-1 §G3 priority enum) + UIService.announce_text crash recovery path mirror ADR-0009 §G3 settings recovery
+- KrBanner family per amend-1 §G2 R9 — live-region absence mitigated by UIService.announce_text gateway
+- ReadOnlyIndicator z-order: above tree canvas, below confirmation dialogs (per ADR-0008 §5 floating badge guidance)
+
+---
+
+## Out of Scope
+
+- Story 001: state machine baseline (this story extends with READ_ONLY-specific mutation guards)
+- Story 002: chain_data construction (this story uses persisted snapshot, doesn't rebuild)
+- Story 007: freeze + submit happy path (this story extends crash recovery branch)
+- Story 010: AccessKit role assignment (this story applies ROLE_STATIC_TEXT for ReadOnlyIndicator; cross-cutting audit is story 010)
+- Story 011: Visual polish for ReadOnlyIndicator pulse (this story sets visibility + announce only)
+- BriefEditor crash recovery (Brief Editor epic — though `active_case_recovered` signal is shared)
+
+---
+
+## QA Test Cases
+
+- **AC-19 Logic**: Transition WorkspaceData ACTIVE→FROZEN; fire `EvaluationService.evaluation_completed` signal manually → `_transition_to_read_only()` fires + state == READ_ONLY
+- **AC-39 Manual**: Trigger READ_ONLY entry → ReadOnlyIndicator banner appears + screen reader announces verdict (verify with VoiceOver / NVDA / Orca)
+- **AC-40b Logic**: In READ_ONLY, attempt `add_node` / drop evidence / edit memo → all return false + announce called
+- **AC-27 Integration**: Persist WorkspaceData with state=FROZEN + chain_data_snapshot; restart scene; verify auto-resubmit fires
+- **AC-27e Manual**: Crash + reboot scenario; measure time from boot to state == READ_ONLY (or FROZEN if EvaluationResult mock-delayed) → ≤500ms
+- **AC-27f Logic**: Persist WorkspaceData with chain_data_snapshot.schema_version=2 (mismatch); load → submission_rejected emitted + CriticalBanner + state reset to INACTIVE
+
+Edge cases: active_case.tres present but workspace_data corrupt (per ADR-0011 .backup recovery cascade), READ_ONLY state with no chain_data_snapshot (impossible per AC-23 but defensive check), evaluation_completed signal arrives before FROZEN transition (race — should latch waiting for FROZEN).
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**:
+- `tests/integration/workspace/read_only_state_test.gd` — AC-19, AC-40b (gdunit4)
+- `tests/integration/workspace/crash_recovery_test.gd` — AC-27, AC-27e, AC-27f
+- `production/qa/evidence/workspace-read-only-banner.md` — AC-39 manual screen reader walkthrough
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (state machine), Story 002 (chain_data persisted snapshot), Story 007 (freeze cascade)
+- Unlocks: Story 010 (ReadOnlyIndicator AccessKit + announce role audit), Story 012 (lifecycle edge cases extend)

--- a/production/epics/reasoning-workspace/story-009-settings-subscription.md
+++ b/production/epics/reasoning-workspace/story-009-settings-subscription.md
@@ -1,0 +1,110 @@
+# Story 009: Settings subscription cascade — UIService auto-subscribe
+
+> **Epic**: Reasoning Workspace
+> **Status**: Ready
+> **Layer**: Feature (Gameplay)
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§6.4 #4 Settings dependency, §10.7 partial reduced_motion / text_scale, §10.8 partial focus_indicator_thickness)
+**Requirement**: TR-WORKSPACE-LAYOUT-001 + (cross-cover TR-settings-006/007/008 from ADR-0009)
+
+**ADR Governing Implementation**: ADR-0010 KrCustomControl auto-subscribe via UIService (text_scale + reduced_motion + focus_indicator_thickness signals) + ADR-0010 amend-1 (corrected AccessKit + announce_text) + ADR-0009 (SettingsService FIFTH autoload + 5-step cascade + setting_changed typed signal)
+**ADR Decision Summary**: KrCustomControl base class `_ready()` auto-subscribes to SettingsService 3 signals (display.reduced_motion / display.text_scale / accessibility.focus_indicator_thickness_px) via UIService. text_scale → Theme.set_font_size cascade (VR-UI1 PASS — auto NOTIFICATION_THEME_CHANGED propagation). reduced_motion → UIService.tween_property gateway returns null. focus_indicator_thickness → dual focus ring outer dashed width 1-4px.
+
+**Engine**: Godot 4.6 | **Risk**: LOW (post-VR-UI1 PASS)
+**Engine Notes**: `Theme.set_font_size()` auto-cascade confirmed VR-UI1 PASS (3/3 dependent Labels receive NOTIFICATION_THEME_CHANGED). `UIService.tween_property` gateway returns null when reduced_motion → caller sets property immediately.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.7 partial + §10.8 partial settings subscription.
+
+- [ ] AC-40 — `display.reduced_motion = true` → all UIService.tween_property() calls within Workspace return null + caller sets property immediately (no animation). Verify: MemoPanel fade (story 005), Camera2D auto-center (story 006), drag preview animations (story 011) all bypass tween
+- [ ] AC-41b — `display.text_scale` change → Theme runtime reload cascades to all KrCustomControl in Workspace scene (HypothesisNode label, MemoEdit, ReadOnlyIndicator) via NOTIFICATION_THEME_CHANGED (VR-UI1 PASS — automatic)
+- [ ] AC-47 — `accessibility.focus_indicator_thickness_px` (1-4) controls dual focus ring outer dashed thickness on HypothesisNode + KrButton + KrDialog
+- [ ] AC-48 — Settings change while Workspace in any state (INACTIVE/ACTIVE/FROZEN/READ_ONLY) applies immediately — no waiting for Workspace-specific signal
+- [ ] AC-48b — KrCustomControl auto-subscribe happens in `_ready()` — verify by inspecting subscriber count on SettingsService after Workspace scene load
+- [ ] AC-48c — `input.mouse_drag_threshold_px` change updates story 004 drag threshold; `input.gamepad_stick_deadzone` change updates story 006 deadzone — both via SettingsService.get() consumption at call-site (no caching per ADR-0009 forbidden_pattern `settings_local_cache`)
+
+---
+
+## Implementation Notes
+
+Per ADR-0010 §Decision + amend-1 §G1/G2 + ADR-0009 §3.1:
+
+```gdscript
+# KrControlHelper.setup() — called from each Kr* class _ready()
+static func setup(control: Control) -> void:
+    if Engine.has_singleton("SettingsService"):
+        SettingsService.setting_changed.connect(_on_setting_changed.bind(control))
+    control._apply_access_kit_role()   # subclass override
+    # ... other Kr setup
+
+static func _on_setting_changed(key: String, _old: Variant, new: Variant, control: Control) -> void:
+    match key:
+        "display.reduced_motion":
+            # No per-control action; UIService.tween_property gateway handles centrally
+            pass
+        "display.text_scale":
+            # No per-control action; Theme.set_font_size cascade handled by UIService.theme mutation
+            pass
+        "accessibility.focus_indicator_thickness_px":
+            control.queue_redraw()   # repaint focus ring with new thickness
+
+# Workspace per-call consumption pattern (no local cache — ADR-0009 forbidden_pattern)
+# story 004 drag threshold check:
+var threshold: int = SettingsService.get("input.mouse_drag_threshold_px", 8)
+if motion.length() < threshold: return
+```
+
+- `settings_local_cache` forbidden_pattern: do NOT do `var _cached_threshold = SettingsService.get(...)` in member vars; always call `SettingsService.get(key)` at use-site OR subscribe to `setting_changed` signal
+- VR-UI1 PASS confirms Theme.set_font_size cascade is automatic — no manual `theme.emit_changed()` (per registry forbidden_pattern from ADR-0004 amend-1)
+- AC-47 dual focus ring: outer dashed component width comes from `accessibility.focus_indicator_thickness_px` — per ADR-0010 §Dual Focus Ring Composite (inner=2px solid fixed, outer=1-4px dashed user-configurable)
+- ADR-0010 R8 (dashed border non-trivial) — implementation deferred to story 011 visual polish; this story wires the setting subscription only
+
+---
+
+## Out of Scope
+
+- Story 005: MemoPanel fade implementation (this story verifies the reduced_motion gateway works for MemoPanel's tween calls)
+- Story 006: Camera2D auto-center implementation (this story verifies the gateway behavior)
+- Story 011: Dual focus ring visual implementation (this story wires `focus_indicator_thickness_px` consumption; story 011 implements the actual outer dashed render via ADR-0010 R8 decision)
+- ADR-0009 SettingsService implementation itself (Settings & Accessibility epic — out of this epic's scope)
+- AccessKit role assignment (story 010)
+
+---
+
+## QA Test Cases
+
+- **AC-40 Integration**: Set `display.reduced_motion = true`; trigger MemoPanel fade (story 005) → no opacity tween created, set immediate; trigger Camera2D auto-center (story 006) → camera.position = target immediately
+- **AC-41b Integration**: Change `display.text_scale = 1.5`; verify HypothesisNode label font size visually +50% (or check Theme.set_font_size called once on UIService.theme then NOTIFICATION_THEME_CHANGED received by Workspace Controls)
+- **AC-47 Manual**: Change `accessibility.focus_indicator_thickness_px` 1→4; focus a HypothesisNode → outer dashed ring visibly thickens
+- **AC-48 Logic**: Workspace state INACTIVE; change `display.reduced_motion` → setting_changed signal received + UIService.tween_property reflects new value on next call
+- **AC-48b Logic**: Load Workspace scene with 3 HypothesisNodes + MemoPanel + ReadOnlyIndicator (5 KrCustomControl); verify SettingsService.setting_changed has ≥5 connections
+- **AC-48c Logic**: Set `input.mouse_drag_threshold_px = 16`; story 004 drag attempt at 12px motion → no drag; at 18px → drag starts (verify on next call, not stale cache)
+
+Edge cases: SettingsService not yet ready when KrControl spawns (race per ADR-0010 R5 — `call_deferred` for UIService self-init; scene Controls always after autoload `_ready()` complete per Godot order); settings_changed signal during state transition.
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**:
+- `tests/integration/workspace/settings_subscription_test.gd` — AC-40, AC-48, AC-48b, AC-48c (gdunit4)
+- `production/qa/evidence/workspace-settings-cascade-evidence.md` — AC-41b text_scale visual + AC-47 focus thickness manual
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (WorkspaceData), Story 003 (HypothesisNode KrCard), Story 005 (MemoPanel), Story 006 (Camera2D), ADR-0009 SettingsService implementation (Settings & Accessibility epic)
+- Unlocks: Story 011 (focus ring visual uses thickness from this story's subscription)

--- a/production/epics/reasoning-workspace/story-010-accesskit-roles.md
+++ b/production/epics/reasoning-workspace/story-010-accesskit-roles.md
@@ -1,0 +1,124 @@
+# Story 010: AccessKit roles per amend-4 §F1 corrected mapping + live-region announce cascade
+
+> **Epic**: Reasoning Workspace
+> **Status**: Ready
+> **Layer**: Feature (Gameplay)
+> **Type**: Logic + UI (Logic primary — role assignment is structural)
+> **Manifest Version**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§9.5 Feedback Patterns, §9.6 Accessibility Requirements, §10.8 Accessibility)
+**Requirement**: TR-WORKSPACE-LAYOUT-001 + (cross-cover TR-settings-014 screen_reader_detected, TR-settings-024 SettingsScreen role mapping)
+
+**ADR Governing Implementation**: ADR-0008 amend-4 §F1 (AccessibilityRole 7 enum corrected mapping — retroactive supersede of hallucinated names) + ADR-0010 amend-1 §G1 (KrCustomControl 21 클래스 corrected mapping) + amend-1 §G3 (UIService.announce_text live-region API — VR-UI6 PASS path: DisplayServer.accessibility_update_set_live + AccessibilityLiveMode)
+**ADR Decision Summary**: Workspace Controls use corrected AccessKit role enum (verified runtime via VR-UI6 dump 46-entry AccessibilityRole). Hallucinated names (ROLE_REGION/HEADING/GROUP/RADIO_GROUP/COMBO_BOX/STATUS/ALERT) replaced per amend-4 §F1. Live-region absence in role enum mitigated via UIService.announce_text(source, message, priority) → DisplayServer.accessibility_update_set_live(rid, mode) wrapper.
+
+**Engine**: Godot 4.6 | **Risk**: LOW (post-sprint VR-UI2 + VR-UI6 PASS runtime confirmed)
+**Engine Notes**: 46 AccessibilityRole values runtime-dumped (VR-UI6 prototype). `DisplayServer.accessibility_update_set_live(id, live)` + `AccessibilityLiveMode {LIVE_OFF=0, LIVE_POLITE=1, LIVE_ASSERTIVE=2}` confirmed. KrCustomControl `_apply_access_kit_role()` override hook (per ADR-0010 §Decision).
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.8 Accessibility (AC-45 ~ AC-48 partial) — 4 AC focused on role + announcement.
+
+- [ ] AC-44a — Workspace root Controls have corrected AccessKit roles applied:
+  - DeskPane root → `ROLE_PANEL` (=6)
+  - DeskCanvas → `ROLE_TREE` (=27)
+  - HypothesisNode → `ROLE_TREE_ITEM` (=28)
+  - MemoPanel → `ROLE_PANEL` (=6)
+  - SubmitButton → `ROLE_BUTTON` (=7)
+  - ReadOnlyIndicator → `ROLE_STATIC_TEXT` (=4) + live-region announce
+  - Confirmation dialog (story 007) → `ROLE_DIALOG` (=44)
+  - HypothesisNode label edit → `ROLE_TEXT_FIELD` (=18)
+  - HypothesisNode memo edit → `ROLE_MULTILINE_TEXT_FIELD` (=19)
+- [ ] AC-44b — `accessibility_name` populated for each Control (HypothesisNode name = label + evidence count, MemoPanel name = "메모 패널", etc.)
+- [ ] AC-44c — ReadOnlyIndicator (KrBanner) announces "평가 완료 — 읽기 전용" with priority POLITE via `UIService.announce_text(self, text, AnnouncePriority.POLITE)` on `_ready()` (per amend-1 §G3)
+- [ ] AC-44d — Crash recovery CriticalBanner uses priority ASSERTIVE (per amend-1 §G3 + ADR-0009 §G3 cascade)
+- [ ] AC-45 — keyboard-only full workflow completion (sub-step KB workflow per §10.8 AC-45) — focus visible throughout, status bar guidance, role announcements correct
+- [ ] AC-48d — Forbidden_pattern check: no Workspace code references hallucinated enum names (`ROLE_REGION`, `ROLE_GROUP`, `ROLE_HEADING`, `ROLE_STATUS`, `ROLE_ALERT`, `ROLE_RADIO_GROUP`, `ROLE_COMBO_BOX`) — gdunit4 meta-test grep
+
+---
+
+## Implementation Notes
+
+Per ADR-0008 amend-4 §F1 + ADR-0010 amend-1 §G1/G3:
+
+```gdscript
+# DeskPane root
+func _apply_access_kit_role() -> void:
+    accessibility_role = AccessibilityRole.ROLE_PANEL   # =6 (was ROLE_REGION — hallucinated)
+    accessibility_name = "추론 작업대"
+
+# DeskCanvas (SubViewportContainer + SubViewport host)
+func _apply_access_kit_role() -> void:
+    accessibility_role = AccessibilityRole.ROLE_TREE   # =27
+    accessibility_name = "사고 트리"
+
+# HypothesisNode
+func _apply_access_kit_role() -> void:
+    accessibility_role = AccessibilityRole.ROLE_TREE_ITEM   # =28
+    accessibility_name = "%s (증거 %d개)" % [data.label, data.evidence.size()]
+
+# ReadOnlyIndicator (KrBanner subclass per ADR-0010 amend-1 §G3)
+func _ready() -> void:
+    super._ready()
+    accessibility_role = AccessibilityRole.ROLE_STATIC_TEXT   # =4 (was ROLE_STATUS — hallucinated)
+    UIService.announce_text(self, "평가 완료 — 읽기 전용", UIService.AnnouncePriority.POLITE)
+
+# Crash recovery banner (CriticalBanner — used by story 008)
+func _on_schema_version_mismatch() -> void:
+    var banner := CriticalBanner.new()
+    banner.text = "스냅샷 손상 — 케이스 재시작 권장"
+    add_child(banner)
+    UIService.announce_text(banner, banner.text, UIService.AnnouncePriority.ASSERTIVE)
+```
+
+- Per amend-4 §F4 registry `accessibility_role_pre_verification_implementation` forbidden_pattern — gdunit4 meta-test cross-references corrected mapping table; this story passes that gate by using only corrected names
+- VR-UI6 PASS confirms `DisplayServer.accessibility_update_set_live` + `LIVE_POLITE/LIVE_ASSERTIVE` enum — UIService.announce_text body fully implementable
+- `kr_banner_dynamic_show_without_announce` forbidden_pattern (amend-1 §G5) — ReadOnlyIndicator + CriticalBanner explicitly satisfy via super()._ready() pattern
+- `accessibility_name` separate from role — gives unique identity per element (mitigates Risk R3 about ROLE_STATIC_TEXT cap across KrHeader + KrBanner family)
+
+---
+
+## Out of Scope
+
+- Story 003: HypothesisNode role assignment (this story does cross-cutting audit + announcement layer; per-story role assignment was in stories 001-008)
+- Story 011: Focus ring visual + dual focus implementation (this story enforces role; story 011 paints focus ring per `accessibility.focus_indicator_thickness_px`)
+- VR-D7 (Korean IME) interactive prototype — non-blocking; affects KrTextEdit memo input but no role assignment
+- AccessKit screen reader manual verification (story 011 visual + audio polish)
+- ADR-0010 amend-1 §G5 forbidden_pattern enforcement (gdunit4 meta-test — out-of-epic CI scope; story 010 only ensures Workspace code complies)
+
+---
+
+## QA Test Cases
+
+- **AC-44a Logic**: For each Workspace Control, assert `accessibility_role == EXPECTED_ROLE` matching the table; values come from `AccessibilityRole.ROLE_*` enum (verified non-hallucinated)
+- **AC-44b Logic**: For each Workspace Control, assert `accessibility_name != ""` and meets the per-control naming convention
+- **AC-44c Manual**: Trigger READ_ONLY transition; verify screen reader (VoiceOver / NVDA / Orca) announces "평가 완료 — 읽기 전용" at POLITE priority
+- **AC-44d Manual**: Trigger schema_version_mismatch crash recovery; verify screen reader announces critical banner at ASSERTIVE priority (interrupts current speech)
+- **AC-45 Manual**: Execute keyboard-only full workflow (per §10.8 AC-45 — 8 steps) → all controls announce correctly + focus visible throughout
+- **AC-48d Logic**: gdunit4 meta-test — grep `src/scenes/workspace/` for `ROLE_REGION|ROLE_GROUP|ROLE_HEADING|ROLE_STATUS|ROLE_ALERT|ROLE_RADIO_GROUP|ROLE_COMBO_BOX` → 0 hits
+
+Edge cases: HypothesisNode with no evidence (accessibility_name = "label (증거 0개)" — verify no null), MemoPanel `_apply_access_kit_role` before scene tree ready (defensive null check).
+
+---
+
+## Test Evidence
+
+**Story Type**: Logic + UI
+**Required**:
+- `tests/unit/workspace/accesskit_roles_test.gd` — AC-44a, AC-44b, AC-48d (gdunit4)
+- `production/qa/evidence/workspace-screen-reader-walkthrough.md` — AC-44c, AC-44d, AC-45 manual (accessibility-specialist sign-off)
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (DeskPane root), Story 003 (HypothesisNode + label edit), Story 005 (MemoPanel + MemoEdit), Story 007 (Confirmation dialog), Story 008 (ReadOnlyIndicator + CriticalBanner), Story 009 (Settings subscription for screen_reader_detected)
+- Unlocks: Story 011 (focus visual polish), Story 012 (Pillar compliance + edge cases)

--- a/production/epics/reasoning-workspace/story-011-visual-audio-polish.md
+++ b/production/epics/reasoning-workspace/story-011-visual-audio-polish.md
@@ -1,0 +1,122 @@
+# Story 011: Visual + audio polish
+
+> **Epic**: Reasoning Workspace
+> **Status**: Ready
+> **Layer**: Feature (Gameplay)
+> **Type**: Visual/Feel
+> **Manifest Version**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§8.1 Visual Requirements — 7 sub, §8.2 Audio Requirements — 6 sub including 21-event catalog, §10.7 UI Visual / Interaction visual portion)
+**Requirement**: TR-WORKSPACE-LAYOUT-001 (visual portion)
+
+**ADR Governing Implementation**: ADR-0004 + amend-1 (17 Theme type variations) + ADR-0008 §1 (DeskPane visual hierarchy) + ADR-0010 (KrCustomControl dual focus ring composite per §Decision Risk R8 — inner solid + outer dashed)
+**ADR Decision Summary**: Workspace visual polish applies Theme type variations (HypothesisNode / MemoLabel / CommentLabel / CourtHeadline / CaptionLabel / Banner family) + dual focus ring composite (inner=2px solid 잉크블랙 fixed, outer=`accessibility.focus_indicator_thickness_px` 1-4px dashed per ADR-0010 R8). Audio plays 21 events from audio-director catalog via AudioService (`weight-stamp` for evidence attach, `paper-blocked` for invalid drop, etc.).
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: StyleBoxFlat has no native dashed border (per ADR-0010 R8) — implementer chooses among 3 options: (1) two overlap StyleBox at different draw layers, (2) Control `_draw()` override + custom draw_rect dashed line routine, (3) shader. Decision made at story implementation time + recorded in epic notes for future stories.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.7 visual portion + §8.1/§8.2 spec compliance.
+
+- [ ] AC-37 — HypothesisNode bottom evidence rule visualization: 6 discrete steps (cap=5 → ρ ∈ {0.0, 0.2, 0.4, 0.6, 0.8, 1.0}); 200×48 hero shape with inner padding rule: ρ=1.0 → 184px rule length, ρ=0.0 → 0px (or 36.8/110.4/184px ±2px per cycle 4 padding correction)
+- [ ] AC-38b — KrCard hover state: subtle 잉크블랙 glow (StyleBoxFlat per Theme variation) + 50ms ease-in
+- [ ] AC-38c — KrCard focus ring composite: inner 2px solid 잉크블랙 (fixed) + outer dashed `accessibility.focus_indicator_thickness_px` (1-4px, consumed from story 009 settings subscription) via chosen ADR-0010 R8 path
+- [ ] AC-39b — ReadOnlyIndicator banner pulse: 0.5s opacity oscillation (50% ↔ 100%) on first entry; Reduced Motion → no pulse
+- [ ] AC-40c — Drag preview opacity: 70% transparent KrCard ghost following cursor (per ADR-0008 §2 drag preview pattern)
+- [ ] AC-39c — MemoPanel fade transition curve: ease-in-out 0.15s (visual polish on top of story 005 duration)
+- [ ] AC-37b — All 21 audio events from §8.2 audio-director catalog wired: weight-stamp / paper-blocked / paper-rustle / ink-pen-mark / book-close / etc. (verify each event triggers from correct game action)
+
+---
+
+## Implementation Notes
+
+Per ADR-0004 amend-1 + ADR-0008 §1 + ADR-0010 R8:
+
+```gdscript
+# HypothesisNode evidence rule (AC-37) — Control _draw override
+func _draw() -> void:
+    # Bottom evidence rule — left edge inset 8px (per cycle 4 padding correction)
+    var rule_density: float = float(data.evidence.size()) / float(EVIDENCE_CAP)
+    var rule_length := rule_density * 184.0   # 200px node width - 16px padding (8 left + 8 right)
+    var rule_y := size.y - 4.0
+    draw_line(Vector2(8, rule_y), Vector2(8 + rule_length, rule_y), Color(0.06, 0.06, 0.06), 2.0)
+
+# Dual focus ring composite (AC-38c) — choose ADR-0010 R8 option 2 (_draw override)
+func _draw() -> void:
+    # ... bottom rule first
+    if has_focus():
+        var inner_thickness := 2.0
+        var outer_thickness: float = float(SettingsService.get("accessibility.focus_indicator_thickness_px", 1))
+        # Inner solid
+        draw_rect(Rect2(Vector2.ZERO, size), Color(0.06, 0.06, 0.06), false, inner_thickness)
+        # Outer dashed
+        _draw_dashed_rect(Rect2(-2, -2, size.x + 4, size.y + 4), Color(0.06, 0.06, 0.06), outer_thickness, 4.0, 4.0)
+
+func _draw_dashed_rect(rect: Rect2, color: Color, thickness: float, dash_len: float, gap_len: float) -> void:
+    # Custom draw_rect dashed routine — iterates edges drawing line segments
+    pass  # full implementation at impl time
+
+# Drag preview (AC-40c)
+func _get_drag_data(_pos: Vector2) -> Variant:
+    var preview := duplicate()
+    preview.modulate.a = 0.7
+    set_drag_preview(preview)
+    # ... rest
+
+# Audio (AC-37b) — wire 21 events per §8.2 catalog
+# AudioService.play("weight-stamp") on evidence attach (story 004)
+# AudioService.play("paper-blocked") on cap rejection (story 003 + story 008 READ_ONLY)
+# AudioService.play("ink-pen-mark") on memo char input (story 005)
+# ... full 21-event map
+```
+
+- Theme type variation registration in `&"HypothesisNode"` per ADR-0004 amend-1 — actual StyleBox values come from art-director spec
+- ADR-0010 R8 — implementation decision: pick option 2 (`_draw()` override) for HypothesisNode; KrButton + KrDialog can reuse via base KrControl helper
+- Audio events — list of 21 events in GDD §8.2 → AudioService.play(event_name) calls scattered across stories 003/004/005/007/008/011
+- Reduced Motion (story 009) — pulse animations (AC-39b) gate via UIService.tween_property null-return
+
+---
+
+## Out of Scope
+
+- Story 005: MemoPanel layout + transition duration (this story polishes the curve, not the duration)
+- Story 003: HypothesisNode invariant enforcement (this story polishes appearance, not behavior)
+- Story 009: Settings subscription wiring (this story consumes `accessibility.focus_indicator_thickness_px` via call-site)
+- Story 010: AccessKit role assignment (this story is purely visual + audio)
+- Art-director asset spec generation (separate `asset-spec` workflow — story 011 consumes specs, doesn't generate them)
+- audio-director sound asset authoring (separate workflow — story 011 wires events, doesn't author SFX)
+
+---
+
+## QA Test Cases
+
+- **AC-37 Manual**: Build HypothesisNode with 0/1/2/3/4/5 evidence → verify bottom rule length matches discrete step pixel value (±2px)
+- **AC-38b Manual**: Hover over KrCard → glow visible within ~50ms; mouse out → glow fades
+- **AC-38c Manual**: Tab to focus HypothesisNode → inner 2px ring + outer dashed visible; change `focus_indicator_thickness_px` 1→4 → outer dashed width updates immediately on next focus
+- **AC-39b Manual**: Trigger READ_ONLY transition → ReadOnlyIndicator pulses 0.5s opacity oscillation; toggle reduced_motion ON → no pulse on next trigger
+- **AC-40c Manual**: Drag LibraryCard → preview ghost at 70% opacity follows cursor
+- **AC-39c Manual**: MemoPanel A↔B transition → opacity curve is ease-in-out (not linear)
+- **AC-37b Manual**: Trigger each of 21 audio events from gameplay actions; verify each plays correct SFX from §8.2 catalog
+
+---
+
+## Test Evidence
+
+**Story Type**: Visual/Feel
+**Required**: `production/qa/evidence/workspace-visual-audio-polish-evidence.md` — manual walkthrough with screenshots / video clips for each AC + art-director + audio-director + ux-designer sign-off
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 003 (HypothesisNode), Story 005 (MemoPanel), Story 006 (Camera2D), Story 008 (ReadOnlyIndicator), Story 009 (Settings subscription), Story 010 (AccessKit roles — focus ring assumes correct ROLE_TREE_ITEM etc.)
+- Unlocks: Story 012 (performance gate — visual polish should not regress 60fps target)

--- a/production/epics/reasoning-workspace/story-012-edge-cases-performance.md
+++ b/production/epics/reasoning-workspace/story-012-edge-cases-performance.md
@@ -1,0 +1,165 @@
+# Story 012: Edge cases + performance gates
+
+> **Epic**: Reasoning Workspace
+> **Status**: Complete (tree-structural subset, 2026-05-23) / feature & service-dependent ECs + perf gate skip-stubbed pending owning stories
+> **Layer**: Feature (Gameplay)
+> **Type**: Logic + Visual/Feel (Logic primary)
+> **Manifest Version**: 2026-05-18
+
+## Context
+
+**GDD**: `design/gdd/reasoning-workspace.md` (§5 Edge Cases — 24 ECs across 7 categories, §10.9 Performance, §10.10 Pillar Compliance Verification, §10.12 Untestable AC Open Questions)
+**Requirement**: TR-WORKSPACE-LAYOUT-001 (edge cases + performance gate cross-cover all 5 TRs)
+
+**ADR Governing Implementation**: ADR-0008 §6 Implementation Guidelines + ADR-0008 amend-1 §A6 (forbidden chain_data ephemeral field) + ADR-0010 R6 (class_name collision smoke test) + ADR-0010 KrCustomControl performance budget
+**ADR Decision Summary**: Comprehensive edge case coverage of 24 ECs across 7 GDD §5 categories. Performance gate AC-49: 60fps with 5 root × 3 deep × 5 evidence (max MVP tree shape). Pillar compliance fuzz tests (AC-52 from story 002 cross-link). Untestable AC OQ-QA-1/2 disposition documentation.
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: gdunit4 v5.0+ skip API uses function-signature parameter pattern (`_do_skip := true, _skip_reason := "..."`) per `.claude/docs/technical-preferences.md`. AC-49 stub test uses skip pattern for headless instantiation if blocked.
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Feature Layer Required/Forbidden/Guardrails apply to this story
+
+---
+
+## Acceptance Criteria
+
+Scope: §10.9 Performance (AC-49) + §10.10 Pillar Compliance + §5 24 EC coverage.
+
+> **Tree-structural subset DONE (2026-05-23)**: ECs testable against existing WorkspaceData (no new services) are implemented + passing. Feature/service-dependent ECs are skip-stubbed (gdunit4 `_do_skip` parameter pattern) pending their owning stories (004 drag-drop, 008 crash-recovery, SaveLoadService, SettingsService, UIService.announce_text, UI Foundation, VR-D7 IME). Perf gate AC-49/49b skip-stubbed pending OQ-W10 headless Control ratify. See Completion Notes.
+
+### 24 GDD §5 Edge Cases
+
+- [x] EC-1 — Empty tree → chain_data empty arrays, no errors (cross-link AC-23) — **DONE** (`edge_cases_test.gd`)
+- [x] EC-2 — Single root, single evidence → chain_data with 1 node + 1 evidence + 0 edges — **DONE**
+- [x] EC-3 — Max tree builds + serializes correctly (3 root × 2-branch × depth-3 × 5 ev = 45 nodes / 225 evidence; JSON round-trip) — **DONE** (story's "~117" was approximate; actual MVP-shape count asserted)
+- [x] EC-4 — Attempted depth-4 → rejected (cross-link AC-12) — **DONE**
+- [x] EC-5 — Cycle attempt → rejected (cross-link AC-13) — **DONE**
+- [ ] EC-6 — Duplicate evidence drop on same node → silent dedupe (no double-add)
+- [ ] EC-7 — Drop non-existent library_id (LibraryService validates) → reject + announce
+- [ ] EC-8 — Drop on non-ACTIVE state → rejected (cross-link AC-28 state guard)
+- [ ] EC-9 — Window resize mid-drag → drag continues, drop region updates
+- [ ] EC-10 — State transition during pending citation → pending auto-cancels (story 004 covers ACTIVE→FROZEN)
+- [ ] EC-11 — Load corrupted active_case.tres → .backup recovery (cross-link AC-27f story 008)
+- [x] EC-12 — Memo char input exactly at cap (500) → no truncation — **DONE** (ASCII + Hangul codepoint variants)
+- [x] EC-13 — Memo char input 501 → truncated to 500 (+ `memo_truncated` signal) — **DONE** (announce part deferred — UIService.announce_text not impl)
+- [ ] EC-14 — Korean IME composition mid-character at cap boundary → defer truncation per amend-4 §F3 (VR-D7 dependent)
+- [ ] EC-15 — Memo focus loss mid-IME → composition committed first then focus lost (Godot 4.6 default)
+- [x] EC-16 — Pillar 1 — memo body in chain_data export attempt → rejected (cross-link AC-10, AC-52) — **DONE**
+- [x] EC-17 — Pillar 1 — settings value in chain_data → rejected by allow-list validator (ADR-0009 settings_in_chain_data intent) — **DONE**
+- [ ] EC-18 — Workspace-Browser boundary — WorkspaceData reference held after case unload → boundary violation logged
+- [ ] EC-19 — Drag from LibraryPane while Browser scene swapping → drag cancelled cleanly
+- [ ] EC-20 — Auto-resubmit cascade with mismatched schema_version → CriticalBanner + reset (cross-link AC-27f)
+- [ ] EC-21 — Camera2D pan at clamp boundary → smooth halt (no jitter)
+- [ ] EC-22 — Gamepad two-step with state transition mid-process → pending citation auto-clear on FROZEN
+- [ ] EC-23 — Focus loss to off-window → focus restored to last node on window refocus
+- [ ] EC-24 — Multiple simultaneous SettingsService changes (text_scale + reduced_motion together) → both apply correctly (no race)
+
+### Performance Gate
+
+- [ ] AC-49 — 60fps with worst-case MVP tree (5 root × 3 deep × 5 evidence per node ≈ 117 nodes) on 1366×768 — stub test until Godot 4.6 headless Control class confirmed (per OQ-QA-2 cycle 5 Tier S-1 closure — gdunit4 v5.x skip API parameter pattern `_do_skip := true, _skip_reason := "VR pending"`)
+- [ ] AC-49b — Memory peak < 2GB working set (per technical-preferences.md performance budget) with worst-case tree
+
+### Pillar Compliance Fuzz
+
+- [x] AC-52 cross-link — 5 forbidden field names fuzz (re-validated as suite test) — **DONE**
+- [x] AC-52b — Settings inclusion fuzz: 5 settings keys injected into chain_data node → all rejected by allow-list validator — **DONE**
+
+### Untestable AC Disposition
+
+- [ ] OQ-QA-1 disposition documented: AC-46 (gamepad CitationDrop) remains ADVISORY until UI Foundation epic OQ-W9 prototype ratify
+- [ ] OQ-QA-2 disposition documented: AC-49 stub uses gdunit4 v5.x skip pattern with `_skip_reason = "VR pending OQ-W10 ratify"` until headless Control instantiation confirmed
+
+---
+
+## Implementation Notes
+
+Per ADR-0008 §6 + gdunit4 v5.x skip API:
+
+```gdscript
+# tests/unit/workspace/edge_cases_test.gd
+extends GdUnitTestSuite
+
+# 24 ECs as individual test functions for clarity
+
+func test_ec_3_max_tree_serializes(_do_skip := false, _skip_reason := ""):
+    var ws := WorkspaceData.new()
+    # build 5 × 3 × 5 tree
+    var cd := ws.build_chain_data()
+    assert_int(cd.nodes.size()).is_equal(117)   # 5 roots + 5*5 depth1 + 5*5*5 depth2 — adjust per actual cap
+    assert_int(cd.total_evidence_count).is_equal(117 * 5)   # 5 evidence per node
+
+# AC-49 stub — gdunit4 skip parameter pattern (NOT skip() imperative call)
+func test_ac_49_60fps_worst_case_tree(_do_skip := true, _skip_reason := "VR pending OQ-W10 ratify — headless Control instantiation"):
+    # When unskipped at impl time:
+    var fps := await _measure_fps_for_seconds(3.0, _build_worst_case_tree())
+    assert_float(fps).is_greater_equal(60.0)
+
+func test_ec_17_settings_in_chain_data_rejected(_do_skip := false, _skip_reason := ""):
+    var cd := {"nodes": [{"node_id": "n1", "label": "x", "parent_id": "", "evidence": [], "depth": 0, "child_count": 0, "evidence_count": 0, "display.text_scale": 1.0}]}
+    assert_bool(WorkspaceData.new().validate_chain_data(cd)).is_false()
+```
+
+- 24 ECs grouped by GDD §5 sub-category — keep individual test functions per EC for clear failure isolation (one function = one scenario per `/architecture-review` standards)
+- AC-49 stub uses gdunit4 v5.x function-signature parameter skip pattern (NOT imperative `skip("reason")` — that's the C# variant per technical-preferences.md Allowed Libraries gdunit4 entry)
+- AC-49 unblock condition: OQ-W10 (tree canvas panning Control class decision) ratified at Workspace Layout ADR (covered by ADR-0008 §4 + §6.4) → headless Control instantiation possible → stub becomes real measurement
+- Settings inclusion fuzz uses ADR-0009 forbidden_pattern `settings_in_chain_data` — story 012 validates the validator's coverage of settings keys (chain_data validator from story 002 + ADR-0009 settings forbidden_pattern intersection)
+
+---
+
+## Out of Scope
+
+- Per-feature edge cases already handled within their story (cycle detection AC-13 in story 003, drop cap AC-30 in story 004, etc.) — this story is the *catch-all suite* covering ECs not explicitly tested in feature stories
+- ADR-0011 SaveLoadService crash recovery (story 008 covers Workspace-side; ADR-0011 owns the cascade)
+- ADR-0010 R6 KrCustomControl class_name uniqueness (VR-UI5 — separate UI Foundation epic concern)
+- VR-D7 cross-platform Korean IME runtime (EC-14 dependency — non-blocking; story 012 marks EC-14 as `_do_skip` if VR-D7 not yet PASS)
+
+---
+
+## QA Test Cases
+
+- **24 ECs Logic**: One gdunit4 test function per EC; assertions per EC's expected behavior (rejection / no-op / specific cascade)
+- **AC-49 Logic (stubbed)**: skip parameter pattern with reason until OQ-QA-2 unblocks
+- **AC-49b Logic**: Memory profiler integration — measure working set after building worst-case tree → assert < 2GB
+- **AC-52 cross-link**: Story 002's fuzz test sufficient; story 012 adds AC-52b settings fuzz as separate suite entry
+- **OQ-QA-1/2 Manual**: Document disposition in `production/qa/evidence/workspace-untestable-ac-disposition.md` — cross-ref to OQ-W9 / OQ-W10 ratify cycle
+
+Edge cases at edge cases (meta): EC test failures during CI → fail entire workspace test suite (24 ECs are atomic).
+
+---
+
+## Test Evidence
+
+**Story Type**: Logic + Visual/Feel
+**Required**:
+- `tests/unit/workspace/edge_cases_test.gd` — 24 ECs + AC-52b settings fuzz (gdunit4)
+- `tests/unit/workspace/performance_test.gd` — AC-49 stub + AC-49b memory measurement (gdunit4)
+- `production/qa/evidence/workspace-untestable-ac-disposition.md` — OQ-QA-1/2 disposition log
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Stories 001-011 (this story's ECs cross-link to all prior story behaviors; runs last as integration safety net)
+- Unlocks: Workspace epic Definition of Done — all stories closed + this suite passes
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23 (tree-structural subset)
+**Criteria**: 11/26 implemented + passing (EC-1/2/3/4/5/12/13/16/17 + AC-52 + AC-52b). 15 ECs + AC-49/49b skip-stubbed (gdunit4 `_do_skip` parameter pattern) — each names its blocking owner story. OQ-QA-1/2 manual disposition doc deferred.
+**Scope split rationale**: This story is the epic's catch-all safety net intended to run last (depends on 001-011). Stories 004/005/006/008/009/010/011 + SaveLoadService/EvaluationService/SettingsService/UIService.announce_text are not yet implemented. The tree-structural / chain_data-validation ECs are testable NOW against the completed data layer (001/002/003a/007) with no new services — implemented as a regression safety net for that layer; the rest are skip-stubbed and unblock incrementally as their owning stories land. Mirrors story-007 data-layer split precedent.
+**Files**:
+- `tests/unit/workspace/edge_cases_test.gd` (28 functions: 13 real executed + 15 skip-stubs) — EC suite + AC-52/52b fuzz
+- `tests/unit/workspace/performance_test.gd` (2 skip-stubs: AC-49 fps, AC-49b memory)
+**No production code changed** — verification-only story against existing WorkspaceData. No production bug found during authoring.
+**Test Evidence**: workspace suite 128 cases / 111 executed / 17 skipped / 0 failures, exit 0 (independently re-run).
+**Code Review**: Complete (godot-gdscript-specialist, 2026-05-23). Verdict MINOR ISSUES → all resolved: `_data_with_nodes` param typed `Array[HypothesisNodeData]`; redundant EC-1 assertion removed; EC-3 round-trip + timestamp-key survival assertion; AC-49b skip reason corrected (API is ADR-0007-sanctioned; true blocker = hollow data-only guard + OQ-W10).
+**Deferred (re-open when owning story lands)**: EC-6/8/9/10/22 (story 004 drag-drop), EC-7 (LibraryService + announce), EC-11/20 (SaveLoadService + story 008), EC-14/15 (VR-D7 IME), EC-18/19 (Case Browser), EC-21/23 (UI camera/focus), EC-24 (SettingsService), AC-49/49b (OQ-W10 headless Control), OQ-QA-1/2 (manual disposition doc).
+
+---
+
+## Notes
+
+This story acts as the Workspace epic's safety net. Failures here indicate a regression in one of stories 001-011 — fix the originating story before adjusting EC test. The EC suite is *atomic* (single CI run, all-or-nothing) to catch silent regressions across feature stories.

--- a/production/epics/save-load/EPIC.md
+++ b/production/epics/save-load/EPIC.md
@@ -61,10 +61,10 @@ This epic is complete when:
 | 002 | [Save-data Resource classes + schema versioning + migration](story-002-save-data-resources-schema-versioning.md) | Logic | Complete | ADR-0011 | AC-10/11 |
 | 003 | [Signal-triggered autosave + 250ms debounce](story-003-signal-triggered-autosave-debounce.md) | Integration | Complete | ADR-0011 | AC-2 |
 | 004 | [Boot load + corruption→backup recovery + casebook/session-meta](story-004-boot-load-corruption-recovery.md) | Integration | Complete | ADR-0011 | AC-7/15/16 |
-| 005 | [Resolution cascade — evaluation→casebook + revert guard](story-005-resolution-cascade-revert-guard.md) | Integration | Ready (AC-3 trigger deferred — EvaluationService/TD-001) | ADR-0011 | AC-3/4 |
-| 006 | [Crash-recovery auto-resubmit cascade (active_case_recovered)](story-006-crash-recovery-auto-resubmit.md) | Integration | Ready (end-to-end deferred — controllers + EvaluationService) | ADR-0011 | AC-5/6 |
+| 005 | [Resolution cascade — evaluation→casebook + revert guard](story-005-resolution-cascade-revert-guard.md) | Integration | Complete (core; evaluation_completed subscription deferred — TD-001) | ADR-0011 | AC-3/4 |
+| 006 | [Crash-recovery auto-resubmit cascade (active_case_recovered)](story-006-crash-recovery-auto-resubmit.md) | Integration | Complete (decision contract; end-to-end resubmit deferred — controllers + EvaluationService) | ADR-0011 | AC-5/6 |
 | 007 | [Anti-Pillar serialization guards](story-007-anti-pillar-serialization-guards.md) | Logic | Complete | ADR-0011 | AC-12/13 |
-| 008 | [Close-request forced flush + full-session persistence](story-008-close-request-flush-session-persistence.md) | Integration | Ready | ADR-0011 | AC-14 |
+| 008 | [Close-request forced flush + full-session persistence](story-008-close-request-flush-session-persistence.md) | Integration | Complete | ADR-0011 | AC-14 |
 
 **Implementation order**: 001 (atomic write foundation) → 002 (Resource classes) → 003 (autosave) → 004 (boot load) → 007 (guards) → 005/006 (cross-service cascades — partially deferred on EvaluationService/controllers, TD-001) → 008 (close flush + full round-trip). Stories 005/006 lock + unit-test their decision/guard logic now; end-to-end resubmit re-opens when EvaluationService + Workspace/Brief controllers land.
 

--- a/production/epics/save-load/EPIC.md
+++ b/production/epics/save-load/EPIC.md
@@ -1,0 +1,73 @@
+# Epic: Save/Load
+
+> **Layer**: Core / Foundation
+> **GDD**: design/gdd/save-load.md
+> **Architecture Module**: `SaveLoadService` autoload (SIXTH position) + `user://saves/` directory + 6-Resource serialization tree
+> **Status**: In Progress
+> **Stories**: 8 created 2026-05-23
+> **Created**: 2026-05-23
+
+## Overview
+
+Save/Load owns persistence of a 60–120 minute case session plus the casebook and career progression. A single `SaveLoadService` autoload (SIXTH position) is the SSOT that serializes four categories — (1) in-progress case work (`WorkspaceData` chain_data + state, `BriefEditorData` grounds/memo/citations + state), (2) casebook (Resolved case results: verdict + final_score + archive), (3) career progression (`CareerData` — MVP placeholder: completed case IDs + reputation), (4) session meta (last_active_case_id + UI hints) — to `user://saves/` via **atomic write** (`.tres` for Resource categories, `.cfg` for session meta). Autosave is **signal-triggered with 250ms debounce** (never per-frame polling), aligned with Reasoning Workspace §3.1 Rule 8. Crash recovery routes both the **Workspace FROZEN auto-resubmit** and **Brief SUBMITTING auto-resubmit** cascades through a single `active_case_recovered` signal entry point. Settings are explicitly NOT serialized here (separate `user://user_settings.cfg`, owned by Settings #4 / ADR-0009).
+
+## Governing ADRs
+
+| ADR | Decision Summary | Engine Risk |
+|-----|-----------------|-------------|
+| **ADR-0011: Save/Load Storage Format** (Accepted 2026-05-17) | `SaveLoadService` autoload SIXTH; atomic write via `ResourceSaver.save(.tmp)` → `DirAccess.rename_absolute`; `.tres` (3 Resource categories) + `.cfg` (session meta); signal-trigger autosave + 250ms debounce; crash-recovery cascade via single `active_case_recovered` entry point; `NOTIFICATION_WM_CLOSE_REQUEST` forced flush; schema versioning + migration framework; 6 signal subscribe / 7 signal emit | MEDIUM (cross-platform atomic rename POSIX vs Windows `ReplaceFile`; 4.5 `Resource.duplicate()` deprecation context — VR-SL1/SL2/SL3 advisory) |
+| ADR-0001 amend-2 (dependency) | `BriefEditorData` lifecycle + `active_case_recovered` interface contract (SaveLoadService = transient boot owner → signal emit → controller runtime owner) | LOW |
+| ADR-0007 amend-1 (dependency) | `PlayerSubmission` / chain_data Variant-primitives-only (serialization safety) | LOW |
+| ADR-0008 amend-1 (dependency) | `WorkspaceData` serialization (chain_data_snapshot primitives-only — story-007 freeze persistence) | LOW |
+
+## GDD Requirements
+
+22 `TR-save-001` … `TR-save-022` in `docs/architecture/tr-registry.yaml` — **all 22 covered by ADR-0011 (0 untraced)** (systems-index #3: "22 TR-save 전체 covered"). Thematic grouping (individual TR-IDs are pulled per story by `/create-stories`):
+
+| Theme | Coverage |
+|-------|----------|
+| `user://saves/` directory structure + `make_dir_recursive_absolute` bootstrap (EC-1) | ADR-0011 ✅ |
+| Atomic write wrapper (`.tmp` → `rename_absolute`; corruption → `.backup` + `save_corrupted` emit) | ADR-0011 ✅ |
+| 6-Resource typed serialization (`ActiveCaseSaveData` / `WorkspaceData` / `BriefEditorData` / `Casebook`+`CasebookEntry` / `CareerData` + session-meta `.cfg`) | ADR-0011 ✅ |
+| Signal-trigger autosave + 250ms debounce (no polling) | ADR-0011 ✅ |
+| Crash-recovery cascade — Workspace FROZEN + Brief SUBMITTING auto-resubmit via single `active_case_recovered` | ADR-0011 ✅ |
+| Casebook eager load (nested `BriefArchiveData` deserialization) + casebook_entry_added | ADR-0011 ✅ |
+| Schema versioning + migration framework | ADR-0011 ✅ |
+| `NOTIFICATION_WM_CLOSE_REQUEST` forced synchronous flush | ADR-0011 ✅ |
+| 6 signal subscribe / 7 signal emit topology | ADR-0011 ✅ |
+| Forbidden patterns (e.g. `save_load_revert_resolved`, atomic-write bypass) | ADR-0011 ✅ |
+
+## Engine / Cross-System Notes
+
+- **Engine risk MEDIUM**: VR-SL2 (cross-platform atomic rename) + VR-SL3 (close-request flush time) are advisory — POSIX atomic guaranteed; Windows NTFS depends on OS (ADR-0011 advisory note pending). Stories touching atomic write must follow ADR-0011's `.tmp`→rename wrapper, not raw `ResourceSaver.save`.
+- **Autoload ordering**: SaveLoadService is SIXTH. Several upstream signal sources are not yet implemented (EvaluationService THIRD, SettingsService FIFTH; Brief Editor controller). Stories must guard signal subscriptions for absent sources (subscribe-if-present) and wire incrementally as those systems land — mirrors the graceful-degradation pattern already used in UIService/KrControlHelper.
+- **Unblocks**: reasoning-workspace story-008 (READ_ONLY + crash recovery cascade) once `active_case_recovered` + atomic persistence exist; Brief Editor epic persistence; #11 Career, #14 Retrospective Replay, #17 Meta-Frame.
+- **TD-001 awareness**: the `EvaluationService.submit()` signature conflict (ADR-0007 PlayerSubmission vs control-manifest chain_data:Dictionary) intersects the FROZEN auto-resubmit cascade — reconcile before wiring the evaluation hand-off (see docs/tech-debt-register.md).
+
+## Definition of Done
+
+This epic is complete when:
+- All stories are implemented, reviewed, and closed via `/story-done`
+- All acceptance criteria from `design/gdd/save-load.md` are verified
+- All Logic and Integration stories have passing test files in `tests/`
+- Atomic-write + crash-recovery cascade have integration tests (round-trip + corruption + recovery)
+- Forbidden patterns are registered in `docs/registry/architecture.yaml` and gated by tests
+
+## Stories
+
+| # | Story | Type | Status | ADR | ACs |
+|---|-------|------|--------|-----|-----|
+| 001 | [SaveLoadService autoload + saves/ bootstrap + atomic write wrapper](story-001-service-autoload-atomic-write.md) | Integration | Complete | ADR-0011 | AC-1/8/9 |
+| 002 | [Save-data Resource classes + schema versioning + migration](story-002-save-data-resources-schema-versioning.md) | Logic | Complete | ADR-0011 | AC-10/11 |
+| 003 | [Signal-triggered autosave + 250ms debounce](story-003-signal-triggered-autosave-debounce.md) | Integration | Complete | ADR-0011 | AC-2 |
+| 004 | [Boot load + corruption→backup recovery + casebook/session-meta](story-004-boot-load-corruption-recovery.md) | Integration | Complete | ADR-0011 | AC-7/15/16 |
+| 005 | [Resolution cascade — evaluation→casebook + revert guard](story-005-resolution-cascade-revert-guard.md) | Integration | Ready (AC-3 trigger deferred — EvaluationService/TD-001) | ADR-0011 | AC-3/4 |
+| 006 | [Crash-recovery auto-resubmit cascade (active_case_recovered)](story-006-crash-recovery-auto-resubmit.md) | Integration | Ready (end-to-end deferred — controllers + EvaluationService) | ADR-0011 | AC-5/6 |
+| 007 | [Anti-Pillar serialization guards](story-007-anti-pillar-serialization-guards.md) | Logic | Complete | ADR-0011 | AC-12/13 |
+| 008 | [Close-request forced flush + full-session persistence](story-008-close-request-flush-session-persistence.md) | Integration | Ready | ADR-0011 | AC-14 |
+
+**Implementation order**: 001 (atomic write foundation) → 002 (Resource classes) → 003 (autosave) → 004 (boot load) → 007 (guards) → 005/006 (cross-service cascades — partially deferred on EvaluationService/controllers, TD-001) → 008 (close flush + full round-trip). Stories 005/006 lock + unit-test their decision/guard logic now; end-to-end resubmit re-opens when EvaluationService + Workspace/Brief controllers land.
+
+## Next Step
+
+Run `/story-readiness production/epics/save-load/story-001-service-autoload-atomic-write.md` then `/dev-story` to begin implementation.

--- a/production/epics/save-load/story-001-service-autoload-atomic-write.md
+++ b/production/epics/save-load/story-001-service-autoload-atomic-write.md
@@ -1,0 +1,110 @@
+# Story 001: SaveLoadService autoload + saves/ bootstrap + atomic write wrapper
+
+> **Epic**: Save/Load
+> **Status**: Complete (2026-05-23)
+> **Layer**: Core / Foundation
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 3-4h (M)
+> **Performance**: atomic write < 100ms typical (40KB case); no per-frame cost (signal-triggered)
+
+## Context
+
+**GDD**: `design/gdd/save-load.md` (§3.1 Core Rules, §10.1 AC-1, §10.3 AC-8/9, §4.4 atomic write time, EC-1/4/9/11)
+**Requirement**: `TR-save-001` … (directory bootstrap + atomic write — read fresh from `tr-registry.yaml`)
+
+**ADR Governing Implementation**: ADR-0011 (Save/Load Storage Format)
+**ADR Decision Summary**: `SaveLoadService` autoload SIXTH; `user://saves/` directory; atomic write = `ResourceSaver.save(<tmp>)` → `DirAccess.rename_absolute(<tmp>, <target>)`. tmp-write failure → `push_error` + return false + target untouched.
+
+**Engine**: Godot 4.6 | **Risk**: MEDIUM
+**Engine Notes**: `ResourceSaver.save()` is NOT guaranteed single-atomic (VR-SL2) → MUST use `.tmp`→rename wrapper. `DirAccess.rename_absolute` atomic on POSIX (Windows NTFS OS-dependent — advisory). `DirAccess.make_dir_recursive_absolute` for bootstrap. `FileAccess`/`DirAccess` return Error codes in 4.x — check them.
+
+**Control Manifest Rules (Core/Foundation)**:
+- Required: atomic write via tmp→rename wrapper (never raw `ResourceSaver.save` to the live target)
+- Forbidden: `save_load_atomic_write_bypass` (writing directly to target without tmp)
+- Guardrail: atomic write < 100ms typical; bootstrap in `_ready()` < 50ms
+
+---
+
+## Acceptance Criteria
+
+- [x] AC-1 (Logic) — SaveLoadService autoload `_ready()` with `saves/` absent → directory auto-created, no `push_warning` (EC-1) — **DONE** (`test_ready_creates_saves_dir_when_absent` + idempotency test)
+- [x] AC-8 (Logic) — `_save_resource_atomic(res, target)` success → target fully updated, tmp absent, round-trips — **DONE** (`test_save_resource_atomic_writes_target_and_removes_tmp`)
+- [x] AC-9 (Logic) — `_save_resource_atomic` tmp-write failure → `push_error` + return false + target unchanged — **DONE** (`test_save_resource_atomic_failure_preserves_existing_target`)
+
+---
+
+## Implementation Notes
+
+Per ADR-0011 §Decision + §Implementation:
+
+```gdscript
+# src/services/save_load_service.gd  (autoload SIXTH — class_name SaveLoadServiceClass)
+const SAVES_DIR := "user://saves/"
+
+func _ready() -> void:
+    if not DirAccess.dir_exists_absolute(SAVES_DIR):
+        DirAccess.make_dir_recursive_absolute(SAVES_DIR)   # EC-1 — silent
+
+func _save_resource_atomic(res: Resource, target_path: String) -> bool:
+    var tmp_path := target_path + ".tmp"
+    var err := ResourceSaver.save(res, tmp_path)
+    if err != OK:
+        push_error("SaveLoadService: tmp write failed (%d) — target preserved" % err)
+        return false                                        # AC-9 — target untouched
+    var dir := DirAccess.open(SAVES_DIR)
+    var rename_err := dir.rename_absolute(...) # tmp → target (atomic on POSIX)
+    if rename_err != OK:
+        push_error(...); return false
+    return true                                             # AC-8
+```
+
+- Autoload registration: add `SaveLoadService="*res://src/services/save_load_service.gd"` SIXTH in `project.godot [autoload]` (after the locked order; intermediate autoloads may not exist yet — fine, ordering is positional intent).
+- `class_name SaveLoadServiceClass` (NOT `SaveLoadService`) — avoid the autoload-name-collision error (same pattern as `UIServiceClass`).
+- Use absolute path forms for rename; verify `rename_absolute` arg form against engine reference before use.
+
+---
+
+## Out of Scope
+
+- Story 002: the Resource class definitions being saved (this story's tests use a minimal/dummy Resource or an existing one like WorkspaceData)
+- Story 003: signal-triggered autosave + debounce (this story exposes `_save_resource_atomic` only)
+- Story 004: load path + corruption recovery
+- session_meta `.cfg` write (story 004/008)
+
+---
+
+## QA Test Cases
+
+- **AC-1**: Given SaveLoadService autoload, When `_ready()` runs with `user://saves/` absent, Then the dir exists afterward and no warning was pushed. Edge: dir already exists → no error (idempotent).
+- **AC-8**: Given a Resource + target path, When `_save_resource_atomic` succeeds, Then `FileAccess.file_exists(target)` true and `<target>.tmp` absent; loading the target round-trips the Resource. 
+- **AC-9**: Given a tmp-write failure (inject an unwritable path or mock), When `_save_resource_atomic` runs, Then it returns false and a pre-existing target file is byte-unchanged. Edge: target did not previously exist → still no target created.
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**: `tests/integration/save_load/atomic_write_test.gd` (gdunit4) — AC-1, AC-8, AC-9. Tests write to `user://` temp paths and clean up.
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: None (Save/Load foundation entry point)
+- Unlocks: Stories 002/003/004 (all SaveLoadService stories build on the atomic write + autoload)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23
+**Criteria**: 3/3 passing (AC-1, AC-8, AC-9) + idempotency.
+**Files**:
+- `src/services/save_load_service.gd` — `class_name SaveLoadServiceClass extends Node`; `SAVES_DIR`/`CURRENT_SAVE_FILE_VERSION` consts; `_ready()`→`_ensure_saves_dir()`; `_save_resource_atomic(res, target) -> bool`.
+- `project.godot` — `SaveLoadService` autoload registered (after CaseService; SIXTH positional intent).
+- `tests/integration/save_load/atomic_write_test.gd` — 4 tests.
+**Test Evidence**: atomic_write_test 4/4 PASS; full unit+integration suite **361 cases / 344 executed / 17 skipped / 0 failures, exit 0** (new autoload boots in all runs without regression).
+**⚠️ ENGINE GOTCHA found + worked around (TD-004)**: `ResourceSaver.save()` picks format by file EXTENSION; a bare `.tmp` suffix → `ERR_FILE_UNRECOGNIZED` (error 15) and the save fails. The reference snippet (`current-best-practices.md` §Atomic Write, `settings.tres.tmp`) is therefore broken. Fixed by inserting `.tmp` BEFORE the extension: `name.tres` → `name.tmp.tres` (recognized). Logged TD-004 to correct the doc.
+**Code Review**: Implemented + reviewed directly by orchestrator (foundational Integration story; verified DirAccess/ResourceSaver/rename_absolute against engine-reference; sub-agent delegation skipped this session due to repeated agent message-truncation). Atomic-write pattern matches current-best-practices.md (with the `.tmp` extension correction).

--- a/production/epics/save-load/story-002-save-data-resources-schema-versioning.md
+++ b/production/epics/save-load/story-002-save-data-resources-schema-versioning.md
@@ -1,0 +1,115 @@
+# Story 002: Save-data Resource classes + schema versioning + migration fallback
+
+> **Epic**: Save/Load
+> **Status**: Complete (2026-05-23)
+> **Layer**: Core / Foundation
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 3-4h (M)
+> **Performance**: No runtime cost — Resource definitions + load-time version check
+
+## Context
+
+**GDD**: `design/gdd/save-load.md` (§3.1 Core Rules — 6-Resource tree, §10.4 AC-10/11 schema migration, EC-8/12)
+**Requirement**: `TR-save-*` (Resource serialization + schema versioning — read fresh from `tr-registry.yaml`)
+
+**ADR Governing Implementation**: ADR-0011
+**ADR Decision Summary**: 6-Resource typed tree — `ActiveCaseSaveData` (wraps WorkspaceData + BriefEditorData), `Casebook` + `CasebookEntry`, `CareerData` (MVP placeholder) + session-meta `.cfg`. Each save Resource carries `save_file_version: int`. Missing-field load → Godot `@export` default fallback. Future version (> current) → corruption cascade.
+
+**Engine**: Godot 4.6 | **Risk**: MEDIUM
+**Engine Notes**: Godot `@export` fields default-fill on load when absent (AC-10 relies on this — verified pattern, ADR-0001 amend-2 nested-resource deser PASSED 2026-05-13). 4.5 `Resource.duplicate()` deprecation context — do NOT rely on deep `Resource.duplicate()`; chain_data is Dictionary (`.duplicate(true)` safe). `class_name` for each Resource.
+
+**Control Manifest Rules (Core/Foundation)**:
+- Required: every save Resource declares `@export var save_file_version: int = 1`; typed `@export` fields only
+- Forbidden: storing Object/Resource refs where primitives suffice in chain_data (ADR-0007 amend-1)
+- Guardrail: load-time version check before deserialization use
+
+---
+
+## Acceptance Criteria
+
+- [x] AC-10 (Logic) — save Resource missing a field → field takes its `@export` default (EC-8) — **DONE** (`test_loading_resource_with_missing_field_uses_export_default` — strips a field line from a real `.tres`, reloads, asserts default)
+- [x] AC-11 (Logic) — `save_file_version` > current → treated as unsupported/corruption (EC-12) — **DONE** (`test_future_save_version_is_unsupported` + `test_loaded_future_version_resource_reports_its_version` via `_is_save_version_supported`)
+
+---
+
+## Implementation Notes
+
+Per ADR-0011 §Decision (Resource tree):
+
+```gdscript
+# src/data/active_case_save_data.gd
+class_name ActiveCaseSaveData extends Resource
+@export var save_file_version: int = 1
+@export var case_id: String = ""
+@export var workspace_data: WorkspaceData            # story-001/002/007 — exists
+@export var brief_editor_data: Resource              # BriefEditorData (Brief epic) — typed loosely until that class lands
+# src/data/casebook.gd
+class_name Casebook extends Resource
+@export var save_file_version: int = 1
+@export var entries: Array[CasebookEntry] = []
+# src/data/casebook_entry.gd
+class_name CasebookEntry extends Resource
+@export var save_file_version: int = 1
+@export var case_id: String
+@export var verdict: String
+@export var final_score: float
+# src/data/career_data.gd  (MVP placeholder)
+class_name CareerData extends Resource
+@export var save_file_version: int = 1
+@export var completed_case_ids: Array[String] = []
+@export var reputation: float = 0.0
+```
+
+- `const CURRENT_SAVE_VERSION := 1` on SaveLoadService. Version check helper: `if loaded.save_file_version > CURRENT_SAVE_VERSION: push_error + corruption cascade`.
+- AC-10 missing-field default is automatic via Godot `@export` defaults — the test writes a Resource with fewer fields (or an older serialized form) and confirms load fills the default.
+- `BriefEditorData` exact class is owned by the Brief Editor epic (ADR-0001 amend-2) — type the field as `Resource` (or forward-declare) until that class exists; do NOT block this story on it.
+
+---
+
+## Out of Scope
+
+- Story 001: atomic write wrapper (this story defines the Resources it serializes)
+- Story 003/004: when/how these are saved/loaded (this story = class definitions + version semantics only)
+- Full BriefEditorData class definition (Brief Editor epic)
+- CareerData full behaviour (#11 Career epic — MVP placeholder only here)
+
+---
+
+## QA Test Cases
+
+- **AC-10**: Given a serialized ActiveCaseSaveData missing a field that exists in the current class, When `ResourceLoader.load`, Then load succeeds and the missing field equals its `@export` default. Edge: empty/minimal Resource → all defaults.
+- **AC-11**: Given a save Resource with `save_file_version` = CURRENT+1, When the version check runs, Then `push_error` fires and the loader treats it as corruption (returns null / triggers recovery), NOT a silent load. Edge: version == CURRENT → loads normally; version < CURRENT → migration path (forward-compat default fill).
+
+---
+
+## Test Evidence
+
+**Story Type**: Logic
+**Required**: `tests/unit/save_load/save_data_schema_test.gd` (gdunit4) — AC-10, AC-11.
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (uses `_save_resource_atomic`/load for round-trip tests) — soft; class defs can precede
+- Unlocks: Stories 003/004/005/006 (all serialize these Resources)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23
+**Criteria**: 2/2 passing (AC-10, AC-11).
+**Files**:
+- `src/data/casebook_entry.gd`, `src/data/casebook.gd`, `src/data/career_data.gd`, `src/data/active_case_save_data.gd` — 4 save Resource classes, each with `@export var save_file_version: int = 1`.
+- `src/services/save_load_service.gd` — added `_is_save_version_supported(version) -> bool` (>=1 and <= CURRENT) version gate.
+- `tests/unit/save_load/save_data_schema_test.gd` — 4 tests.
+**Test Evidence**: save_data_schema 4/4 PASS; full unit+integration **365 cases / 348 executed / 17 skipped / 0 failures, exit 0**.
+**Notes**:
+- AC-10 tested robustly by serializing a real CasebookEntry, stripping the `final_score` line from the `.tres` text, reloading → field returns to its `@export` default (genuine forward-compat / missing-field behavior, not a hand-crafted fixture).
+- AC-11: future version detected via `_is_save_version_supported`; the full corruption→`.backup` recovery cascade is story-004 (this story owns the version semantics + predicate).
+- `BriefEditorData` class doesn't exist yet (Brief epic) → `ActiveCaseSaveData.brief_editor_data` typed as `Resource` until it lands.
+- Test type annotations use base `Resource` (not the `class_name` globals) — `class_name` globals don't resolve in headless gdunit4 runs; instances created via preloaded Script consts (same pattern as ui_service_test).
+**Code Review**: Implemented + reviewed directly by orchestrator. Resource serialization + `@export` default behavior verified against ADR-0001 amend-2 nested-resource deser (PASSED 2026-05-13).

--- a/production/epics/save-load/story-003-signal-triggered-autosave-debounce.md
+++ b/production/epics/save-load/story-003-signal-triggered-autosave-debounce.md
@@ -1,0 +1,110 @@
+# Story 003: Signal-triggered autosave + 250ms debounce
+
+> **Epic**: Save/Load
+> **Status**: Complete (2026-05-23)
+> **Layer**: Core / Foundation
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 3h (M)
+> **Performance**: No polling — signal-triggered only; 250ms debounce coalesces bursts; save off the debounce timeout (not per-frame)
+
+## Context
+
+**GDD**: `design/gdd/save-load.md` (§3.1 Core Rules — autosave policy, §3.3 signal contract, §4.3 debounce timer, §10.1 AC-2, EC-9/10)
+**Requirement**: `TR-save-*` (signal-triggered autosave + debounce — read fresh from `tr-registry.yaml`)
+
+**ADR Governing Implementation**: ADR-0011
+**ADR Decision Summary**: Autosave is signal-triggered (never per-frame polling) + 250ms debounce. SaveLoadService subscribes to 6 signals (`workspace_state_changed`, `brief_editor_state_changed`, `brief_editor_submitted`, `evaluation_completed`, `submission_rejected`, `case_state_changed`). Most route through a debounced `active_case` save; resolution signals are immediate (0ms). Subscribe-if-present for sources not yet implemented.
+
+**Engine**: Godot 4.6 | **Risk**: MEDIUM
+**Engine Notes**: `Timer` one-shot, `wait_time = 0.25`, `start()` resets a running timer (debounce coalescing — same pattern as UIService viewport debounce). `WorkspaceData.workspace_state_changed(old:int,new:int)` exists (story-007). Other emitters (Brief controller, EvaluationService, CaseService `case_state_changed`) may be absent → guard `connect` with presence checks.
+
+**Control Manifest Rules (Core/Foundation)**:
+- Required: signal-triggered autosave via typed `.connect()`; 250ms debounce; subscribe-if-present guard for absent emitters
+- Forbidden: `save_load_per_frame_polling` (saving in `_process`/`_physics_process` or on a repeating poll Timer)
+- Guardrail: debounce window 250ms (externalized constant); save executes once per coalesced burst
+
+---
+
+## Acceptance Criteria
+
+- [x] AC-2 (Logic) — `workspace_state_changed` → 250ms debounce → `_perform_save` atomic-writes `active_case.tres` — **DONE** (`test_workspace_change_starts_debounce_timer` + `test_perform_save_writes_active_case_atomically`)
+- [x] Debounce coalescing — repeated changes reuse one timer + reset (EC-9) — **DONE** (`test_repeated_changes_reuse_one_timer_and_reset`)
+- [x] No-polling — forbidden pattern `save_load_polling_based_autosave` registered; service is signal-only — **DONE** (`test_no_per_frame_polling_autosave`)
+
+---
+
+## Implementation Notes
+
+Per ADR-0011 §Decision (autosave cascade):
+
+```gdscript
+const AUTOSAVE_DEBOUNCE_MS := 250
+var _autosave_timer: Timer
+
+func _ready() -> void:
+    # ... (story 001 bootstrap) ...
+    _autosave_timer = Timer.new()
+    _autosave_timer.one_shot = true
+    _autosave_timer.wait_time = AUTOSAVE_DEBOUNCE_MS / 1000.0
+    _autosave_timer.timeout.connect(func() -> void: _perform_save("active_case"))
+    add_child(_autosave_timer)
+    # subscribe-if-present (await one frame so emitters' _ready ran — ADR-0001 amend-2 §C3)
+    await get_tree().process_frame
+    _connect_if_present("workspace_state_changed", _on_workspace_changed)  # via the live WorkspaceData/controller
+
+func _on_workspace_changed(_old: int, _new: int) -> void:
+    _autosave_timer.start()   # debounce — resets if running (EC-9 coalescing)
+```
+
+- The actual emitter binding (which node owns `workspace_state_changed`) depends on the runtime workspace controller. For this story's tests, drive `_on_workspace_changed` / the debounce path directly and assert `_perform_save` fires once. Real emitter wiring follows when the workspace scene controller exists; keep the connect guarded.
+- `_perform_save(category)` calls `_save_resource_atomic` (story 001) for the active_case Resource (story 002).
+- Externalize `AUTOSAVE_DEBOUNCE_MS` as a const (Tuning Knob §7.1).
+
+---
+
+## Out of Scope
+
+- Story 004: load path
+- Story 005/006: resolution/recovery cascades (immediate, 0ms — different path; this story is the debounced active_case path)
+- Real workspace-scene controller signal binding (wire when that controller lands; guard here)
+
+---
+
+## QA Test Cases
+
+- **AC-2**: Given a SaveLoadService with an active_case Resource, When the workspace-changed handler fires and 250ms passes, Then `_perform_save("active_case")` ran and `active_case.tres` exists/updated. (Use the same await-real-timer or direct-callback approach as ui_service_test debounce; if headless Timer tick is unreliable, assert the callback chain structurally + that direct `_perform_save` writes.)
+- **Coalescing**: Given 3 handler fires within 30ms, When 300ms passes, Then `_perform_save` ran exactly once (timer.start resets time_left — assert structurally like ui_service_test).
+- **No-polling**: assert `architecture.yaml` registers `save_load_per_frame_polling` forbidden pattern (automated registry-read), and the service has no `_process`/`_physics_process` save.
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**: `tests/integration/save_load/autosave_debounce_test.gd` (gdunit4) — AC-2 + coalescing + no-polling.
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (atomic write), Story 002 (active_case Resource)
+- Unlocks: Story 008 (close-request flush drains the debounce queue)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23
+**Criteria**: 3/3 passing (AC-2, coalescing, no-polling).
+**Files**:
+- `src/services/save_load_service.gd` — `DEBOUNCE_MS` per-category dict (ADR-0011) + `ACTIVE_CASE_FILE` const + `_active_case` field + `_on_workspace_changed` + `_schedule_save(category)` (0ms → immediate, else debounce timer) + `_debounce_timer_for` (lazy per-category Timer) + `_perform_save(category)` (active_case atomic write).
+- `tests/integration/save_load/autosave_debounce_test.gd` — 5 tests.
+**Test Evidence**: autosave_debounce 5/5 PASS; full unit+integration **370 cases / 353 executed / 17 skipped / 0 failures, exit 0**.
+**Notes**:
+- Forbidden pattern is `save_load_polling_based_autosave` (architecture.yaml line 1769) — the story draft's `save_load_per_frame_polling` was a misname; the test uses the registered name.
+- Debounce timing verified structurally (timer running + time_left reset on repeated starts) + a direct `_perform_save` write — gdunit4 headless does not reliably advance real Timer ticks (same as ui_service_test).
+- Real workspace-controller signal binding deferred to when that controller exists; `_on_workspace_changed` is the guarded entry the workspace side will connect to.
+- The `_active_case` field is set by boot load (story 004) / runtime controllers; tests set it directly.
+**Code Review**: Implemented + reviewed directly by orchestrator. Discovered + worked around the global-class-cache headless issue (see TD-005).

--- a/production/epics/save-load/story-004-boot-load-corruption-recovery.md
+++ b/production/epics/save-load/story-004-boot-load-corruption-recovery.md
@@ -1,0 +1,113 @@
+# Story 004: Boot load + corruption→backup recovery + casebook/session-meta load
+
+> **Epic**: Save/Load
+> **Status**: Complete (2026-05-23)
+> **Layer**: Core / Foundation
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 3-4h (M)
+> **Performance**: boot load < 100ms typical; casebook eager load (≤100 entries) within budget
+
+## Context
+
+**GDD**: `design/gdd/save-load.md` (§3.1 Core Rules — load path + Rule 6 corruption recovery, §10.2 AC-7, §10.6 AC-15/16, EC-2/3)
+**Requirement**: `TR-save-*` (boot load + corruption recovery + casebook/session-meta — read fresh from `tr-registry.yaml`)
+
+**ADR Governing Implementation**: ADR-0011
+**ADR Decision Summary**: `_ready()` boot loads `active_case.tres`, `casebook.tres`, `session_meta.cfg`. Load failure/corruption → rename to `.backup` + `push_error` + emit `save_corrupted` (consumer shows CriticalBanner). Casebook eager-loaded (nested `BriefArchiveData` deserialization). `active_case_recovered` emitted as the single recovery entry point (its subscribers are story 005/006).
+
+**Engine**: Godot 4.6 | **Risk**: MEDIUM
+**Engine Notes**: `ResourceLoader.load(path, "", CACHE_MODE_IGNORE)` for fresh deserialization. Corrupt `.tres` → load returns null / error → must be caught (don't assume non-null). `ConfigFile.load()` for session_meta (returns Error). `DirAccess.rename_absolute` for `.backup`. CriticalBanner display needs `UIService.announce_text` (UI Foundation story-005 — NOT yet implemented) → emit the signal; banner display is deferred.
+
+**Control Manifest Rules (Core/Foundation)**:
+- Required: catch load errors (null/Error) before use; corruption → `.backup` + `save_corrupted` emit; never overwrite a corrupt file in place
+- Forbidden: assuming `ResourceLoader.load` succeeds without a null/error check
+- Guardrail: boot load < 100ms typical
+
+---
+
+## Acceptance Criteria
+
+- [x] AC-7 (Logic) — corrupt `active_case.tres` → `.backup` + `save_corrupted("active_case")` emit + load returns null (EC-3) — **DONE** (`test_corrupt_active_case_renamed_to_backup_and_signals`; CriticalBanner display deferred to UI announce_text)
+- [x] AC-15 (Integration) — 5-entry casebook → `_load_casebook()` returns 5 entries — **DONE** (`test_casebook_loads_five_entries`)
+- [x] AC-16 (Integration) — `session_meta.cfg` read back → `last_active_case_id` + `workspace_f2_hint_seen` exposed — **DONE** (`test_session_meta_values_read_back`)
+
+---
+
+## Implementation Notes
+
+Per ADR-0011 §Decision (boot load path):
+
+```gdscript
+func _ready() -> void:
+    # ... story 001 bootstrap + story 003 timer/subscriptions ...
+    _load_casebook()                       # eager
+    _load_session_meta()                   # ConfigFile
+    var active := _load_active_case_or_recover()
+    await get_tree().process_frame         # ADR-0001 amend-2 §C3 — let subscribers' _ready run
+    if active != null:
+        active_case_recovered.emit(active.workspace_data, active.brief_editor_data)
+
+func _load_active_case_or_recover() -> ActiveCaseSaveData:
+    if not FileAccess.file_exists(ACTIVE_CASE_FILE): return null   # EC-2 — fresh start
+    var res := ResourceLoader.load(ACTIVE_CASE_FILE, "", ResourceLoader.CACHE_MODE_IGNORE)
+    if res == null or not (res is ActiveCaseSaveData) or res.save_file_version > CURRENT_SAVE_VERSION:
+        _rename_to_backup(ACTIVE_CASE_FILE)        # → .backup
+        save_corrupted.emit("active_case")          # consumer shows CriticalBanner (deferred UI)
+        return null
+    return res
+```
+
+- AC-7 banner: emit `save_corrupted` only; the CriticalBanner display goes through `UIService.announce_text` which is NOT yet implemented (UI Foundation story-005) → display is DEFERRED. Test the signal emit + `.backup` creation.
+- AC-15 casebook eager load: `_load_casebook()` loads `casebook.tres` (or empty Casebook if absent — EC-2). Nested entry deserialization verified.
+- AC-16 session_meta: `ConfigFile.load(session_meta.cfg)`; expose `last_active_case_id` / `workspace_f2_hint_seen` via getters. Consumers (Browser, Workspace toast) deferred.
+- `active_case_recovered` is emitted here but its SUBSCRIBERS (auto-resubmit) are story 005/006.
+
+---
+
+## Out of Scope
+
+- Story 005/006: `active_case_recovered` subscribers (auto-resubmit cascades)
+- CriticalBanner visual display (UI Foundation story-005 `announce_text` — emit signal only here)
+- Browser auto-entry + F2 toast suppression (consumer systems — this story only persists/exposes session_meta)
+- Story 003: the save path (this story = load path)
+
+---
+
+## QA Test Cases
+
+- **AC-7**: Given a deliberately-corrupted `active_case.tres` (garbage bytes), When boot load runs, Then `<file>.backup` exists, the load returns null, and `save_corrupted("active_case")` was emitted (connect a listener). Edge: file absent → no backup, no emit, fresh start (EC-2).
+- **AC-15**: Given a `casebook.tres` written with 5 CasebookEntry, When `_load_casebook`, Then `Casebook.entries.size() == 5` and a sampled entry's `case_id`/`verdict`/`final_score` match. Edge: casebook absent → empty Casebook, no error.
+- **AC-16**: Given a `session_meta.cfg` with the two keys, When `_load_session_meta`, Then the getters return `"case:2026-001"` and `true`. Edge: cfg absent → defaults (empty id, false).
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**: `tests/integration/save_load/boot_load_recovery_test.gd` (gdunit4) — AC-7, AC-15, AC-16. Write fixtures to `user://` temp, clean up.
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (atomic write/dir), Story 002 (Resource classes + version check)
+- Unlocks: Story 005 + 006 (consume `active_case_recovered`)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23
+**Criteria**: 3/3 passing (AC-7, AC-15, AC-16) + absent-file edge cases.
+**Files**:
+- `src/services/save_load_service.gd` — `save_corrupted` + `active_case_recovered` signals; `CASEBOOK_FILE`/`SESSION_META_FILE` consts; `_casebook` + `last_active_case_id` + `workspace_f2_hint_seen` fields; `_boot_load()` (called from `_ready` via await); `_load_active_case_or_recover()`, `_load_casebook()`, `_load_session_meta()`, `_rename_to_backup()`.
+- `tests/integration/save_load/boot_load_recovery_test.gd` — 6 tests.
+**Test Evidence**: boot_load_recovery 6/6 PASS; full unit+integration **376 cases / 359 executed / 17 skipped / 0 failures, exit 0** (autoload `_boot_load` runs in every test boot without regression — absent files → safe no-op).
+**Notes**:
+- Corruption detection covers load failure / wrong type / unsupported `save_file_version` (reuses story-002 `_is_save_version_supported`). Corrupt file → `.backup` (preserved for diagnostics, not overwritten).
+- CriticalBanner display for AC-7 is DEFERRED — needs `UIService.announce_text` (UI Foundation story-005, not yet implemented). This story emits `save_corrupted`; the banner is the consumer's job.
+- `active_case_recovered` is emitted here (single recovery entry point); its auto-resubmit SUBSCRIBERS are story 006 (deferred — controllers + EvaluationService).
+- `_boot_load` emit is deferred one frame (`await get_tree().process_frame`) per ADR-0001 amend-2 §C3.
+**Code Review**: Implemented + reviewed directly by orchestrator. ConfigFile/ResourceLoader/DirAccess.rename verified against engine-reference + ADR-0011 boot-load diagram.

--- a/production/epics/save-load/story-005-resolution-cascade-revert-guard.md
+++ b/production/epics/save-load/story-005-resolution-cascade-revert-guard.md
@@ -1,7 +1,7 @@
 # Story 005: Resolution cascade — evaluation_completed → casebook + revert guard
 
 > **Epic**: Save/Load
-> **Status**: Ready
+> **Status**: Complete (core logic, 2026-05-23) / evaluation_completed subscription deferred (EvaluationService — TD-001)
 > **Layer**: Core / Feature
 > **Type**: Integration
 > **Manifest Version**: 2026-05-18
@@ -28,8 +28,8 @@
 
 ## Acceptance Criteria
 
-- [ ] AC-3 (Logic) — `evaluation_completed` received, When Rule 4 cascade, Then `Casebook.entries.append` + `casebook.tres` immediate serialize + `active_case.tres` deleted + `casebook_entry_added` emitted. Test: `test_save_load_service_evaluation_completed_cascade`.
-- [ ] AC-4 (Logic) — `save_active_case()` with case_id already in Casebook, When Rule 4.3 guard, Then `push_error` + return false + `active_case.tres` unchanged (EC-5). Test: `test_save_load_service_revert_resolved_blocked`.
+- [x] AC-3 (Logic) — `evaluation_completed` cascade: casebook append + immediate write + active_case delete + `casebook_entry_added` emit — **DONE (handler)** (`test_evaluation_completed_archives_and_deletes_active`); the EvaluationService SUBSCRIPTION is DEFERRED (TD-001) — handler tested directly via duck-typed result
+- [x] AC-4 (Logic) — `save_active_case()` on a Resolved case → push_error + false + active_case unchanged (EC-5, `save_load_revert_resolved`) — **DONE** (`test_save_active_case_blocked_when_resolved` + allowed-when-not-resolved)
 
 ---
 
@@ -88,3 +88,15 @@ func save_active_case() -> bool:
 
 - Depends on: Story 001 (atomic write), Story 002 (Casebook/CasebookEntry), Story 004 (casebook loaded)
 - Unlocks: #11 Career, #14 Retrospective Replay (consume casebook entries)
+
+---
+
+## Completion Notes
+**Completed (core)**: 2026-05-23
+**Criteria**: AC-3 (handler) + AC-4 passing. AC-3 EvaluationService subscription DEFERRED (TD-001 — submit signature must reconcile before EvaluationService exists).
+**Files**:
+- `src/services/save_load_service.gd` — `casebook_entry_added` signal; `_casebook_has(case_id)`; `_on_evaluation_completed(result)` (casebook append → immediate write → active_case delete → emit; result duck-typed since EvaluationResult is the Submission/Evaluation epic); `save_active_case()` revert guard.
+- `tests/integration/save_load/resolution_cascade_test.gd` — 4 tests.
+**Test Evidence**: resolution_cascade 4/4 PASS; full suite **394 cases / 377 executed / 17 skipped / 0 failures, exit 0**.
+**Deferred**: `EvaluationService.evaluation_completed` → `_on_evaluation_completed` connection (forward-claim) — EvaluationService unimplemented; TD-001 signature conflict to reconcile first. Handler + guard logic tested in isolation.
+**Code Review**: Implemented + reviewed directly by orchestrator. `save_load_revert_resolved` registered (architecture.yaml line 1782).

--- a/production/epics/save-load/story-005-resolution-cascade-revert-guard.md
+++ b/production/epics/save-load/story-005-resolution-cascade-revert-guard.md
@@ -1,0 +1,90 @@
+# Story 005: Resolution cascade — evaluation_completed → casebook + revert guard
+
+> **Epic**: Save/Load
+> **Status**: Ready
+> **Layer**: Core / Feature
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 3h (M)
+> **Performance**: casebook write immediate (0ms debounce); active_case delete atomic
+
+## Context
+
+**GDD**: `design/gdd/save-load.md` (§3.1 Core Rules — Rule 4 resolution cascade + Rule 4.3 revert guard, §3.3 signals, §10.1 AC-3/4, §10.5, EC-5)
+**Requirement**: `TR-save-*` (resolution cascade + Anti-Pillar revert guard — read fresh from `tr-registry.yaml`)
+
+**ADR Governing Implementation**: ADR-0011 (+ ADR-0007 evaluation contract — see TD-001)
+**ADR Decision Summary**: On `evaluation_completed`, append a `CasebookEntry`, write `casebook.tres` immediately (0ms), delete `active_case.tres`, emit `casebook_entry_added`. `save_active_case()` when the case_id already exists in the Casebook → `push_error` + return false + no write (Anti-Pillar `save_load_revert_resolved`, Pillar 1 irreversibility).
+
+**Engine**: Godot 4.6 | **Risk**: MEDIUM
+**Engine Notes**: `evaluation_completed(result: EvaluationResult)` is emitted by EvaluationService — **NOT yet implemented** (TD-001: ADR-0007 `submit(PlayerSubmission)` vs control-manifest `submit(chain_data)` signature conflict unresolved). AC-3's trigger is therefore deferred; the casebook-append + revert-guard LOGIC is implementable and unit-testable by invoking the cascade handler directly. `DirAccess.remove_absolute` for active_case deletion.
+
+**Control Manifest Rules (Core/Feature)**:
+- Required: resolution writes casebook immediately (0ms, not debounced); revert guard on `save_active_case`
+- Forbidden: `save_load_revert_resolved` (re-saving an active_case whose case_id is already Resolved/in Casebook)
+- Guardrail: casebook write + active_case delete are sequenced (write casebook BEFORE deleting active_case)
+
+---
+
+## Acceptance Criteria
+
+- [ ] AC-3 (Logic) — `evaluation_completed` received, When Rule 4 cascade, Then `Casebook.entries.append` + `casebook.tres` immediate serialize + `active_case.tres` deleted + `casebook_entry_added` emitted. Test: `test_save_load_service_evaluation_completed_cascade`.
+- [ ] AC-4 (Logic) — `save_active_case()` with case_id already in Casebook, When Rule 4.3 guard, Then `push_error` + return false + `active_case.tres` unchanged (EC-5). Test: `test_save_load_service_revert_resolved_blocked`.
+
+---
+
+## Implementation Notes
+
+Per ADR-0011 §Decision (resolution cascade):
+
+```gdscript
+func _on_evaluation_completed(result) -> void:   # subscribed if EvaluationService present
+    var entry := CasebookEntry.new()
+    entry.case_id = result.case_id
+    entry.verdict = result.verdict
+    entry.final_score = result.final_score
+    _casebook.entries.append(entry)
+    _save_resource_atomic(_casebook, CASEBOOK_FILE)        # immediate (0ms)
+    DirAccess.remove_absolute(ProjectSettings.globalize_path(ACTIVE_CASE_FILE))
+    casebook_entry_added.emit(entry)
+
+func save_active_case() -> bool:
+    if _casebook_has(_active_case.case_id):
+        push_error("save_load_revert_resolved: case '%s' is Resolved" % _active_case.case_id)
+        return false                                        # AC-4 (EC-5)
+    return _save_resource_atomic(_active_case, ACTIVE_CASE_FILE)
+```
+
+- **DEFERRED**: the `evaluation_completed` SUBSCRIPTION (EvaluationService doesn't exist; TD-001 must reconcile the submit signature first). Implement `_on_evaluation_completed` as a directly-callable handler + guard the `.connect` with presence; test the handler directly. Forward-claim comment at the connect site.
+- Register forbidden_pattern `save_load_revert_resolved` in `architecture.yaml` if not already present (verify first).
+
+---
+
+## Out of Scope
+
+- EvaluationService implementation + the real `evaluation_completed` wiring (Submission/Evaluation epic; TD-001 reconcile first)
+- Story 006: crash-recovery auto-resubmit (different cascade)
+- Casebook trim policy at >100 entries (EC-13 — v1+)
+
+---
+
+## QA Test Cases
+
+- **AC-3**: Given a SaveLoadService with an active_case + empty casebook, When `_on_evaluation_completed(result)` is invoked directly with a mock result, Then casebook has 1 entry with matching fields, `casebook.tres` exists, `active_case.tres` is deleted, and `casebook_entry_added` fired (listener). Edge: write casebook BEFORE delete (if delete fails, casebook still has the entry).
+- **AC-4**: Given a casebook already containing `case:X`, When `save_active_case()` is called with `_active_case.case_id == "case:X"`, Then it returns false, `push_error` fired, and `active_case.tres` is byte-unchanged. Edge: case_id NOT in casebook → save proceeds normally.
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**: `tests/integration/save_load/resolution_cascade_test.gd` (gdunit4) — AC-3 (handler-direct), AC-4.
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (atomic write), Story 002 (Casebook/CasebookEntry), Story 004 (casebook loaded)
+- Unlocks: #11 Career, #14 Retrospective Replay (consume casebook entries)

--- a/production/epics/save-load/story-006-crash-recovery-auto-resubmit.md
+++ b/production/epics/save-load/story-006-crash-recovery-auto-resubmit.md
@@ -1,7 +1,7 @@
 # Story 006: Crash-recovery auto-resubmit cascade (active_case_recovered)
 
 > **Epic**: Save/Load
-> **Status**: Ready
+> **Status**: Complete (decision contract, 2026-05-23) / end-to-end auto-resubmit deferred (controllers + EvaluationService)
 > **Layer**: Core / Feature
 > **Type**: Integration
 > **Manifest Version**: 2026-05-18
@@ -30,7 +30,8 @@
 
 - [ ] AC-5 (Integration) — Workspace freeze (state=FROZEN) → quit → restart, When `active_case_recovered` emit, Then Workspace controller auto-calls `EvaluationService.submit()` + recovery banner. **DEFERRED end-to-end** (needs Workspace controller + EvaluationService); this story tests the recovery-decision contract: given a recovered `workspace_data.state == FROZEN`, the cascade selects the workspace-resubmit branch.
 - [ ] AC-6 (Integration) — Brief Editor SUBMITTING → quit → restart, When `active_case_recovered` emit, Then Brief controller auto-calls `EvaluationService.submit(brief_editor_data.pending_submission)`. **DEFERRED end-to-end**; this story tests: given recovered `brief_editor_data.state == SUBMITTING`, the cascade selects the brief-resubmit branch.
-- [ ] Single entry point — both cascades dispatch from one `active_case_recovered` signal (no second recovery signal).
+- [x] **Decision contract DONE** — `recovery_branch_for(workspace_data, brief_editor_data)` selects `workspace_resubmit` (FROZEN) / `brief_resubmit` (SUBMITTING) / `none`, FROZEN precedence (`crash_recovery_cascade_test.gd`). AC-5/6 end-to-end resubmit DEFERRED (Workspace/Brief controllers + EvaluationService).
+- [x] Single entry point — recovery dispatches from one `active_case_recovered` signal (no duplicate recovery signal) — **DONE** (`test_active_case_recovered_is_a_single_signal`)
 
 ---
 
@@ -88,3 +89,15 @@ func recovery_branch_for(workspace_data, brief_editor_data) -> String:
 
 - Depends on: Story 004 (`active_case_recovered` emit)
 - Unlocks: workspace story-008 (Workspace-side subscriber), Brief Editor epic (Brief-side subscriber)
+
+---
+
+## Completion Notes
+**Completed (decision contract)**: 2026-05-23
+**Criteria**: recovery-branch contract + single-entry-point passing. End-to-end AC-5/6 auto-resubmit DEFERRED (Workspace/Brief controllers + EvaluationService unimplemented; TD-001).
+**Files**:
+- `src/services/save_load_service.gd` — `recovery_branch_for(workspace_data, brief_editor_data) -> String` (FROZEN→workspace_resubmit, SUBMITTING→brief_resubmit, FROZEN precedence) + `BRIEF_SUBMITTING` const (mirrors Brief enum until that class lands). (`active_case_recovered` single-emit is in story 004.)
+- `tests/integration/save_load/crash_recovery_cascade_test.gd` — 7 tests.
+**Test Evidence**: crash_recovery_cascade 7/7 PASS; full suite **394 cases / 377 executed / 17 skipped / 0 failures, exit 0**.
+**Deferred**: the actual subscribers — Workspace controller `_on_active_case_recovered` → `EvaluationService.submit` (workspace story-008) and Brief controller (Brief epic). Both need EvaluationService (TD-001). Forward-claim documented; the decision helper is locked + tested now.
+**Code Review**: Implemented + reviewed directly by orchestrator.

--- a/production/epics/save-load/story-006-crash-recovery-auto-resubmit.md
+++ b/production/epics/save-load/story-006-crash-recovery-auto-resubmit.md
@@ -1,0 +1,90 @@
+# Story 006: Crash-recovery auto-resubmit cascade (active_case_recovered)
+
+> **Epic**: Save/Load
+> **Status**: Ready
+> **Layer**: Core / Feature
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 3h (M)
+> **Performance**: recovery cascade completes within boot budget (≤500ms to recovered state — workspace story-008 AC-27e)
+
+## Context
+
+**GDD**: `design/gdd/save-load.md` (§3.1 Core Rules — crash recovery cascade, §10.2 AC-5/6)
+**Requirement**: `TR-save-*` (crash recovery auto-resubmit — read fresh from `tr-registry.yaml`)
+
+**ADR Governing Implementation**: ADR-0011 (+ ADR-0001 amend-2 `active_case_recovered` contract)
+**ADR Decision Summary**: Both crash-recovery cascades route through one `active_case_recovered(workspace_data, brief_editor_data)` signal (emitted by story 004 boot load). Subscribers: Workspace controller (if `workspace_data.state == FROZEN` → auto `EvaluationService.submit`); Brief controller (if `brief_editor_data.state == SUBMITTING` → auto `EvaluationService.submit(pending_submission)`).
+
+**Engine**: Godot 4.6 | **Risk**: MEDIUM
+**Engine Notes**: This story owns the SaveLoadService SIDE (the single `active_case_recovered` emit — already in story 004) and the **subscriber contract**. The actual subscribers live in the Workspace controller (workspace story-008) and Brief controller (Brief epic) — **neither exists yet**, and both call `EvaluationService.submit()` which is **not implemented** (TD-001). So AC-5/AC-6 end-to-end are DEFERRED; this story locks + tests the recovery-decision contract (which state triggers which resubmit) in isolation.
+
+**Control Manifest Rules (Core/Feature)**:
+- Required: single `active_case_recovered` entry point for BOTH cascades; recovery decision keyed on persisted state (FROZEN / SUBMITTING)
+- Forbidden: duplicate/parallel recovery paths (two separate recovery signals)
+- Guardrail: recovery cascade ≤500ms boot-to-recovered (workspace story-008 AC-27e)
+
+---
+
+## Acceptance Criteria
+
+- [ ] AC-5 (Integration) — Workspace freeze (state=FROZEN) → quit → restart, When `active_case_recovered` emit, Then Workspace controller auto-calls `EvaluationService.submit()` + recovery banner. **DEFERRED end-to-end** (needs Workspace controller + EvaluationService); this story tests the recovery-decision contract: given a recovered `workspace_data.state == FROZEN`, the cascade selects the workspace-resubmit branch.
+- [ ] AC-6 (Integration) — Brief Editor SUBMITTING → quit → restart, When `active_case_recovered` emit, Then Brief controller auto-calls `EvaluationService.submit(brief_editor_data.pending_submission)`. **DEFERRED end-to-end**; this story tests: given recovered `brief_editor_data.state == SUBMITTING`, the cascade selects the brief-resubmit branch.
+- [ ] Single entry point — both cascades dispatch from one `active_case_recovered` signal (no second recovery signal).
+
+---
+
+## Implementation Notes
+
+Per ADR-0011 §Decision (recovery cascade) + ADR-0001 amend-2 §C3:
+
+```gdscript
+# SaveLoadService emits (story 004): active_case_recovered(workspace_data, brief_editor_data)
+#
+# Recovery-decision contract (this story locks + tests it). A small pure helper
+# makes the branch selection unit-testable without the (absent) controllers:
+func recovery_branch_for(workspace_data, brief_editor_data) -> String:
+    if workspace_data != null and workspace_data.state == WorkspaceData.WorkspaceState.FROZEN:
+        return "workspace_resubmit"
+    if brief_editor_data != null and brief_editor_data.get("state") == BRIEF_SUBMITTING:
+        return "brief_resubmit"
+    return "none"
+```
+
+- **DEFERRED**: the actual subscribers (Workspace controller `_on_active_case_recovered` → `EvaluationService.submit`; Brief controller → `EvaluationService.submit(pending_submission)`) — both controllers + EvaluationService are unimplemented (TD-001 first). Forward-claim comments where the subscribers will attach.
+- This story's testable deliverable: the `recovery_branch_for(...)` pure decision helper + confirmation that story-004 emits exactly one `active_case_recovered`. End-to-end AC-5/6 re-open when Workspace/Brief controllers + EvaluationService land.
+- BriefEditorData state enum/`SUBMITTING` is owned by the Brief epic — type loosely until that class exists.
+
+---
+
+## Out of Scope
+
+- Workspace controller `_on_active_case_recovered` (workspace story-008)
+- Brief controller `_on_active_case_recovered` (Brief Editor epic)
+- EvaluationService.submit (Submission/Evaluation epic; TD-001 reconcile first)
+- Recovery banner display (UIService.announce_text — UI Foundation story-005)
+
+---
+
+## QA Test Cases
+
+- **AC-5 (contract)**: Given a recovered `workspace_data` with `state == FROZEN` (and brief null/INACTIVE), When `recovery_branch_for`, Then returns `"workspace_resubmit"`. Edge: workspace ACTIVE (not frozen) → not this branch.
+- **AC-6 (contract)**: Given a recovered `brief_editor_data` with `state == SUBMITTING` (workspace not FROZEN), When `recovery_branch_for`, Then returns `"brief_resubmit"`. Edge: both FROZEN + SUBMITTING → workspace branch wins (deterministic priority — document the precedence).
+- **Single entry point**: assert story-004 boot emits exactly one `active_case_recovered` (one listener, count == 1).
+- Neither / null → `"none"`.
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**: `tests/integration/save_load/crash_recovery_cascade_test.gd` (gdunit4) — recovery-branch contract + single-emit. End-to-end AC-5/6 deferred (note in story when EvaluationService + controllers land).
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 004 (`active_case_recovered` emit)
+- Unlocks: workspace story-008 (Workspace-side subscriber), Brief Editor epic (Brief-side subscriber)

--- a/production/epics/save-load/story-007-anti-pillar-serialization-guards.md
+++ b/production/epics/save-load/story-007-anti-pillar-serialization-guards.md
@@ -1,0 +1,97 @@
+# Story 007: Anti-Pillar serialization guards (settings + ephemeral exclusion)
+
+> **Epic**: Save/Load
+> **Status**: Complete (2026-05-23)
+> **Layer**: Core / Foundation
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 2h (S)
+> **Performance**: validation at serialize time only — negligible
+
+## Context
+
+**GDD**: `design/gdd/save-load.md` (§2 Anti-Pillar guards, §3.4 Settings separation, §7.2 forbidden patterns, §10.5 AC-12/13)
+**Requirement**: `TR-save-*` (Anti-Pillar serialization guards — read fresh from `tr-registry.yaml`)
+
+**ADR Governing Implementation**: ADR-0011 (+ ADR-0008 amend-1 §A6 ephemeral-field ban, ADR-0009 settings separation)
+**ADR Decision Summary**: `active_case.tres` MUST NOT include Settings values (Settings live in a separate `user://user_settings.cfg`, owned by ADR-0009) — `save_load_settings_inclusion`. chain_data MUST NOT include ephemeral fields (`last_touched_usec`, `memo_text`, etc.) — `chain_data_include_ephemeral_field` (already enforced by `WorkspaceData.validate_chain_data`, story-002 workspace).
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: Pure data validation — no post-cutoff API. Reuse the canonical `WorkspaceData.validate_chain_data()` allow-list (do NOT duplicate it). The active_case Resource has no Settings `@export` fields by construction (structural guarantee + a test that asserts the field set).
+
+**Control Manifest Rules (Core/Foundation)**:
+- Required: single canonical chain_data allow-list validator (`WorkspaceData.validate_chain_data`); active_case excludes settings by construction
+- Forbidden: `save_load_settings_inclusion`, `chain_data_include_ephemeral_field`, `chain_data_schema_allow_list_duplication`
+- Guardrail: validate before atomic write
+
+---
+
+## Acceptance Criteria
+
+- [x] AC-12 (Logic) — active_case carries no Settings fields (structural; `save_load_settings_inclusion`) — **DONE** (`test_active_case_save_data_has_no_settings_fields` + property-set shape test)
+- [x] AC-13 (Logic) — chain_data with an ephemeral field (`last_touched_usec`) rejected via canonical validator (`chain_data_include_ephemeral_field`) — **DONE** (`test_active_case_with_ephemeral_chain_data_field_rejected`)
+
+---
+
+## Implementation Notes
+
+Per ADR-0011 + ADR-0008 amend-1 §A6:
+
+```gdscript
+# Before atomic write of active_case, validate the embedded chain_data via the
+# canonical workspace validator (NO duplicate allow-list here):
+func _validate_active_case(active: ActiveCaseSaveData) -> bool:
+    var cd: Dictionary = active.workspace_data.chain_data_snapshot
+    if not active.workspace_data.validate_chain_data(cd):   # emits submission_rejected on violation
+        return false                                        # AC-13
+    return true
+```
+
+- **AC-12** is structural: `ActiveCaseSaveData` (story 002) has NO settings `@export` fields — Settings live in `user_settings.cfg` (ADR-0009). The test asserts the active_case Resource's serialized property set contains no `display.*` / `audio.*` / `input.*` keys.
+- **AC-13** reuses `WorkspaceData.validate_chain_data()` (story-002 workspace) — the allow-list already rejects non-allowed node fields (including ephemeral ones like `last_touched_usec`, `memo_text`). Do NOT re-implement the allow-list (`chain_data_schema_allow_list_duplication` forbidden).
+- Register/verify `save_load_settings_inclusion` in `architecture.yaml`.
+
+---
+
+## Out of Scope
+
+- The allow-list validator itself (owned by WorkspaceData — story-002 workspace; reuse only)
+- Settings serialization (separate system — ADR-0009 / Settings epic)
+- Save/load mechanics (stories 001-006)
+
+---
+
+## QA Test Cases
+
+- **AC-12**: Given an `ActiveCaseSaveData` instance, When its serialized property list is inspected, Then no Settings keys (`display.text_scale`, `display.reduced_motion`, `audio.*`, `input.*`) appear. Edge: confirm via the Resource's `get_property_list()` or a round-trip `.tres` text scan — no settings keys present.
+- **AC-13**: Given a chain_data with `last_touched_usec` injected into a node dict, When `validate_chain_data` runs (via `_validate_active_case`), Then it returns false + `submission_rejected("schema_violation")` (cross-link workspace AC-10/52). Edge: clean chain_data → passes.
+
+---
+
+## Test Evidence
+
+**Story Type**: Logic
+**Required**: `tests/unit/save_load/anti_pillar_guards_test.gd` (gdunit4) — AC-12, AC-13.
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 002 (ActiveCaseSaveData), WorkspaceData.validate_chain_data (workspace story-002 — Complete)
+- Unlocks: None (guard layer)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23
+**Criteria**: 2/2 passing (AC-12, AC-13) + null-safety + clean-data positive.
+**Files**:
+- `src/services/save_load_service.gd` — `_validate_active_case(active) -> bool` delegating to the canonical `WorkspaceData.validate_chain_data` (no allow-list duplication).
+- `tests/unit/save_load/anti_pillar_guards_test.gd` — 5 tests.
+**Test Evidence**: anti_pillar_guards 5/5 PASS; full unit+integration **381 cases / 364 executed / 17 skipped / 0 failures, exit 0**.
+**Notes**:
+- AC-12 is structural — `ActiveCaseSaveData` declares no Settings `@export` fields (Settings persist separately, ADR-0009). Test inspects `get_property_list()` for absence of `display.*`/`audio.*`/`input.*`/`accessibility.*` + verifies the declared script-variable set.
+- AC-13 reuses the SINGLE canonical `WorkspaceData.validate_chain_data` (workspace story-002, Complete) — `chain_data_schema_allow_list_duplication` avoided. Both forbidden patterns confirmed registered (architecture.yaml lines 1433, 1808).
+**Code Review**: Implemented + reviewed directly by orchestrator.

--- a/production/epics/save-load/story-008-close-request-flush-session-persistence.md
+++ b/production/epics/save-load/story-008-close-request-flush-session-persistence.md
@@ -1,0 +1,89 @@
+# Story 008: Close-request forced flush + full-session persistence
+
+> **Epic**: Save/Load
+> **Status**: Ready
+> **Layer**: Core / Foundation
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 2-3h (M)
+> **Performance**: close flush synchronous; if > 100ms a spinner is required (OQ-SL3) — measure
+
+## Context
+
+**GDD**: `design/gdd/save-load.md` (§3.4 Inter-system — game-exit forced flush, §10.6 AC-14, §4.4 atomic write time, EC-10)
+**Requirement**: `TR-save-*` (close-request flush + full-session persistence — read fresh from `tr-registry.yaml`)
+
+**ADR Governing Implementation**: ADR-0011
+**ADR Decision Summary**: On `NOTIFICATION_WM_CLOSE_REQUEST`, drain any pending debounce queue and run a synchronous `_perform_save` before quit so the last edits are not lost (EC-10). Full 30-min session reconstructs from `active_case.tres` on restart (only the final < 250ms debounce window may be lost).
+
+**Engine**: Godot 4.6 | **Risk**: MEDIUM
+**Engine Notes**: `NOTIFICATION_WM_CLOSE_REQUEST` in `_notification`. Requires `get_tree().set_auto_accept_quit(false)` (or `Window.auto_accept_quit = false` on root) so the close can be intercepted, the save flushed synchronously, then `get_tree().quit()`. VR-SL3 (close-block time vs perception) is advisory — measure; > 100ms → spinner (OQ-SL3). On an autoload Node, `_notification` receives the WM close on the main window.
+
+**Control Manifest Rules (Core/Foundation)**:
+- Required: intercept close → synchronous flush of pending save → quit; drain debounce queue (don't drop the pending save)
+- Forbidden: quitting without flushing a pending (dirty) save
+- Guardrail: close flush synchronous; measure block time (VR-SL3)
+
+---
+
+## Acceptance Criteria
+
+- [ ] AC-14 (Integration) — Workspace work for 30 min + force-quit (Alt+F4), When restart, Then `active_case.tres` restores all 30 min of work (only the final < 250ms debounce window may be lost). Evidence: integration test + manual reproducer.
+- [ ] Close-request flush — a pending (dirty/debounced) save is flushed synchronously on `NOTIFICATION_WM_CLOSE_REQUEST` before quit (EC-10).
+
+---
+
+## Implementation Notes
+
+Per ADR-0011 §3.4 (game-exit forced flush):
+
+```gdscript
+func _ready() -> void:
+    # ... story 001/003/004 ...
+    get_tree().set_auto_accept_quit(false)   # intercept close to flush first
+
+func _notification(what: int) -> void:
+    if what == NOTIFICATION_WM_CLOSE_REQUEST:
+        _flush_pending_save()                 # drain debounce: if dirty, _perform_save now (synchronous)
+        get_tree().quit()
+
+func _flush_pending_save() -> void:
+    if _autosave_timer != null and not _autosave_timer.is_stopped():
+        _autosave_timer.stop()
+        _perform_save("active_case")           # EC-10 — don't lose the queued edit
+```
+
+- `_flush_pending_save` checks whether the debounce timer (story 003) is running (= dirty) and, if so, performs the save immediately rather than waiting for the 250ms timeout.
+- AC-14 is reconstruction: it relies on stories 001-004 (atomic write + load). The integration test simulates a sequence of edits + a flush + a reload and asserts the final state matches. Real "force-quit" is a manual reproducer; the automated test exercises `_flush_pending_save` + reload round-trip.
+- Measure close-block time (VR-SL3); if a casebook of 100 entries pushes it > 100ms, note for the OQ-SL3 spinner decision (v1+).
+
+---
+
+## Out of Scope
+
+- Spinner UI for slow flush (OQ-SL3 — v1+, needs UI Foundation)
+- Stories 001-004 mechanics (this story adds the close-request hook + drives the full round-trip)
+- Resolution/recovery cascades (stories 005/006)
+
+---
+
+## QA Test Cases
+
+- **AC-14 (reconstruction)**: Given a SaveLoadService with an active_case mutated through several debounced edits, When `_flush_pending_save` is invoked (simulating close) then the Resource is reloaded, Then the reloaded active_case reflects the latest edits (not just the last-committed debounce). Edge: no pending edit → flush is a no-op (timer stopped), no spurious write.
+- **Close-flush**: Given the debounce timer running (dirty), When `_flush_pending_save`, Then the timer is stopped and `_perform_save("active_case")` ran exactly once before quit. Edge: timer already stopped (clean) → no save.
+
+---
+
+## Test Evidence
+
+**Story Type**: Integration
+**Required**: `tests/integration/save_load/close_flush_persistence_test.gd` (gdunit4) — AC-14 + close-flush. Manual reproducer noted for true force-quit.
+
+**Status**: [ ] Not yet created
+
+---
+
+## Dependencies
+
+- Depends on: Story 001 (atomic write), Story 003 (debounce timer to drain), Story 004 (load for round-trip)
+- Unlocks: None (lifecycle completeness)

--- a/production/epics/save-load/story-008-close-request-flush-session-persistence.md
+++ b/production/epics/save-load/story-008-close-request-flush-session-persistence.md
@@ -1,7 +1,7 @@
 # Story 008: Close-request forced flush + full-session persistence
 
 > **Epic**: Save/Load
-> **Status**: Ready
+> **Status**: Complete (2026-05-23)
 > **Layer**: Core / Foundation
 > **Type**: Integration
 > **Manifest Version**: 2026-05-18
@@ -28,8 +28,8 @@
 
 ## Acceptance Criteria
 
-- [ ] AC-14 (Integration) — Workspace work for 30 min + force-quit (Alt+F4), When restart, Then `active_case.tres` restores all 30 min of work (only the final < 250ms debounce window may be lost). Evidence: integration test + manual reproducer.
-- [ ] Close-request flush — a pending (dirty/debounced) save is flushed synchronously on `NOTIFICATION_WM_CLOSE_REQUEST` before quit (EC-10).
+- [x] AC-14 (Integration) — full-session reconstruction: debounced edits recoverable after flush + reload (latest pending edit wins) — **DONE** (`test_full_session_reconstructs_latest_edits_after_flush`; true force-quit is a manual reproducer)
+- [x] Close-request flush — pending dirty debounced save flushed synchronously (EC-10) — **DONE** (`test_flush_writes_pending_dirty_save` + no-op-when-clean); `NOTIFICATION_WM_CLOSE_REQUEST` → `_flush_pending_save` + quit wired (quit path not in-process testable)
 
 ---
 
@@ -87,3 +87,17 @@ func _flush_pending_save() -> void:
 
 - Depends on: Story 001 (atomic write), Story 003 (debounce timer to drain), Story 004 (load for round-trip)
 - Unlocks: None (lifecycle completeness)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23
+**Criteria**: AC-14 + close-flush passing.
+**Files**:
+- `src/services/save_load_service.gd` — `_ready` sets `get_tree().set_auto_accept_quit(false)`; `_notification(NOTIFICATION_WM_CLOSE_REQUEST)` → `_flush_pending_save` + `quit()`; `_flush_pending_save()` drains running per-category debounce timers (immediate save).
+- `tests/integration/save_load/close_flush_persistence_test.gd` — 3 tests.
+**Test Evidence**: close_flush_persistence 3/3 PASS; full unit+integration **384 cases / 367 executed / 17 skipped / 0 failures, exit 0** (`set_auto_accept_quit(false)` does not affect the test runner — gdunit4 quits explicitly, the setting only gates WM_CLOSE_REQUEST).
+**Notes**:
+- The `NOTIFICATION_WM_CLOSE_REQUEST` → quit path can't be exercised in-process (it quits the runner), so `_flush_pending_save` is tested directly; the notification wiring is by inspection.
+- VR-SL3 (close-block time) advisory — measure on target; > 100ms casebook flush would need a spinner (OQ-SL3, v1+).
+**Code Review**: Implemented + reviewed directly by orchestrator.

--- a/production/epics/submission-evaluation/EPIC.md
+++ b/production/epics/submission-evaluation/EPIC.md
@@ -1,0 +1,67 @@
+# Epic: Submission & Evaluation
+
+> **Layer**: Feature (Gameplay) / Core
+> **GDD**: design/gdd/submission-evaluation.md
+> **Architecture Module**: `EvaluationService` autoload (THIRD position) + `PlayerSubmission` / `EvaluationResult` / `CommentTemplates` Resource tree
+> **Status**: In Progress
+> **Stories**: 5 created 2026-05-23
+> **Created**: 2026-05-23
+
+## Overview
+
+Submission & Evaluation is the weighted-grading core (Pillar 1 — *Truth Is Weighted*). It takes a `PlayerSubmission` (chosen disposition + cited Library IDs + chain_data) and grades it against the case's `correct_disposition` / `correct_citations` / `scoring_weights` (data-driven — *algorithm is code, weights are data*, ADR-0003). It computes 5 subscores (MVP active: `disposition_match`, `core_citation_coverage`, `redundant_citation_penalty`; v1+: `chain_coherence`, `precedent_seniority_bonus` — weight-0 locked in MVP), weight-sums them into a single `final_score`, and produces a verdict (파기/파기환송/기각/각하) plus per-subscore one-line comments. The Anti-Pillar guard `case_disposition_match_minimum_weight = 0.4` ensures disposition alone cannot decide the outcome. `EvaluationService` is an autoload (THIRD) running a 5-state machine (IDLE→VALIDATING→COMPUTING→REPORTING→DONE) that emits `evaluation_completed(result: EvaluationResult)`. Responsibility boundary: this system grades only — verdict *presentation* is #10 Verdict Reveal, result *persistence* is #11 Career / Save/Load.
+
+## Governing ADRs
+
+| ADR | Decision Summary | Engine Risk |
+|-----|-----------------|-------------|
+| **ADR-0007: Submission Evaluation Algorithm** (Accepted 2026-05-17) | `EvaluationService` autoload THIRD; `submit(submission: PlayerSubmission)` (TD-001 resolved); PlayerSubmission/EvaluationResult/CommentTemplates Resources; 5-state machine; 5 subscores; verdict thresholds {pagi:0.7, low:0.3} global-locked in `entities.yaml`; per-case threshold override forbidden | None — `class_name`/`@export`/`signal`/`enum`/Autoload all 4.0+ stable (no post-cutoff APIs) |
+| ADR-0001 (dependency) | `LibraryService.validate_citations()` (Validating gate) | LOW |
+| ADR-0003 (dependency) | `CaseService.get_case()` + `scoring_weights` externalization | LOW |
+
+## GDD Requirements
+
+23 `TR-submission-*` in `tr-registry.yaml` — covered by ADR-0007. Thematic grouping (per-story TR-IDs pulled by `/create-stories`):
+
+| Theme | Coverage |
+|-------|----------|
+| PlayerSubmission/EvaluationResult/CommentTemplates Resource tree + autoload THIRD | ADR-0007 ✅ |
+| 5-subscore definitions (disposition_match / core_citation_coverage / redundant_citation_penalty + v1+ chain_coherence / precedent_seniority_bonus weight-0) | ADR-0007 ✅ |
+| final_score weighted sum + [0,1] clamp + Anti-Pillar min-weight guard | ADR-0007 ✅ |
+| Verdict function (파기/파기환송/기각/각하) + global thresholds | ADR-0007 ✅ |
+| 5-state machine + double-submit reject + Validating gate (validate_citations) | ADR-0007 ✅ |
+| Comment-template decision tree (per-subscore key selection) | ADR-0007 ✅ |
+| Per-case verdict-threshold-override forbidden pattern | ADR-0007 ✅ |
+
+## Engine / Cross-System Notes
+
+- **No post-cutoff engine risk** — pure GDScript Resource + autoload + signal.
+- **Dependencies all present**: `LibraryService.validate_citations` (src/data/library_service.gd:286), `CaseService.get_case` (src/data/case_service.gd:99), `CaseFile.correct_disposition`/`correct_citations`/`scoring_weights` (src/data/case_file.gd), `entities.yaml submission_verdict_thresholds` = {pagi:0.7, low:0.3}.
+- **Autoload THIRD**: per ADR-0007 `entry_count()`/`case_count()` heuristic guard avoids signal pre-fire deadlock. Real registration after LibraryService(FIRST)/CaseService — note current project has LibraryService/UIService/CaseService/SaveLoadService; EvaluationService slot is positional intent.
+- **TD-001 RESOLVED**: `submit(submission: PlayerSubmission)` is the entry point (control-manifest corrected). Unblocks Save/Load sl-005/006 end-to-end + reasoning-workspace 007/008 submit hand-off.
+- **Unblocks**: #10 Verdict Reveal, #11 Career, #14 Retrospective Replay; Save/Load resolution + recovery cascades.
+
+## Definition of Done
+
+This epic is complete when:
+- All stories implemented, reviewed, closed via `/story-done`
+- All `design/gdd/submission-evaluation.md` §8 acceptance criteria verified
+- Scoring algorithm + verdict function have deterministic unit tests (§8.8)
+- 5-state machine + double-submit + Validating gate have integration tests
+- Per-case-override + min-weight Anti-Pillar guards gated by tests
+
+## Stories
+
+| # | Story | Type | Status | ADR |
+|---|-------|------|--------|-----|
+| 001 | [Resource tree + autoload + threshold load](story-001-resource-tree-autoload-thresholds.md) | Logic | Complete | ADR-0007 |
+| 002 | [Scoring — 5 subscores + weighted final_score](story-002-scoring-subscores-final-score.md) | Logic | Complete | ADR-0007 |
+| 003 | [Verdict function (파기/파기환송/기각/각하)](story-003-verdict-function.md) | Logic | Complete | ADR-0007 |
+| 004 | [submit() 5-state machine + Validating gate + evaluation_completed](story-004-state-machine-submit-pipeline.md) | Integration | Ready | ADR-0007 |
+| 005 | [Comment-template decision tree + per-case-override guard](story-005-comment-templates-decision-tree.md) | Logic | Ready | ADR-0007 |
+
+**Implementation order**: 001 (Resources/autoload/thresholds) → 002 (scoring) → 003 (verdict) → 004 (state machine wires 002/003 + Library/Case integration) → 005 (comments). 001-003 are the deterministic gradable core; 004 wires the pipeline + cross-system integration; 005 adds comment selection.
+
+## Next Step
+
+Run `/story-readiness production/epics/submission-evaluation/story-001-resource-tree-autoload-thresholds.md` then `/dev-story`.

--- a/production/epics/submission-evaluation/EPIC.md
+++ b/production/epics/submission-evaluation/EPIC.md
@@ -3,8 +3,8 @@
 > **Layer**: Feature (Gameplay) / Core
 > **GDD**: design/gdd/submission-evaluation.md
 > **Architecture Module**: `EvaluationService` autoload (THIRD position) + `PlayerSubmission` / `EvaluationResult` / `CommentTemplates` Resource tree
-> **Status**: In Progress
-> **Stories**: 5 created 2026-05-23
+> **Status**: Complete (implementation — 5/5 stories; comment_templates.tres Korean content is a separate content task)
+> **Stories**: 5 created 2026-05-23, all Complete
 > **Created**: 2026-05-23
 
 ## Overview
@@ -58,7 +58,7 @@ This epic is complete when:
 | 002 | [Scoring — 5 subscores + weighted final_score](story-002-scoring-subscores-final-score.md) | Logic | Complete | ADR-0007 |
 | 003 | [Verdict function (파기/파기환송/기각/각하)](story-003-verdict-function.md) | Logic | Complete | ADR-0007 |
 | 004 | [submit() 5-state machine + Validating gate + evaluation_completed](story-004-state-machine-submit-pipeline.md) | Integration | Complete | ADR-0007 |
-| 005 | [Comment-template decision tree + per-case-override guard](story-005-comment-templates-decision-tree.md) | Logic | Ready | ADR-0007 |
+| 005 | [Comment-template decision tree + per-case-override guard](story-005-comment-templates-decision-tree.md) | Logic | Complete | ADR-0007 |
 
 **Implementation order**: 001 (Resources/autoload/thresholds) → 002 (scoring) → 003 (verdict) → 004 (state machine wires 002/003 + Library/Case integration) → 005 (comments). 001-003 are the deterministic gradable core; 004 wires the pipeline + cross-system integration; 005 adds comment selection.
 

--- a/production/epics/submission-evaluation/EPIC.md
+++ b/production/epics/submission-evaluation/EPIC.md
@@ -57,7 +57,7 @@ This epic is complete when:
 | 001 | [Resource tree + autoload + threshold load](story-001-resource-tree-autoload-thresholds.md) | Logic | Complete | ADR-0007 |
 | 002 | [Scoring — 5 subscores + weighted final_score](story-002-scoring-subscores-final-score.md) | Logic | Complete | ADR-0007 |
 | 003 | [Verdict function (파기/파기환송/기각/각하)](story-003-verdict-function.md) | Logic | Complete | ADR-0007 |
-| 004 | [submit() 5-state machine + Validating gate + evaluation_completed](story-004-state-machine-submit-pipeline.md) | Integration | Ready | ADR-0007 |
+| 004 | [submit() 5-state machine + Validating gate + evaluation_completed](story-004-state-machine-submit-pipeline.md) | Integration | Complete | ADR-0007 |
 | 005 | [Comment-template decision tree + per-case-override guard](story-005-comment-templates-decision-tree.md) | Logic | Ready | ADR-0007 |
 
 **Implementation order**: 001 (Resources/autoload/thresholds) → 002 (scoring) → 003 (verdict) → 004 (state machine wires 002/003 + Library/Case integration) → 005 (comments). 001-003 are the deterministic gradable core; 004 wires the pipeline + cross-system integration; 005 adds comment selection.

--- a/production/epics/submission-evaluation/story-001-resource-tree-autoload-thresholds.md
+++ b/production/epics/submission-evaluation/story-001-resource-tree-autoload-thresholds.md
@@ -1,0 +1,42 @@
+# Story 001: Resource tree + EvaluationService autoload + threshold load
+
+> **Epic**: Submission & Evaluation
+> **Status**: Complete (2026-05-23)
+> **Layer**: Feature (Gameplay) / Core
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 3h (M)
+> **Performance**: _ready() threshold load < 5ms; no per-frame cost
+
+## Context
+**GDD**: `design/gdd/submission-evaluation.md` §3.1 (Resource tree), §3.1.4/§7.1 (thresholds)
+**Requirement**: `TR-submission-*` (Resource tree + autoload + threshold externalization)
+**ADR Governing Implementation**: ADR-0007 §Decision (Resource tree + autoload THIRD + entities.yaml thresholds)
+**ADR Decision Summary**: `PlayerSubmission` (case_id/player_disposition/player_citations/chain_data/submission_time_ms), `EvaluationResult` (case_id/final_score/verdict/subscores/weighted_contributions/comments/correct_set/missed_set/redundant_set/evaluated_at), `CommentTemplates` (Dictionary template_key→한국어). `EvaluationService` autoload THIRD; `_ready()` loads `submission_verdict_thresholds` {pagi:0.7, low:0.3}.
+**Engine**: Godot 4.6 | **Risk**: None (class_name/@export/autoload 4.0+ stable)
+**Control Manifest Rules**: Feature Layer — typed @export; verdict thresholds global (no per-case override — `per_case_verdict_threshold_override` forbidden)
+
+## Acceptance Criteria
+- [ ] AC — `PlayerSubmission` / `EvaluationResult` / `CommentTemplates` Resource classes per ADR-0007 §Decision field trees (typed @export)
+- [ ] AC — `EvaluationService` autoload THIRD skeleton with `enum State {IDLE,VALIDATING,COMPUTING,REPORTING,DONE}`, `current_state` (IDLE), signals `evaluation_completed(result)` + `submission_rejected(reason)`
+- [ ] AC-12/14 — `_ready()` loads `verdict_threshold_pagi=0.7` + `verdict_threshold_low=0.3` from entities.yaml/registry constant (global lock; no runtime mutation)
+
+## Implementation Notes
+Per ADR-0007: `class_name EvaluationServiceClass extends Node` (autoload-name-collision avoidance). Resources in `src/data/`. Thresholds: read from `design/registry/entities.yaml submission_verdict_thresholds` value `{pagi:0.7, low:0.3}` (or inline const mirroring it if registry parse is heavy — ADR-0007 §Alt notes inline const acceptable). class_name globals require `--import` cache regen (TD-005).
+
+## Out of Scope
+- Story 002 (scoring), 003 (verdict fn), 004 (state machine/submit), 005 (comments)
+
+## QA Test Cases
+- AC: instantiate each Resource → field defaults correct; EvaluationService autoload registered + current_state==IDLE + signals exist; thresholds loaded (0.7/0.3).
+
+## Test Evidence
+**Story Type**: Logic | **Required**: `tests/unit/submission_evaluation/resource_tree_test.gd`
+**Status**: [ ] Not yet created
+
+## Dependencies
+- Depends on: None (epic entry)
+- Unlocks: 002/003/004/005
+
+## Completion Notes
+**Completed**: 2026-05-23. 3/3 ACs. Files: src/data/player_submission.gd, evaluation_result.gd, comment_templates.gd; src/services/evaluation_service.gd (State enum + IDLE + signals + thresholds); project.godot autoload (EvaluationService, THIRD intent — registered after CaseService). Thresholds as inline const mirroring entities.yaml {pagi:0.7, low:0.3} (ADR-0007 §Alt sanctions inline const). Tests: resource_tree_test.gd 5/5. Full suite 420/0-fail. class cache regenerated (TD-005). Reviewed by orchestrator.

--- a/production/epics/submission-evaluation/story-002-scoring-subscores-final-score.md
+++ b/production/epics/submission-evaluation/story-002-scoring-subscores-final-score.md
@@ -1,0 +1,43 @@
+# Story 002: Scoring — 5 subscores + weighted final_score
+
+> **Epic**: Submission & Evaluation
+> **Status**: Complete (2026-05-23)
+> **Layer**: Feature (Gameplay) / Core
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 4h (M)
+> **Performance**: ≤50ms per evaluation (AC-21); 5 subscore + Set ops O(|P|·|C|) < 1ms typical
+
+## Context
+**GDD**: `design/gdd/submission-evaluation.md` §4.1-4.3 (MVP subscores), §4.6 (final_score), §3.1.3 (5 subscore defs), §7.3 (penalty cap)
+**Requirement**: `TR-submission-*` (subscore formulas + weighted sum)
+**ADR Governing Implementation**: ADR-0007 §Decision (scoring algorithm)
+**ADR Decision Summary**: 5 subscores [0,1] (penalty [-0.3,0]). MVP active: `disposition_match` (discrete 1.0/0.0 = player_disposition==correct_disposition), `core_citation_coverage` (Set recall over correct_citations — iterate CORRECT side for natural [0,1] cap per review BLOCKING #2 fix), `redundant_citation_penalty` (negative, over player\correct). v1+ (weight-0): chain_coherence, precedent_seniority_bonus. `final_score = clamp(Σ subscore[k]×case.scoring_weights[k], 0, 1)`.
+**Engine**: Godot 4.6 | **Risk**: None
+**Control Manifest Rules**: Feature Layer — Anti-Pillar `case_disposition_match_minimum_weight=0.4` (disposition alone can't decide); penalty cap [-0.3,0]
+
+## Acceptance Criteria
+- [ ] AC (§8.2) — `disposition_match` = 1.0 iff player_disposition==correct_disposition else 0.0
+- [ ] AC (§8.2) — `core_citation_coverage` = |player ∩ correct| / |correct| (iterate correct side; [0,1]; correct empty→define per GDD)
+- [ ] AC (§8.2) — `redundant_citation_penalty` ∈ [-0.3, 0.0] over player citations not in correct (penalty cap §7.3)
+- [ ] AC (§8.3) — `final_score = clamp(Σ subscore[k] × scoring_weights[k], 0.0, 1.0)`; v1+ subscores (chain_coherence/precedent_seniority_bonus) computed but weight-0 in MVP → no effect
+
+## Implementation Notes
+Per ADR-0007 + GDD §4: pure functions on (player_disposition, player_citations, correct_disposition, correct_citations, scoring_weights). All 5 keys computed (v1+ weight-0). Use Dictionary/Array Set ops. Deterministic (§8.8) — no time/random. Penalty cap clamp.
+
+## Out of Scope
+- Story 003 (verdict fn maps final_score→verdict), 004 (state machine), 001 (Resources)
+
+## QA Test Cases
+- disposition_match: match→1.0, mismatch→0.0. coverage: 3/6 correct cited→0.5; all→1.0; none→0.0; correct empty→GDD-defined. penalty: 2 redundant→within [-0.3,0]; cap respected at many redundant. final_score: weighted sum + clamp; v1+ weight-0 confirmed no-effect. Boundary values exact.
+
+## Test Evidence
+**Story Type**: Logic | **Required**: `tests/unit/submission_evaluation/scoring_test.gd`
+**Status**: [ ] Not yet created
+
+## Dependencies
+- Depends on: Story 001 (EvaluationResult subscores Dict)
+- Unlocks: 003 (verdict consumes final_score), 004
+
+## Completion Notes
+**Completed**: 2026-05-23. 4/4 ACs. EvaluationService pure functions: compute_disposition_match / compute_core_citation_coverage (correct-side recall, citation_similarity 1.0/0.5/0.0, GDD §4.2 example=0.5 verified) / compute_redundant_citation_penalty (-min(0.3, ratio×0.5), §4.3 examples -0.25/-0.3 verified) / compute_final_score (clamp[0,1], v1+ weight-0 no-effect verified) / compute_weighted_contributions. Tests: scoring_test.gd 13/13. Deterministic (§8.8). Reviewed by orchestrator.

--- a/production/epics/submission-evaluation/story-003-verdict-function.md
+++ b/production/epics/submission-evaluation/story-003-verdict-function.md
@@ -1,0 +1,45 @@
+# Story 003: Verdict function (파기/파기환송/기각/각하)
+
+> **Epic**: Submission & Evaluation
+> **Status**: Complete (2026-05-23)
+> **Layer**: Feature (Gameplay) / Core
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 2h (S)
+> **Performance**: trivial (comparison only)
+
+## Context
+**GDD**: `design/gdd/submission-evaluation.md` §4.7 (verdict 결정 함수), §7.1 (thresholds)
+**Requirement**: `TR-submission-*` (verdict determination)
+**ADR Governing Implementation**: ADR-0007 §Decision (verdict thresholds global)
+**ADR Decision Summary**: verdict(player_disp, correct_disp, final_score) with thresholds pagi=0.7, low=0.3.
+**Engine**: Godot 4.6 | **Risk**: None
+**Control Manifest Rules**: thresholds global-locked; per-case override forbidden
+
+## Acceptance Criteria
+- [ ] AC (§8.3, §4.7) — verdict mapping (GDD §4.7 exact):
+  - "파기" if match AND final_score ≥ 0.7
+  - "파기환송" if match AND final_score ≥ 0.3 (and < 0.7)
+  - "기각" if NOT match AND final_score ≥ 0.3
+  - "각하" if final_score < 0.3 (regardless of match)
+- [ ] AC-19 (review BLOCKING #3) — every verdict value is reachable; deterministic boundary at exact thresholds
+
+## Implementation Notes
+Per GDD §4.7: pure function using `verdict_threshold_pagi`/`verdict_threshold_low` (story 001 loaded). Boundary: ≥ is inclusive. 파기환송·기각 share low=0.3, branch on disposition match.
+
+## Out of Scope
+- Story 002 (produces final_score), 005 (comments)
+
+## QA Test Cases
+- match+0.7→파기; match+0.69→파기환송; match+0.3→파기환송; match+0.29→각하; mismatch+0.3→기각; mismatch+0.29→각하; mismatch+0.7→기각 (mismatch never 파기). Exact-threshold boundaries deterministic.
+
+## Test Evidence
+**Story Type**: Logic | **Required**: `tests/unit/submission_evaluation/verdict_test.gd`
+**Status**: [ ] Not yet created
+
+## Dependencies
+- Depends on: Story 001 (thresholds), Story 002 (final_score)
+- Unlocks: 004 (REPORTING populates verdict)
+
+## Completion Notes
+**Completed**: 2026-05-23. 2/2 ACs. EvaluationService.determine_verdict — 파기(match&≥0.7)/파기환송(match&≥0.3)/기각(!match&≥0.3)/각하(<0.3); all 4 reachable; exact-threshold boundaries deterministic; mismatch never 파기. Tests: verdict_test.gd 8/8. Reviewed by orchestrator.

--- a/production/epics/submission-evaluation/story-004-state-machine-submit-pipeline.md
+++ b/production/epics/submission-evaluation/story-004-state-machine-submit-pipeline.md
@@ -1,7 +1,7 @@
 # Story 004: submit() 5-state machine + Validating gate + evaluation_completed
 
 > **Epic**: Submission & Evaluation
-> **Status**: Ready
+> **Status**: Complete (2026-05-23)
 > **Layer**: Feature (Gameplay) / Core
 > **Type**: Integration
 > **Manifest Version**: 2026-05-18
@@ -38,3 +38,10 @@ Per ADR-0007: state transitions guard current_state; CaseService.get_case(submis
 ## Dependencies
 - Depends on: Story 001 (Resources/autoload), 002 (scoring), 003 (verdict); LibraryService.validate_citations + CaseService.get_case (exist)
 - Unlocks: Save/Load sl-005/006 end-to-end, reasoning-workspace 007/008 submit hand-off, #10 Verdict Reveal
+
+## Completion Notes
+**Completed**: 2026-05-23. 3/3 ACs (double-submit reject AC-18, empty/invalid citation gate AC-1/2, happy-path emit AC-4/5).
+**Files**: `src/services/evaluation_service.gd` — `submit(submission: PlayerSubmission)` (IDLE→VALIDATING→COMPUTING→REPORTING→DONE→IDLE; guarded /root LibraryService.validate_citations + CaseService.get_case lookups) + `_reject` + pure `evaluate(submission, case_file)` (subscores+final_score+verdict+correct/missed/redundant sets) + set helpers. `tests/integration/submission_evaluation/submit_pipeline_test.gd` 5 tests (Library+Case fixtures loaded into autoloads).
+**Test Evidence**: submit_pipeline 5/5 PASS; full suite **425 cases / 408 executed / 17 skipped / 0 failures, exit 0**.
+**Keystone**: `EvaluationService.submit(PlayerSubmission)` now works end-to-end → unblocks the deferred Save/Load sl-005 (evaluation_completed→casebook) + sl-006 (auto-resubmit) subscriptions and reasoning-workspace 007/008 submit hand-off (those subscriber wirings live in their own stories).
+**Reviewed by orchestrator.** Remaining EvaluationService: story-005 (comment-template decision tree).

--- a/production/epics/submission-evaluation/story-004-state-machine-submit-pipeline.md
+++ b/production/epics/submission-evaluation/story-004-state-machine-submit-pipeline.md
@@ -1,0 +1,40 @@
+# Story 004: submit() 5-state machine + Validating gate + evaluation_completed
+
+> **Epic**: Submission & Evaluation
+> **Status**: Ready
+> **Layer**: Feature (Gameplay) / Core
+> **Type**: Integration
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 4h (M)
+> **Performance**: full pipeline ≤50ms (AC-21)
+
+## Context
+**GDD**: `design/gdd/submission-evaluation.md` §3.1.2 (pre-eval gate), §3.2 (states), §8.1/§8.5
+**Requirement**: `TR-submission-*` (state machine + submit pipeline + validation)
+**ADR Governing Implementation**: ADR-0007 §Decision (5-state machine, double-submit reject, validate_citations)
+**ADR Decision Summary**: `submit(submission: PlayerSubmission)` (TD-001 RESOLVED): IDLE→VALIDATING (player_citations.size()≥1 + LibraryService.validate_citations all-pass; CaseService.get_case)→COMPUTING (scoring 002 + verdict 003)→REPORTING (emit evaluation_completed)→DONE→IDLE. Double-submit (current_state != IDLE) → push_warning + ignore (AC-18).
+**Engine**: Godot 4.6 | **Risk**: None
+**Control Manifest Rules**: never start 2nd submit while in flight (`submit_during_active_evaluation` forbidden); never cache EvaluationResult by case_id (`evaluation_caching_by_case_id` forbidden)
+
+## Acceptance Criteria
+- [ ] AC-17/18 (§8.1/§8.5) — `submit()` from non-IDLE → push_warning + ignored (double-submit reject)
+- [ ] AC-1/2 (§8.1) — Validating gate: empty player_citations (size<1) → `submission_rejected("empty_citations")` (EC-1); citation failing `LibraryService.validate_citations` → `submission_rejected("invalid_citation")` (EC-2)
+- [ ] AC (§8.4/§8.5) — happy path: VALIDATING→COMPUTING→REPORTING→DONE→IDLE; emits `evaluation_completed(result)` once with populated EvaluationResult (final_score + verdict + subscores + correct/missed/redundant sets)
+
+## Implementation Notes
+Per ADR-0007: state transitions guard current_state; CaseService.get_case(submission.case_id) for correct_disposition/correct_citations/scoring_weights; LibraryService.validate_citations(player_citations) returns invalid IDs (empty=all valid). Wire scoring (002) + verdict (003) in COMPUTING. correct_set/missed_set/redundant_set from Set ops. Return to IDLE after DONE.
+
+## Out of Scope
+- Stories 002/003 (scoring/verdict functions — this wires them), 005 (comments — REPORTING may call), 001 (Resources)
+- Save/Load resolution subscription (sl-005 subscribes to evaluation_completed)
+
+## QA Test Cases
+- double-submit: 2nd submit while VALIDATING → ignored + warning. empty citations → submission_rejected. invalid citation (mock LibraryService) → submission_rejected. happy path → evaluation_completed once, state returns IDLE, result fields populated. Integration with real Library/Case fixtures.
+
+## Test Evidence
+**Story Type**: Integration | **Required**: `tests/integration/submission_evaluation/submit_pipeline_test.gd`
+**Status**: [ ] Not yet created
+
+## Dependencies
+- Depends on: Story 001 (Resources/autoload), 002 (scoring), 003 (verdict); LibraryService.validate_citations + CaseService.get_case (exist)
+- Unlocks: Save/Load sl-005/006 end-to-end, reasoning-workspace 007/008 submit hand-off, #10 Verdict Reveal

--- a/production/epics/submission-evaluation/story-005-comment-templates-decision-tree.md
+++ b/production/epics/submission-evaluation/story-005-comment-templates-decision-tree.md
@@ -1,7 +1,7 @@
 # Story 005: Comment-template decision tree + per-case-override guard
 
 > **Epic**: Submission & Evaluation
-> **Status**: Ready
+> **Status**: Complete (2026-05-23)
 > **Layer**: Feature (Gameplay) / Core
 > **Type**: Logic
 > **Manifest Version**: 2026-05-18
@@ -37,3 +37,6 @@ Per ADR-0007 + GDD §3.1.5: comment key selection is a pure decision tree per su
 ## Dependencies
 - Depends on: Story 001 (CommentTemplates), 002 (subscores drive keys)
 - Unlocks: #10 Verdict Reveal (displays comments)
+
+## Completion Notes
+**Completed**: 2026-05-23. 3/3 ACs. `EvaluationService.compute_comment_keys` (per-subscore decision tree → 7-key set, GDD §3.1.5 boundaries: disp match/miss, core high≥0.8/mid≥0.4/low, redund clean≥-0.05/bloat) + `select_comments` (key→body via CommentTemplates, absent/null graceful) + wired into `evaluate()`. `_comment_templates` empty default (assets/data/evaluation/comment_templates.tres Korean content is a separate content task). per_case_verdict_threshold_override registered (architecture.yaml line 1133). `comment_generation_test.gd` 9/9. Full suite 434/0-fail. Reviewed by orchestrator.

--- a/production/epics/submission-evaluation/story-005-comment-templates-decision-tree.md
+++ b/production/epics/submission-evaluation/story-005-comment-templates-decision-tree.md
@@ -1,0 +1,39 @@
+# Story 005: Comment-template decision tree + per-case-override guard
+
+> **Epic**: Submission & Evaluation
+> **Status**: Ready
+> **Layer**: Feature (Gameplay) / Core
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimated Effort**: 3h (M)
+> **Performance**: trivial (per-subscore key lookup)
+
+## Context
+**GDD**: `design/gdd/submission-evaluation.md` §3.1.5 (comment templates), §7.4 (comment content knob)
+**Requirement**: `TR-submission-*` (comment generation + threshold override guard)
+**ADR Governing Implementation**: ADR-0007 §Decision (CommentTemplates .tres in assets/data/evaluation/), §Risk 2 (per_case_verdict_threshold_override)
+**ADR Decision Summary**: per-subscore decision tree → template key; 한국어 본문 external (CommentTemplates Dictionary[key→String], assets/data/evaluation/comment_templates.tres). Algorithm decides WHICH key, not content.
+**Engine**: Godot 4.6 | **Risk**: None
+**Control Manifest Rules**: per_case_verdict_threshold_override forbidden (case .tres must not carry verdict_threshold_* — Pillar 1)
+
+## Acceptance Criteria
+- [ ] AC (§3.1.5) — per-subscore decision tree selects exactly one template key (e.g. disposition match/mismatch; coverage high/partial/missed-core; redundant present/absent)
+- [ ] AC (§8.4) — EvaluationResult.comments populated from CommentTemplates by selected keys (graceful if a key is absent → skip/empty, no crash)
+- [ ] AC (§Risk 2) — `per_case_verdict_threshold_override` forbidden_pattern registered (case .tres carrying verdict_threshold_* rejected/flagged)
+
+## Implementation Notes
+Per ADR-0007 + GDD §3.1.5: comment key selection is a pure decision tree per subscore; content lives in CommentTemplates Resource. MVP may ship template keys + placeholder 한국어 (content authoring later). Verify per_case_verdict_threshold_override in architecture.yaml.
+
+## Out of Scope
+- Stories 002/003/004; actual 한국어 comment content authoring (content task)
+
+## QA Test Cases
+- decision tree: disposition match→key_disp_match; mismatch→key_disp_mismatch; coverage 1.0→key_core_full, partial→key_core_partial, 0→key_core_missed; redundant→key_redundant. comments assembled from keys. absent key → no crash. per_case_verdict_threshold_override registered (registry-read test).
+
+## Test Evidence
+**Story Type**: Logic | **Required**: `tests/unit/submission_evaluation/comment_generation_test.gd`
+**Status**: [ ] Not yet created
+
+## Dependencies
+- Depends on: Story 001 (CommentTemplates), 002 (subscores drive keys)
+- Unlocks: #10 Verdict Reveal (displays comments)

--- a/production/epics/ui-foundation/EPIC.md
+++ b/production/epics/ui-foundation/EPIC.md
@@ -1,0 +1,64 @@
+# Epic: UI Foundation
+
+> **Layer**: Foundation (Core — depends only on Settings/Library autoload signals)
+> **GDD**: `design/gdd/ui-foundation.md`
+> **Architecture Module**: `UIService` autoload SECOND + `KrCustomControl` tree (21 classes per ADR-0010 §Architecture Diagram) + Theme + 17 type variations (ADR-0004 amend-1) + Kr3PaneLayout primitive + KrFreezeOverlay + Reduced Motion gateway + dual focus ring composite + `announce_text` live-region API
+> **Status**: Ready
+> **Stories**: 5 stories created 2026-05-18 — minimum-viable scope to unblock #6 Reasoning Workspace UI stories (003b/005/006/009/010/011) + #7 Brief Editor. Full 21-class KrCustomControl tree + R8 dual focus ring polish + AC-18 viewport too-small dialog deferred to follow-up cycle.
+> **Created**: 2026-05-18
+
+## Overview
+
+UI Foundation provides the cross-system UI infrastructure that all gameplay systems (#5/#6/#7/#9/#10) depend on: a Theme registry with type variations for consistent visual identity, a `KrCustomControl` base hierarchy that auto-wires Settings subscription + AccessKit roles + Reduced Motion gating, and `UIService` autoload SECOND providing animation gateway + live-region announcement + Theme runtime reload cascade.
+
+This epic implements the **minimum-viable scope** for unblocking Reasoning Workspace UI stories. Specifically: UIService autoload + Theme runtime reload + KrCustomControl base + 6 essential type variations (Pane / HypothesisNode / MemoLabel / MemoEdit / Banner / Button) + tween_property gateway + announce_text live-region API. **Deferred to follow-up cycle**: full 21-class KrCustomControl tree, R8 dual focus ring composite rendering (3 options to evaluate), Kr3PaneLayout primitive completeness (3-pane width clamp at 1280-1365 dynamic), AC-18 viewport-too-small warning dialog.
+
+## Governing ADRs
+
+| ADR | Decision Summary | Engine Risk |
+|-----|-----------------|-------------|
+| ADR-0010: UI Foundation Architecture | UIService SECOND autoload + KrCustomControl base + Theme runtime reload (VR-UI1 PASS — auto NOTIFICATION_THEME_CHANGED cascade) + Reduced Motion gateway + dual focus ring composite | LOW (VR sprint closure) |
+| ADR-0010 amend-1: KrCustomControl Role Corrections + Live-Region | 7 enum corrected mapping (KrPane → ROLE_PANEL etc.) + UIService.announce_text(source, message, priority) via DisplayServer.accessibility_update_set_live + AccessibilityLiveMode {LIVE_OFF=0, LIVE_POLITE=1, LIVE_ASSERTIVE=2} (VR-UI6 PASS) | LOW |
+| ADR-0004: Korean Text Rendering MSDF Font | 3-font family lock (본명조 court_title + Pretendard body_sans + IBM Plex Mono code_mono) | LOW |
+| ADR-0004 amend-1: Component Type Variations Expansion | 17 Theme type variations (Pane/Header/Card/HypothesisNode/MemoLabel/CommentLabel/CourtHeadline/CaptionLabel/Banner family 등) + text_scale runtime reload single-emit cascade | LOW |
+| ADR-0009: Settings Storage Format | SettingsService FIFTH autoload + reduced_motion + text_scale + focus_indicator_thickness signals (UIService subscribes) | LOW |
+| ADR-0008 amend-4: Verification Sprint FAIL Closure | AccessibilityRole corrected enum mapping (ROLE_REGION→ROLE_PANEL, etc. — runtime VR-UI6 verified 46-entry enum) | LOW |
+
+## GDD Requirements (TR-ui-*)
+
+22 TR-ui IDs in tr-registry covering Theme registration, KrCustomControl tree, Kr3PaneLayout, tween_property gateway, announce_text API, AccessKit role assignment, viewport reflow, Reduced Motion handling. All addressed by ADR-0010 + amend-1 (already covered in TR registry).
+
+Story-level decomposition focuses on minimum-viable path; remaining TR-ui (full 21-class hierarchy, R8 dashed border) deferred to follow-up stories within this epic.
+
+## Stories
+
+| # | Story | Type | Status | ADR |
+|---|-------|------|--------|-----|
+| 001 | [UIService autoload + Theme load + viewport_resized signal](story-001-ui-service-autoload.md) | Logic | Complete | ADR-0010 §Decision |
+| 002 | [KrCustomControl base + KrControlHelper](story-002-kr-custom-control-base.md) | Logic | Complete | ADR-0010 §Decision Note (composition + helper pattern) |
+| 003 | [6 essential Theme type variations + base styles](story-003-theme-type-variations.md) | Config/Data + UI | Ready | ADR-0004 + amend-1 |
+| 004 | [tween_property gateway + Reduced Motion path](story-004-tween-property-gateway.md) | Logic | Complete | ADR-0010 §Decision + §Risk R7 |
+| 005 | [announce_text live-region API + AccessKit role helper](story-005-announce-text-api.md) | Logic + Integration | Ready | ADR-0010 amend-1 §G3 + amend-4 §F1 corrected enum |
+
+## Deferred (follow-up cycle — UI Foundation v2)
+
+- Full 21-class KrCustomControl tree (currently only base + workspace-relevant subclasses)
+- R8 dual focus ring composite rendering (3 implementation options to evaluate: overlap StyleBox / `_draw()` custom dashed / shader)
+- Kr3PaneLayout full primitive (currently subset for workspace 3-pane usage)
+- KrFreezeOverlay full implementation (workspace inline usage acceptable)
+- AC-18 viewport-too-small warning dialog (low-priority — game requires 1366 floor)
+- 11 remaining Theme type variations beyond the 6 essential (Header/Card/LibraryCard/EnvelopeCard/GroundsCard/Dialog/Slider/Banner subvariants/etc.)
+- AccessKit live-region API runtime test on multiple screen readers (VoiceOver/NVDA/Orca — VR-UI6 PASS is API existence only)
+
+## Definition of Done (minimum-viable)
+
+- All 5 stories implemented + reviewed + closed via `/story-done`
+- 6 essential type variations registered + applied to test scenes
+- UIService autoload registered in `project.godot [autoload]` SECOND position
+- Workspace story-003b (KrCard scene wrapping) becomes implementable (KrCard base + theme_type_variation + tween_property + announce_text available)
+- Logic stories: passing test files in `tests/unit/ui_foundation/`
+- Integration stories (003 cascade + 005 live-region): integration tests in `tests/integration/ui_foundation/` OR manual evidence in `production/qa/evidence/`
+
+## Next Step
+
+Run `/story-readiness ui-foundation/story-001-ui-service-autoload.md` then `/dev-story` per story. Stories ordered for dependency safety: 001 → 002 → 003 (Config/Data, can parallel 002) → 004 → 005.

--- a/production/epics/ui-foundation/story-001-ui-service-autoload.md
+++ b/production/epics/ui-foundation/story-001-ui-service-autoload.md
@@ -1,0 +1,127 @@
+# Story 001: UIService autoload + Theme load + viewport_resized signal
+
+> **Epic**: UI Foundation
+> **Status**: Complete (2026-05-23)
+> **Layer**: Foundation (Core)
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimate**: 3 hours (M) — UIService autoload skeleton + Theme load (initial) + viewport_resized signal subscription + 8-10 unit tests
+> **Performance**: No expected impact — _ready() boot (< 50ms target per control-manifest), viewport_resized debounced 50ms (no per-frame allocation)
+
+## Context
+
+**GDD**: `design/gdd/ui-foundation.md` §3.1 Core Rules (UIService autoload responsibility) + §10.1 AC-1 (service initialization)
+**Requirement**: TR-ui-001 (UIService FIFTH→SECOND autoload — corrected to SECOND per ADR-0010)
+
+**ADR Governing Implementation**: ADR-0010 §Decision (UIService autoload SECOND position) + amend-1 (G3 announce_text API stub deferred to story 005)
+**ADR Decision Summary**: UIService is the Theme + Reduced Motion gateway + viewport reflow + announce_text SSOT. Autoload SECOND (after LibraryService FIRST). _ready() loads Theme, connects viewport_resized signal, exposes Theme as `UIService.theme: Theme` property for KrCustomControl base to read.
+
+**Engine**: Godot 4.6 | **Risk**: LOW
+**Engine Notes**: `get_viewport().size_changed` signal (4.0+ stable) + 50ms debounce Timer. `Theme.new()` instantiation + `Theme.set_font_size()` mutation (cascades NOTIFICATION_THEME_CHANGED automatically — VR-UI1 PASS confirmed).
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Foundation Layer Required/Forbidden/Guardrails apply
+
+## Acceptance Criteria
+
+- [x] AC-1 — UIService autoload _ready() loads Theme + connects `get_viewport().size_changed` signal + emits `ui_service_initialized()` signal (typed) — **DONE**
+- [x] AC-1.2 — `UIService.theme: Theme` property exposed as read-only (getter only — direct assignment forbidden similar to WorkspaceData state Option C) — **DONE**
+- [x] AC-1.3 — viewport_resized cascade: `get_viewport().size_changed` → debounced 50ms Timer → `viewport_reflow_needed()` typed signal emit — **DONE** (real 50ms timing verified structurally — headless Timer tick limitation noted; callback chain + coalescing covered)
+- [x] AC-1.4 — `VIEWPORT_REFLOW_DEBOUNCE_MS` constant = 50 (from GDD §7.1) — **DONE**
+- [x] AC-1.5 — UIService is a Node-derived autoload (not Resource — needs scene tree access for viewport signals) — **DONE**
+- [x] AC-1.6 — Theme is initially empty (type variations populated by story 003; this story registers an empty Theme + cascade infrastructure) — **DONE**
+- [x] AC-1.7 — Test: autoload spawns, _ready completes, theme is Theme instance, viewport_reflow_needed signal exists — **DONE** (`ui_service_test.gd` 12/12 PASS)
+
+## Implementation Notes
+
+Per ADR-0010 §Decision:
+
+```gdscript
+## UIService — autoload SECOND. Theme + Reduced Motion gateway + announce_text SSOT.
+##
+## Story 001 scope: Theme instance + viewport_resized signal + ui_service_initialized signal.
+## Stories 003/004/005 populate Theme variations, add tween_property gateway, announce_text API.
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md
+class_name UIServiceClass extends Node
+
+const VIEWPORT_REFLOW_DEBOUNCE_MS := 50
+
+signal ui_service_initialized()
+signal viewport_reflow_needed()
+
+var _theme: Theme = Theme.new()
+var _viewport_debounce_timer: Timer
+
+var theme: Theme:
+    get: return _theme
+    set(value): push_error("UIService.theme is read-only. Use Theme.set_font_size/set_color via UIService methods.")
+
+func _ready() -> void:
+    _viewport_debounce_timer = Timer.new()
+    _viewport_debounce_timer.wait_time = VIEWPORT_REFLOW_DEBOUNCE_MS / 1000.0
+    _viewport_debounce_timer.one_shot = true
+    _viewport_debounce_timer.timeout.connect(_on_viewport_debounce_timeout)
+    add_child(_viewport_debounce_timer)
+    get_viewport().size_changed.connect(_on_viewport_size_changed)
+    ui_service_initialized.emit()
+
+func _on_viewport_size_changed() -> void:
+    _viewport_debounce_timer.start()
+
+func _on_viewport_debounce_timeout() -> void:
+    viewport_reflow_needed.emit()
+```
+
+**Autoload registration**: `project.godot [autoload]` add `UIService="*res://src/ui/ui_service.gd"` SECOND position (after `LibraryService`, before `CaseService`).
+
+**File path**: `src/ui/ui_service.gd` (NEW directory — first UI Foundation file).
+
+## Out of Scope (deferred to later stories)
+
+- Story 002: KrCustomControl base + KrControlHelper
+- Story 003: 6 essential type variations (`&"Pane"` / `&"HypothesisNode"` / `&"MemoLabel"` / `&"MemoEdit"` / `&"Banner"` / `&"Button"`)
+- Story 004: tween_property gateway + Reduced Motion path
+- Story 005: announce_text API + AccessKit role helper
+- AC-2 text_scale cascade (story 003 implements Theme runtime reload)
+- AC-3/AC-4 Kr3PaneLayout (deferred — minimum-viable scope)
+- AC-11/12 AccessKit verification gate (story 005)
+- AC-15/16 tween_property tests (story 004)
+
+## QA Test Cases
+
+- **AC-1**: After autoload `_ready()`, assert `ui_service_initialized` signal fired once + `UIService.theme is Theme` true
+- **AC-1.2**: `UIService.theme = Theme.new()` direct assignment → push_error fires, `theme` reference unchanged
+- **AC-1.3**: Resize window programmatically (or fire `get_viewport().size_changed` mock) → wait 60ms → assert `viewport_reflow_needed` fired exactly once
+- **AC-1.3-debounce**: Fire `size_changed` 3 times within 30ms → wait 60ms → assert `viewport_reflow_needed` fired exactly once (debounce coalescing)
+- **AC-1.4**: Inspect `UIServiceClass.VIEWPORT_REFLOW_DEBOUNCE_MS` constant == 50
+- **AC-1.5**: `UIService extends Node` (not Resource) — `is_node()` true
+- **AC-1.6**: `UIService.theme.get_type_variation_list("Label")` returns empty array initially (no variations registered yet)
+- **AC-1.7**: Run full test — see all above pass
+
+Edge cases: ui_service_initialized fires before scene Controls _ready() complete (autoload ordering — UIService SECOND), multiple size_changed during debounce window.
+
+## Test Evidence
+
+**Story Type**: Logic
+**Required**: `tests/unit/ui_foundation/ui_service_test.gd` — gdunit4 v5.x (BLOCKING gate per control-manifest)
+
+**Status**: [ ] Not yet created
+
+## Dependencies
+
+- Depends on: None (Foundation layer entry point)
+- Unlocks: Stories 002/003/004/005 (all UI Foundation epic stories) + workspace 003b (HypothesisNode KrCard scene wrapping needs UIService.theme + signals)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23
+**Criteria**: 7/7 passing (AC-1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7).
+**Files**:
+- `src/ui/ui_service.gd` — `class_name UIServiceClass extends Node` (autoload name-collision avoidance), Theme + viewport debounce + `ui_service_initialized`/`viewport_reflow_needed` signals, read-only `theme` property (Option C guard). **Pre-existing from an earlier session.**
+- `project.godot` — `UIService` autoload SECOND (after LibraryService, before CaseService). Pre-existing.
+- `tests/unit/ui_foundation/ui_service_test.gd` — 12 tests.
+**Bug fixed this session**: `test_debounce_timeout_callback_emits_viewport_reflow_needed` used a plain `int` counter inside a signal-callback lambda — GDScript captures primitives BY VALUE, so the outer counter stayed 0 and the test failed deterministically (the story had been left in Ready with this broken test). Fixed to the Array-accumulator pattern (documented in freeze_contract_test.gd header). Now 12/12 PASS.
+**Test Evidence**: `tests/unit/ui_foundation/ui_service_test.gd` — 12/12 PASS, exit 0.
+**Note on AC-1.3**: real 50ms debounce wall-clock timing is verified structurally (timer.start resets time_left, callback chain emits) rather than by awaiting the real timer — headless gdunit4 Timer-tick limitation, documented in the test file. Acceptable for a Logic story; real-timing belongs to an integration/manual pass.
+**Code Review**: Production code pre-existing (reviewed when authored); this session's change is a one-line documented-pattern test fix — formal /code-review skipped per triviality.

--- a/production/epics/ui-foundation/story-002-kr-custom-control-base.md
+++ b/production/epics/ui-foundation/story-002-kr-custom-control-base.md
@@ -1,0 +1,97 @@
+# Story 002: KrCustomControl base + KrControlHelper
+
+> **Epic**: UI Foundation
+> **Status**: Complete (2026-05-23)
+> **Layer**: Foundation (Core)
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimate**: 3 hours (M) — KrControlHelper static helper + 4 minimal Kr* subclasses (KrPane / KrCard / KrButton / KrBanner) + base lifecycle test
+> **Performance**: No expected impact — _ready() one-time setup + signal connect; no per-frame cost
+
+## Context
+
+**GDD**: `design/gdd/ui-foundation.md` §3.1 Core Rules (KrCustomControl tree) + §10.2 AC-5/AC-7
+**Requirement**: TR-ui-005 (KrCustomControl base composition pattern)
+**ADR**: ADR-0010 §Decision Note (composition + static helper pattern — godot-specialist 2026-05-17 redefine to bypass GDScript multiple-inheritance)
+**Engine**: Godot 4.6 | **Risk**: LOW
+
+**Control Manifest Rules**: see `docs/architecture/control-manifest.md` v2026-05-18 — Foundation Layer
+
+## Acceptance Criteria
+
+- [x] AC-5 — KrCustomControl subclass `_ready()` calls `KrControlHelper.setup(self)` which (a) guards SettingsService 3-signal subscription (stub — skips if singleton absent), (b) calls `Control.queue_accessibility_update()`; subclass applies role in `_notification(NOTIFICATION_ACCESSIBILITY_UPDATE)` → `_apply_access_kit_role()` — **DONE** (see API deviation in Completion Notes)
+- [x] AC-7 — `custom_control_outside_kr_hierarchy` forbidden_pattern registered in architecture.yaml — **DONE** (automated registry-read test, confirmed line 1851)
+- [x] KrPane (Container) + KrCard (PanelContainer) + KrButton (Button) + KrBanner (PanelContainer) — 4 subclass scaffolds with `_apply_access_kit_role()` override + `theme_type_variation` + `ACCESSIBILITY_ROLE` constant — **DONE**
+- [x] `KrControlHelper.setup(control)` static method tested independently — **DONE**
+- [x] AC-7 verification — automated `architecture.yaml` registry-read assertion — **DONE**
+
+## Implementation Notes
+
+Per ADR-0010 §Decision Note (composition + static helper pattern):
+
+```gdscript
+# src/ui/kr_control_helper.gd
+class_name KrControlHelper
+
+static func setup(control: Control) -> void:
+    if Engine.has_singleton("SettingsService"):
+        # SettingsService 3 signals — auto subscribe (stub for story 002; real subscriber wiring in workspace 009)
+        pass
+    if control.has_method("_apply_access_kit_role"):
+        control._apply_access_kit_role()
+
+# src/ui/kr_pane.gd
+class_name KrPane extends Container
+
+func _ready() -> void:
+    theme_type_variation = &"Pane"
+    KrControlHelper.setup(self)
+
+func _apply_access_kit_role() -> void:
+    accessibility_role = AccessibilityRole.ROLE_PANEL  # =6 per amend-4 §F1
+```
+
+Similarly for KrCard (ROLE_PANEL), KrButton (ROLE_BUTTON=7), KrBanner (ROLE_STATIC_TEXT=4).
+
+**SettingsService subscription**: stub for story-002 (real wiring is story 005 + workspace 009). Just check `Engine.has_singleton("SettingsService")` and skip if absent (test fixtures don't load full autoload chain).
+
+## Out of Scope
+
+- Full 17 Kr* subclasses (only 4 essentials for now: Pane / Card / Button / Banner)
+- Theme type variations content (story 003)
+- announce_text API (story 005)
+- Dual focus ring composite (R8 — deferred to follow-up)
+
+## QA Test Cases
+
+- **AC-5**: Instantiate KrPane in scene, assert `theme_type_variation == &"Pane"` + `accessibility_role == ROLE_PANEL` after _ready()
+- **AC-5-no-singleton**: KrControlHelper.setup with SettingsService absent → no error
+- **AC-7-registry**: grep architecture.yaml for `custom_control_outside_kr_hierarchy` → found (already registered per control-manifest)
+- Per-subclass tests: KrCard / KrButton / KrBanner each instantiate + correct role
+- KrControlHelper static method directly callable
+
+## Test Evidence
+
+**Required**: `tests/unit/ui_foundation/kr_custom_control_test.gd`
+**Status**: [ ] Not yet created
+
+## Dependencies
+
+- Depends on: Story 001 (UIService autoload — KrControlHelper may reference UIService.theme in future stories)
+- Unlocks: Story 003 (Theme variations use these Kr* classes) + workspace 003b (KrCard scene wrapping uses KrCard base)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23
+**Criteria**: 5/5 passing.
+**Files created**:
+- `src/ui/kr_control_helper.gd` — `class_name KrControlHelper extends RefCounted`, static `setup(control)` (SettingsService guard + `queue_accessibility_update()`)
+- `src/ui/kr_pane.gd` (Container, ROLE_PANEL=6), `src/ui/kr_card.gd` (PanelContainer, ROLE_PANEL=6), `src/ui/kr_button.gd` (Button, ROLE_BUTTON=7), `src/ui/kr_banner.gd` (PanelContainer, ROLE_STATIC_TEXT=4) — each: `_ready()` (theme_type_variation + setup) + `_notification(NOTIFICATION_ACCESSIBILITY_UPDATE)` + `_apply_access_kit_role()` + `ACCESSIBILITY_ROLE` const
+- `tests/unit/ui_foundation/kr_custom_control_test.gd` (17 tests)
+**Test Evidence**: ui_foundation suite 29/29 PASS, exit 0 (independently re-run).
+**⚠️ ENGINE API DEVIATION (important)**: The story pseudo-code used `accessibility_role = AccessibilityRole.ROLE_PANEL` (property assignment). Runtime investigation found **Godot 4.6 Control has no `accessibility_role` property and no `set_accessibility_role()` method** — despite `docs/engine-reference/godot/modules/ui.md` line 94 claiming "set via `Control.set_accessibility_role()`". The working API is `DisplayServer.accessibility_update_set_role(rid, role)` where `rid = get_accessibility_element()`, called **inside `NOTIFICATION_ACCESSIBILITY_UPDATE` (=3000)** — calling it elsewhere errors. Hence the `_ready()→queue_accessibility_update()` + `_notification()→_apply_access_kit_role()` pattern. The intended role int is exposed as `ACCESSIBILITY_ROLE` const for headless testability (live RID unavailable headless). **ui.md line 94 discrepancy logged as TD-003 for source verification.**
+**Implementation notes**:
+- Composition + static-helper pattern (ADR-0010 §Decision Note) — Kr* classes extend native Control types directly, share behavior via KrControlHelper; NO common base class (GDScript has no multiple inheritance).
+- SettingsService 3-signal subscription is a stub (guarded by `Engine.has_singleton`) — real wiring deferred to story 005 / workspace 009.
+**Code Review**: Performed by orchestrator via direct full-file inspection (agent was interrupted mid-migration leaving `kr_banner.gd` on the old `_ready`-dispatch pattern without `_notification` — would have silently never applied its role at runtime; orchestrator fixed banner to the canonical `_notification` pattern + corrected stale/misleading test comments + a misleadingly-named test). No separate review agent spawned.

--- a/production/epics/ui-foundation/story-003-theme-type-variations.md
+++ b/production/epics/ui-foundation/story-003-theme-type-variations.md
@@ -1,0 +1,99 @@
+# Story 003: 6 essential Theme type variations + base styles
+
+> **Epic**: UI Foundation
+> **Status**: Ready
+> **Layer**: Foundation (Core)
+> **Type**: Config/Data + UI
+> **Manifest Version**: 2026-05-18
+> **Estimate**: 2 hours (S-M) — register 6 type variations on UIService.theme + base StyleBox/font/color values per Art Bible + cascade test (text_scale changes propagate to KrCustomControl labels)
+> **Performance**: text_scale cascade < 50ms per control-manifest guardrail (VR-UI1 PASS — automatic NOTIFICATION_THEME_CHANGED)
+
+## Context
+
+**GDD**: `design/gdd/ui-foundation.md` §3.1 + §10.3 AC-2/AC-8 (text_scale cascade)
+**Requirement**: TR-ui-002 (Theme type variations) + TR-ui-007 (text_scale cascade)
+**ADR**: ADR-0004 + amend-1 (17 type variations) — implementing 6 essential subset for workspace
+**Engine**: Godot 4.6 | **Risk**: LOW (VR-UI1 PASS confirmed Theme cascade)
+
+## Acceptance Criteria
+
+- [ ] 6 type variations registered on UIService.theme (in UIService._ready() or dedicated method called from _ready()):
+  - `&"Pane"` (Container — Pane bg color + padding)
+  - `&"HypothesisNode"` (PanelContainer — KrCard variant — 200×48 hero shape)
+  - `&"MemoLabel"` (Label — body_sans font + base font_size 14)
+  - `&"MemoEdit"` (TextEdit — code_mono or body_sans font + 14)
+  - `&"Banner"` (PanelContainer — 32px height + ink-black bg + white text)
+  - `&"Button"` (Button — base button styling)
+- [ ] AC-2 — `UIService.set_text_scale(scale: float)` method: calls `theme.set_font_size(...)` for each registered variation with `base_size × scale`. NOTIFICATION_THEME_CHANGED auto-cascades.
+- [ ] AC-8 — text_scale cascade: KrCustomControl subclass instances (story 002 KrPane / KrButton / KrBanner + a test KrLabel) auto-reflow when text_scale changes (verify via NOTIFICATION_THEME_CHANGED handler firing)
+- [ ] Base font_size constants (`PANE_FONT_SIZE = 14`, `HEADER_FONT_SIZE = 24`, etc.) defined in UIService for centralized tuning
+- [ ] No inline `theme_override_*` properties (forbidden_pattern `inline_theme_override_without_type_variation`)
+
+## Implementation Notes
+
+Per ADR-0004 amend-1 + ADR-0010:
+
+```gdscript
+# Add to UIService
+const BASE_FONT_SIZE_BODY := 14   # MemoLabel, MemoEdit, Button base
+const BASE_FONT_SIZE_HEADER := 24  # CourtHeadline (future)
+const HYPOTHESIS_NODE_SIZE := Vector2(200, 48)
+
+func _register_type_variations() -> void:
+    # Pane
+    var pane_style := StyleBoxFlat.new()
+    pane_style.bg_color = Color(0.96, 0.95, 0.92)  # 판결지 #F5F2EC
+    pane_style.set_content_margin_all(16)
+    _theme.set_stylebox(&"panel", &"Pane", pane_style)
+    
+    # HypothesisNode (KrCard variant)
+    var hypothesis_style := pane_style.duplicate()
+    hypothesis_style.set_content_margin_all(8)
+    _theme.set_stylebox(&"panel", &"HypothesisNode", hypothesis_style)
+    
+    # MemoLabel / MemoEdit
+    _theme.set_font_size(&"font_size", &"MemoLabel", BASE_FONT_SIZE_BODY)
+    _theme.set_font_size(&"font_size", &"MemoEdit", BASE_FONT_SIZE_BODY)
+    
+    # Banner — ink-black bg
+    var banner_style := StyleBoxFlat.new()
+    banner_style.bg_color = Color(0.06, 0.06, 0.06)
+    _theme.set_stylebox(&"panel", &"Banner", banner_style)
+    
+    # Button — base
+    _theme.set_font_size(&"font_size", &"Button", BASE_FONT_SIZE_BODY)
+
+func set_text_scale(scale: float) -> void:
+    _theme.set_font_size(&"font_size", &"MemoLabel", int(BASE_FONT_SIZE_BODY * scale))
+    _theme.set_font_size(&"font_size", &"MemoEdit", int(BASE_FONT_SIZE_BODY * scale))
+    _theme.set_font_size(&"font_size", &"Button", int(BASE_FONT_SIZE_BODY * scale))
+    # NOTIFICATION_THEME_CHANGED cascades automatically (VR-UI1 PASS)
+```
+
+Add `_register_type_variations()` call to UIService `_ready()` (after Timer setup).
+
+Font resources: use Godot default for now (full court_title MSDF + Pretendard + IBM Plex Mono integration deferred to art-director asset pipeline). 6 essential variations work with system default fonts.
+
+## Out of Scope
+
+- Full 17 type variations (Header / Card / LibraryCard / EnvelopeCard / GroundsCard / Dialog / Slider / Banner subvariants) — follow-up
+- MSDF font asset integration (`assets/fonts/court_title.tres` etc.) — art-director pipeline
+- text_scale + Reduced Motion cross-cutting (story 004 owns Reduced Motion)
+- Per-screen visual polish (workspace 011)
+
+## QA Test Cases
+
+- 6 type variations registered: `_theme.has_stylebox(&"panel", &"Pane")` true etc. for each
+- AC-2: `UIService.set_text_scale(1.5)` → `theme.get_font_size(&"font_size", &"MemoLabel") == 21` (14 × 1.5)
+- AC-8 cascade: KrPane instance + MemoLabel child; call `set_text_scale(1.5)`; assert MemoLabel `_notification(NOTIFICATION_THEME_CHANGED)` fires (use NotifyingLabel helper from VR-UI1 prototype pattern)
+- No inline override: grep src/ui/ for `add_theme_*_override` calls → 0 hits (or only in test fixtures)
+
+## Test Evidence
+
+**Required**: `tests/unit/ui_foundation/theme_variations_test.gd` (Logic portion) + `production/qa/evidence/ui_theme_cascade-evidence.md` (UI portion — screenshot at text_scale 1.0 / 1.5 / 2.0)
+**Status**: [ ] Not yet created
+
+## Dependencies
+
+- Depends on: Story 001 (UIService autoload + theme instance), Story 002 (KrPane / KrCard / KrButton / KrBanner subclasses for cascade test)
+- Unlocks: workspace stories that use these 6 variations (003b HypothesisNode / 005 MemoPanel / 008 ReadOnlyIndicator / 011 visual polish)

--- a/production/epics/ui-foundation/story-004-tween-property-gateway.md
+++ b/production/epics/ui-foundation/story-004-tween-property-gateway.md
@@ -1,0 +1,83 @@
+# Story 004: tween_property gateway + Reduced Motion path
+
+> **Epic**: UI Foundation
+> **Status**: Complete (2026-05-23)
+> **Layer**: Foundation (Core)
+> **Type**: Logic
+> **Manifest Version**: 2026-05-18
+> **Estimate**: 2 hours (S) — tween_property method + Reduced Motion check + ~8 unit tests
+> **Performance**: tween_property call < 0.5ms per call; 0 allocation when Reduced Motion (skips Tween creation)
+
+## Context
+
+**GDD**: `design/gdd/ui-foundation.md` §10.5 AC-10/15/16
+**Requirement**: TR-ui-010 (Reduced Motion gateway)
+**ADR**: ADR-0010 §Decision + §Risk R7 + forbidden_pattern `direct_create_tween_bypassing_reduced_motion`
+**Engine**: Godot 4.6 | **Risk**: LOW
+
+## Acceptance Criteria
+
+- [x] AC-15 — `UIService.tween_property(target, property, final_value, duration) -> Tween` with Reduced Motion = false: creates Tween + chains tween_property + returns Tween — **DONE**
+- [x] AC-16 — Reduced Motion = true: returns `null` + immediately `target.set_indexed(property, final_value)` — **DONE**
+- [x] AC-10 — Reduced Motion read via settable `UIService.reduced_motion` state field (default false; SettingsService signal wires it in story 005/009) — **DONE** (design improvement over story pseudo-code — see Completion Notes)
+- [x] All callers use this gateway; direct `create_tween()` forbidden — **DONE** (forbidden_pattern `direct_create_tween_bypassing_reduced_motion` verified in architecture.yaml line 1866 via automated registry-read test)
+
+## Implementation Notes
+
+Per ADR-0010 §Decision:
+
+```gdscript
+# Add to UIService
+func tween_property(
+    target: Object,
+    property: NodePath,
+    final_value: Variant,
+    duration: float
+) -> Tween:
+    if _is_reduced_motion():
+        target.set_indexed(property, final_value)
+        return null
+    var tween := create_tween()
+    tween.tween_property(target, property, final_value, duration)
+    return tween
+
+func _is_reduced_motion() -> bool:
+    if Engine.has_singleton("SettingsService"):
+        return SettingsService.get("display.reduced_motion", false)
+    return false
+```
+
+## Out of Scope
+
+- Real SettingsService.get subscription wiring (story 005 + workspace 009)
+- Easing curve / transition type customization (use default LINEAR/ease for now)
+- Tween parallel composition (callers can chain via returned Tween)
+
+## QA Test Cases
+
+- **AC-15**: target Node with `modulate.a = 0.0`, call `UIService.tween_property(node, "modulate:a", 1.0, 0.15)` with no SettingsService → returns Tween, after 0.2s `node.modulate.a == 1.0`
+- **AC-16**: Mock SettingsService.get returns true for `display.reduced_motion` → call same → returns `null`, `node.modulate.a == 1.0` immediately
+- **AC-10**: Without SettingsService (test fixture), `_is_reduced_motion()` returns false (safe default)
+- Edge: target null → push_error (Godot will fault anyway, but graceful behavior preferred)
+
+## Test Evidence
+
+**Required**: `tests/unit/ui_foundation/tween_property_test.gd`
+**Status**: [ ] Not yet created
+
+## Dependencies
+
+- Depends on: Story 001 (UIService autoload)
+- Unlocks: workspace stories using animation (005 MemoPanel fade / 006 Camera2D auto-center / 011 visual polish) + 005 (announce_text uses similar gateway pattern)
+
+---
+
+## Completion Notes
+**Completed**: 2026-05-23
+**Criteria**: 4/4 passing (AC-15, AC-16, AC-10, forbidden-pattern gate).
+**Files**:
+- `src/ui/ui_service.gd` — added `var reduced_motion: bool = false` + `tween_property(target, property, final_value, duration) -> Tween` (+ null-target guard).
+- `tests/unit/ui_foundation/tween_property_test.gd` — 7 tests.
+**Test Evidence**: tween_property_test 7/7 PASS, exit 0 (incl. real-timing interpolation — Tween advances correctly in gdunit4, unlike the headless Timer-tick limitation noted for the viewport debounce).
+**Deviation from story pseudo-code (design improvement)**: The story queried `Engine.has_singleton("SettingsService")` + `SettingsService.get("display.reduced_motion", false)` synchronously per call. Two problems: (1) autoloads are scene-tree nodes at `/root`, NOT Engine singletons — `Engine.has_singleton` is an unreliable presence check for them (empirically false for the LibraryService autoload); (2) `Object.get()` is single-arg (no default param). Replaced with a settable `reduced_motion` state field that the SettingsService `display.reduced_motion` signal subscription sets (story 005/009). This is correct, testable (tests set the field directly to drive AC-16), zero per-call lookup, and is the exact integration seam story 005/009 needs. The same `Engine.has_singleton` questionable pattern exists in `kr_control_helper.gd` (story-002) as a no-op stub — flagged for story 005/009 to resolve when wiring real SettingsService.
+**Code Review**: Implemented + reviewed directly by orchestrator (small Logic story, well-known Tween API; sub-agent delegation skipped this session due to repeated agent message-truncation requiring heavy cleanup). Tween API (`create_tween`/`tween_property`) verified against engine-reference (modules/audio.md). forbidden_pattern existence verified pre-implementation (architecture.yaml line 1866).

--- a/production/epics/ui-foundation/story-005-announce-text-api.md
+++ b/production/epics/ui-foundation/story-005-announce-text-api.md
@@ -1,0 +1,92 @@
+# Story 005: announce_text live-region API + AccessKit role helper
+
+> **Epic**: UI Foundation
+> **Status**: Ready
+> **Layer**: Foundation (Core)
+> **Type**: Logic + Integration
+> **Manifest Version**: 2026-05-18
+> **Estimate**: 3 hours (M) — announce_text API + AnnouncePriority enum + AccessKit role static helper + ~10 unit tests
+> **Performance**: < 0.5ms per announce_text call (single DisplayServer API call); negligible
+
+## Context
+
+**GDD**: `design/gdd/ui-foundation.md` §10.4 AC-11/12/13/14 (AccessKit + Focus)
+**Requirement**: TR-ui-014 (announce_text) + TR-ui-013 (AccessKit role assignment)
+**ADR**: ADR-0010 amend-1 §G3 (UIService.announce_text via DisplayServer.accessibility_update_set_live, VR-UI6 PASS path) + amend-4 §F1 (46-entry AccessibilityRole corrected mapping)
+**Engine**: Godot 4.6 | **Risk**: LOW (VR-UI6 PASS — DisplayServer.accessibility_update_set_live + AccessibilityLiveMode runtime confirmed)
+
+## Acceptance Criteria
+
+- [ ] AC-11 — `UIService.announce_text(source: Control, message: String, priority: AnnouncePriority)` calls `DisplayServer.accessibility_update_set_live(rid, mode)` + `accessibility_update_set_name(rid, message)`
+- [ ] AC-11.2 — AnnouncePriority enum: `POLITE = 0, ASSERTIVE = 1` mapping to `DisplayServer.LIVE_POLITE = 1, LIVE_ASSERTIVE = 2`
+- [ ] AC-11.3 — source Control with no accessibility element → push_warning + no-op (graceful)
+- [ ] AC-11.4 — `_map_priority(AnnouncePriority) -> int` returns correct DisplayServer enum (POLITE→1, ASSERTIVE→2, default→LIVE_OFF=0)
+- [ ] AC-14 — `KrAccessKitHelper.apply_role(control: Control, role: int)` static helper sets `control.accessibility_role = role` + asserts role is in valid range (0..45 per VR-UI6 enum dump)
+- [ ] AC-14.2 — `KrAccessKitHelper.is_valid_role(role: int)` returns true for role in 0..45, false otherwise
+
+## Implementation Notes
+
+Per ADR-0010 amend-1 §G3 (VR-UI6 PASS path — focus-shift fallback UNUSED):
+
+```gdscript
+# Add to UIService
+enum AnnouncePriority { POLITE, ASSERTIVE }
+
+func announce_text(source: Control, message: String, priority: AnnouncePriority = AnnouncePriority.POLITE) -> void:
+    if source == null:
+        push_warning("UIService.announce_text: source Control is null — skipped")
+        return
+    var rid: RID = source.get_accessibility_element()
+    if not rid.is_valid():
+        push_warning("UIService.announce_text: source has no AccessKit element — skipped")
+        return
+    DisplayServer.accessibility_update_set_live(rid, _map_priority(priority))
+    DisplayServer.accessibility_update_set_name(rid, message)
+
+func _map_priority(p: AnnouncePriority) -> int:
+    match p:
+        AnnouncePriority.POLITE:    return DisplayServer.LIVE_POLITE     # = 1
+        AnnouncePriority.ASSERTIVE: return DisplayServer.LIVE_ASSERTIVE  # = 2
+        _:                          return DisplayServer.LIVE_OFF        # = 0
+```
+
+```gdscript
+# src/ui/kr_access_kit_helper.gd
+class_name KrAccessKitHelper
+
+const MIN_ROLE := 0   # ROLE_UNKNOWN
+const MAX_ROLE := 45  # ROLE_TOOLTIP (per VR-UI6 46-entry enum dump)
+
+static func apply_role(control: Control, role: int) -> void:
+    if not is_valid_role(role):
+        push_error("KrAccessKitHelper.apply_role: invalid role %d (must be 0..%d)" % [role, MAX_ROLE])
+        return
+    control.accessibility_role = role
+
+static func is_valid_role(role: int) -> bool:
+    return role >= MIN_ROLE and role <= MAX_ROLE
+```
+
+## Out of Scope
+
+- AC-12 (AccessKit verification gate fail mode) — defer, requires Godot project-level AccessKit init check (lower-priority MVP)
+- AC-13 KrButton focus visual ring (R8 dual focus composite — deferred follow-up)
+- Real screen reader integration tests (VoiceOver / NVDA / Orca — manual evidence portion deferred)
+
+## QA Test Cases
+
+- **AC-11**: Mock Control with valid accessibility_element RID → call announce_text → assert DisplayServer.accessibility_update_set_live + set_name called via test instrumentation (or verify RID state)
+- **AC-11.3**: null source → push_warning + no API call
+- **AC-11.4**: `_map_priority(POLITE) == DisplayServer.LIVE_POLITE` (1) + `_map_priority(ASSERTIVE) == DisplayServer.LIVE_ASSERTIVE` (2)
+- **AC-14**: `KrAccessKitHelper.apply_role(control, 28)` (ROLE_TREE_ITEM) → `control.accessibility_role == 28`
+- **AC-14.2**: `is_valid_role(-1)` false, `is_valid_role(46)` false, `is_valid_role(0)` true, `is_valid_role(45)` true
+
+## Test Evidence
+
+**Required**: `tests/unit/ui_foundation/announce_text_test.gd` + `tests/unit/ui_foundation/access_kit_helper_test.gd`
+**Status**: [ ] Not yet created
+
+## Dependencies
+
+- Depends on: Story 001 (UIService autoload), Story 002 (KrCustomControl subclasses can use KrAccessKitHelper.apply_role)
+- Unlocks: workspace 008 (ReadOnlyIndicator + CriticalBanner announce) + 010 (AccessKit role audit) + workspace 003b (KrCard scene wrapping uses KrAccessKitHelper)

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,26 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="파기"
+run/main_scene="uid://d10jap5a2mlws"
+config/features=PackedStringArray("4.6", "Forward Plus")
+
+[autoload]
+
+LibraryService="*res://src/data/library_service.gd"
+UIService="*res://src/ui/ui_service.gd"
+CaseService="*res://src/data/case_service.gd"
+SaveLoadService="*res://src/services/save_load_service.gd"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")

--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,7 @@ config/features=PackedStringArray("4.6", "Forward Plus")
 LibraryService="*res://src/data/library_service.gd"
 UIService="*res://src/ui/ui_service.gd"
 CaseService="*res://src/data/case_service.gd"
+EvaluationService="*res://src/services/evaluation_service.gd"
 SaveLoadService="*res://src/services/save_load_service.gd"
 
 [editor_plugins]

--- a/src/data/active_case_save_data.gd
+++ b/src/data/active_case_save_data.gd
@@ -1,0 +1,32 @@
+## ActiveCaseSaveData — the single in-progress case snapshot.
+##
+## Wraps the live [WorkspaceData] (chain_data snapshot + state) and the
+## BriefEditorData (grounds/memo/citations + state) for the one case currently being
+## worked. Persisted as `user://saves/active_case.tres` via the debounced autosave
+## (story 003) and deleted on resolution (story 005, anti-save-scumming).
+##
+## [b]Note on [member brief_editor_data][/b]: the concrete `BriefEditorData` class is
+## owned by the Brief Editor epic (ADR-0001 amend-2) and does not exist yet — the field
+## is typed as [Resource] until that class lands, then it can be tightened.
+##
+## [member save_file_version] participates in the schema-migration framework (ADR-0011):
+## a loaded snapshot with a version higher than
+## [code]SaveLoadServiceClass.CURRENT_SAVE_FILE_VERSION[/code] is treated as corruption
+## (story 004 recovery cascade).
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+class_name ActiveCaseSaveData extends Resource
+
+## On-disk schema version for this Resource (ADR-0011 migration framework).
+@export var save_file_version: int = 1
+
+## Canonical identifier of the active case (e.g. "case:2026-001").
+@export var case_id: String = ""
+
+## Reasoning Workspace state snapshot (chain_data_snapshot + 4-state machine).
+@export var workspace_data: WorkspaceData = null
+
+## Brief Editor state snapshot. Typed loosely as [Resource] until the
+## `BriefEditorData` class exists (Brief Editor epic / ADR-0001 amend-2).
+@export var brief_editor_data: Resource = null

--- a/src/data/career_data.gd
+++ b/src/data/career_data.gd
@@ -1,0 +1,21 @@
+## CareerData — career progression state (MVP placeholder).
+##
+## Owned at the design level by #11 Career Progression; Save/Load only provides the
+## serialization infrastructure (ADR-0011 §Enables). MVP stores the completed-case ID
+## list + a reputation scalar (#12 Reputation Alpha). Persisted as
+## `user://saves/career.tres`.
+##
+## [member save_file_version] participates in the schema-migration framework (ADR-0011).
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+class_name CareerData extends Resource
+
+## On-disk schema version for this Resource (ADR-0011 migration framework).
+@export var save_file_version: int = 1
+
+## Canonical IDs of all completed (Resolved) cases.
+@export var completed_case_ids: Array[String] = []
+
+## Reputation score (#12 Reputation Alpha — MVP placeholder).
+@export var reputation: float = 0.0

--- a/src/data/casebook.gd
+++ b/src/data/casebook.gd
@@ -1,0 +1,18 @@
+## Casebook — the lawyer's archive of all Resolved cases.
+##
+## Eager-loaded at boot (story 004) and appended to by the resolution cascade
+## (story 005). Persisted as `user://saves/casebook.tres`. Consumed by #11 Career
+## and #14 Retrospective Replay.
+##
+## [member save_file_version] participates in the schema-migration framework
+## (ADR-0011). Nested [CasebookEntry] resources are serialized inline.
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+class_name Casebook extends Resource
+
+## On-disk schema version for this Resource (ADR-0011 migration framework).
+@export var save_file_version: int = 1
+
+## All archived Resolved cases, in insertion (resolution) order.
+@export var entries: Array[CasebookEntry] = []

--- a/src/data/casebook_entry.gd
+++ b/src/data/casebook_entry.gd
@@ -1,0 +1,25 @@
+## CasebookEntry — one Resolved case preserved in the casebook.
+##
+## Written by the resolution cascade (story 005) when an `evaluation_completed`
+## arrives: the case's verdict + final score are archived here and appended to
+## [Casebook]. Read-only afterward (Pillar 1 — Resolved cases cannot be reverted).
+##
+## [member save_file_version] participates in the schema-migration framework
+## (ADR-0011): a loaded entry with a version higher than
+## [code]SaveLoadServiceClass.CURRENT_SAVE_FILE_VERSION[/code] is treated as corruption.
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+class_name CasebookEntry extends Resource
+
+## On-disk schema version for this Resource (ADR-0011 migration framework).
+@export var save_file_version: int = 1
+
+## Canonical case identifier (e.g. "case:2026-001").
+@export var case_id: String = ""
+
+## The court disposition verdict (library_dispositions_court enum member, as String).
+@export var verdict: String = ""
+
+## Final evaluation score in [code][0.0, 1.0][/code].
+@export var final_score: float = 0.0

--- a/src/data/comment_templates.gd
+++ b/src/data/comment_templates.gd
@@ -1,0 +1,11 @@
+## CommentTemplates — externalized Korean comment bodies keyed by template key (ADR-0007).
+##
+## The evaluation algorithm selects WHICH key per subscore (story 005); the content lives
+## here (assets/data/evaluation/comment_templates.tres). GDD §3.1.5 7-key set.
+##
+## ADR: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+## TR:  TR-submission-*
+class_name CommentTemplates extends Resource
+
+## template_key → 한국어 본문.
+@export var templates: Dictionary = {}

--- a/src/data/evaluation_result.gd
+++ b/src/data/evaluation_result.gd
@@ -1,0 +1,28 @@
+## EvaluationResult — the weighted grade produced by EvaluationService (ADR-0007).
+##
+## Emitted via [code]evaluation_completed(result)[/code]; consumed by #10 Verdict Reveal
+## (presentation), #11 Career + Save/Load (persistence), #14 Retrospective Replay.
+##
+## ADR: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+## TR:  TR-submission-*
+class_name EvaluationResult extends Resource
+
+@export var case_id: String = ""
+## Weighted total in [0.0, 1.0].
+@export var final_score: float = 0.0
+## Court disposition verdict (파기/파기환송/기각/각하).
+@export var verdict: String = ""
+## 5 subscore keys → float (penalty negative allowed).
+@export var subscores: Dictionary = {}
+## 5 keys → float; sum == final_score (AC-16).
+@export var weighted_contributions: Dictionary = {}
+## Selected comment template bodies (story 005).
+@export var comments: Array[String] = []
+## Matched correct citations (UI display).
+@export var correct_set: Array[String] = []
+## Missed correct citations.
+@export var missed_set: Array[String] = []
+## Redundant (irrelevant) citations.
+@export var redundant_set: Array[String] = []
+## Unix ms timestamp (excluded from AC-23 byte comparison).
+@export var evaluated_at: int = 0

--- a/src/data/player_submission.gd
+++ b/src/data/player_submission.gd
@@ -1,0 +1,20 @@
+## PlayerSubmission — the player's brief submitted for evaluation (ADR-0007).
+##
+## Built by the Brief Editor submit flow; passed to
+## [code]EvaluationService.submit(submission)[/code] (TD-001: PlayerSubmission is the
+## canonical entry — the grading algorithm scores disposition + citations, neither of
+## which is in chain_data alone).
+##
+## ADR: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+## TR:  TR-submission-*
+class_name PlayerSubmission extends Resource
+
+@export var case_id: String = ""
+## library_dispositions_court enum member (파기/파기환송/기각/각하).
+@export var player_disposition: String = ""
+## Cited Library IDs, insertion order preserved.
+@export var player_citations: Array[String] = []
+## v1+ reasoning chain (MVP: empty Dict — GDD §3.1.1). Variant primitives only (ADR-0007 amend-1).
+@export var chain_data: Dictionary = {}
+## Telemetry — NOT scored.
+@export var submission_time_ms: int = 0

--- a/src/data/workspace_data.gd
+++ b/src/data/workspace_data.gd
@@ -1,0 +1,674 @@
+## WorkspaceData — Persistent Resource for the Reasoning Workspace state machine.
+##
+## Owns the 4-state lifecycle (INACTIVE → ACTIVE → FROZEN → READ_ONLY) and all
+## workspace-scoped fields that must survive session save/load.
+##
+## AC-21 guard design (Option C):
+##   [code]_state[/code] is a private backing variable written only by the three
+##   transition functions. The public [code]state[/code] property exposes a getter
+##   (read-only in practice) and a setter that calls [code]push_error[/code] and
+##   returns without mutation — direct assignment is rejected at runtime with an
+##   error message, leaving state unchanged.
+##
+## Legal transition graph:
+##   INACTIVE → ACTIVE      via [method _transition_to_active]
+##   ACTIVE   → FROZEN      via [method _transition_to_frozen]
+##   FROZEN   → READ_ONLY   via [method _transition_to_read_only]
+##   All other transitions: [code]push_error[/code] + no state change.
+##
+## Story 002 additions:
+##   [method build_chain_data] now builds a fully-constructed new Dictionary from
+##   the current [member nodes] array using BFS canonical ordering (lex root sort +
+##   BFS depth traversal with lex child sort). 5 derivation formulas:
+##   depth / max_depth_reached / total_evidence_count / child_count / evidence_count.
+##   [method validate_chain_data] enforces the 7-field allow-list per ADR-0007 amend-1.
+##   [signal submission_rejected] emitted on schema_violation.
+##
+##   Freeze cascade (chain_data_snapshot population on FROZEN) → story 007.
+##   Crash recovery cascade integration → story 008.
+##
+## ADR: docs/architecture/adr-0007-amend-1-chain-data-primitive-only.md
+##      docs/architecture/adr-0008-workspace-layout.md §1 + amend-1 §A5/§A6
+## TR:  TR-WORKSPACE-LAYOUT-001
+class_name WorkspaceData extends Resource
+
+
+# ─── Enum ─────────────────────────────────────────────────────────────────────
+
+## The four lifecycle states of the Reasoning Workspace.
+##
+## INACTIVE   — case loaded, no player interaction yet.
+## ACTIVE     — player has interacted (first node added or first citation drop).
+## FROZEN     — player submitted; tree is locked, awaiting evaluation.
+## READ_ONLY  — EvaluationResult received; tree visible, no mutations possible.
+enum WorkspaceState {
+	INACTIVE = 0,
+	ACTIVE = 1,
+	FROZEN = 2,
+	READ_ONLY = 3,
+}
+
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+## Allow-list for chain_data node dict fields (schema_version=1 lock).
+##
+## AC-2 + AC-10 + AC-52: exactly 7 fields permitted. Any other key in a node dict
+## triggers [method validate_chain_data] to emit [signal submission_rejected] and
+## return false. Field names are locked per ADR-0007 §1 — bump requires explicit
+## migration ADR.
+const ALLOWED_NODE_FIELDS: Array = [
+	"node_id",
+	"label",
+	"parent_id",
+	"evidence",
+	"depth",
+	"child_count",
+	"evidence_count",
+]
+
+## Tree structural invariants (entities.yaml v8).
+##
+## AC-12: Maximum depth a node may occupy. A child add is rejected when
+## [code]parent.depth + 1 > MAX_TREE_DEPTH[/code].
+const MAX_TREE_DEPTH := 3              # workspace_max_tree_depth
+
+## AC-14: Maximum number of library citations per node.
+## Attach is rejected when [code]node.evidence.size() >= EVIDENCE_PER_NODE_CAP[/code].
+const EVIDENCE_PER_NODE_CAP := 5       # workspace_evidence_per_node_cap
+
+## AC-15: Hard character limit for a node label (UTF-16 code units, which equals
+## codepoints for BMP characters). Input exceeding this is silently truncated.
+const NODE_LABEL_CHAR_LIMIT := 60      # workspace_node_label_char_limit
+
+## AC-16: Hard limit for memo text in UTF-8 codepoints.
+## GDScript [code]String.length()[/code] returns codepoint count in Godot 4.
+## Input exceeding this is silently truncated.
+const NODE_MEMO_CHAR_LIMIT := 500      # workspace_node_memo_char_limit (UTF-8 codepoints)
+
+
+# ─── Signals ──────────────────────────────────────────────────────────────────
+
+## Emitted on every legal state transition.
+## [param old_state] and [param new_state] are [enum WorkspaceState] integer values.
+## AC-20: all transitions emit this signal — subscribers use typed `.connect()`.
+## Forbidden pattern: never use string-keyed [code]emit_signal("workspace_state_changed", ...)[/code].
+signal workspace_state_changed(old_state: int, new_state: int)
+
+## Emitted when [method validate_chain_data] detects a forbidden node field.
+##
+## AC-10 + AC-52: schema_violation is the only [param reason] value in story 002.
+## Downstream stories (007/008) may emit additional reason values via this signal.
+## EvaluationService MUST NOT be called after this signal fires.
+signal submission_rejected(reason: String)
+
+## Emitted when a tree mutation violates a structural invariant (story 003a).
+##
+## [param reason] values:
+##   [code]"max_depth"[/code]       — AC-12: child add rejected; parent already at MAX_TREE_DEPTH.
+##   [code]"cycle"[/code]           — AC-13: reparent rejected; new_parent is a descendant of node.
+##   [code]"evidence_cap"[/code]    — AC-14: attach rejected; node already at EVIDENCE_PER_NODE_CAP.
+##   [code]"label_truncated"[/code] — AC-15: label input exceeded NODE_LABEL_CHAR_LIMIT; truncated.
+##   [code]"memo_truncated"[/code]  — AC-16: memo input exceeded NODE_MEMO_CHAR_LIMIT; truncated.
+##   [code]"frozen_state"[/code]    — AC-19: mutation rejected; workspace is FROZEN or READ_ONLY.
+signal tree_invariant_violation(reason: String)
+
+
+# ─── Exported fields (persisted by ResourceSaver) ─────────────────────────────
+
+## Hypothesis tree nodes. Typed array requires HypothesisNodeData class to exist
+## (scaffold in story 001; full fields in story 003).
+@export var nodes: Array[HypothesisNodeData] = []
+
+## Library ID of the citation currently pending KB/gamepad two-step attach.
+## Empty string means no pending citation.
+## ADR-0008 §2 — application-level state; native drag and KB pending are mutually exclusive.
+@export var pending_citation: String = ""
+
+## Snapshot of the chain_data Dictionary built at freeze time.
+## Populated by [method submit] at the moment the workspace transitions ACTIVE → FROZEN.
+## Story 002 defines the schema; story 007 wires the population.
+## ADR-0007 amend-1 §A1: values MUST be Variant primitives only
+## (String / int / float / bool / Array / Dictionary / null).
+## Never store Resource, Object, RID, Callable, Signal, NodePath, StringName,
+## or built-in value types (Vector2, Color, etc.) as values.
+## AC-24: this is a fully independent copy — post-freeze mutation of [member nodes]
+## or any [HypothesisNodeData] does NOT affect this snapshot.
+@export var chain_data_snapshot: Dictionary = {}
+
+
+# ─── Private state ────────────────────────────────────────────────────────────
+
+## Backing variable for the public [member state] property.
+## Written only by [method _transition_to_active], [method _transition_to_frozen],
+## and [method _transition_to_read_only]. Never assign directly.
+var _state: WorkspaceState = WorkspaceState.INACTIVE
+
+
+# ─── Public read-only property ────────────────────────────────────────────────
+
+## Current workspace state. Read-only via public API.
+##
+## AC-21: The setter rejects direct assignment with [code]push_error[/code] and
+## returns without mutation. Use [method _transition_to_active],
+## [method _transition_to_frozen], or [method _transition_to_read_only] instead.
+var state: WorkspaceState:
+	get:
+		return _state
+	set(value):
+		push_error(
+			"WorkspaceData.state cannot be set directly. " +
+			"Use _transition_to_active(), _transition_to_frozen(), " +
+			"or _transition_to_read_only() instead."
+		)
+
+
+# ─── Public methods ───────────────────────────────────────────────────────────
+
+## Adds a root node and transitions INACTIVE → ACTIVE if currently INACTIVE.
+##
+## AC-17: first DeskPane interaction (first root added) triggers activation.
+## In ACTIVE state, additional roots are appended without a state transition.
+## In FROZEN or READ_ONLY, mutation is rejected (AC-19 — "no mutations possible").
+## Null [param node_data] is rejected with [code]push_error[/code] + early return
+## (production-safe — does not rely on debug-only [code]assert()[/code]).
+##
+## [param node_data] must be a non-null [HypothesisNodeData] with [code]parent_id == ""[/code].
+func add_first_root_node(node_data: HypothesisNodeData) -> void:
+	# W1 — production-safe null guard (replaces release-stripped assert)
+	if node_data == null:
+		push_error("WorkspaceData.add_first_root_node: node_data must not be null")
+		return
+	# AC-19 enforcement — reject tree mutation in FROZEN / READ_ONLY (qa BUG-CANDIDATE closure)
+	if _state == WorkspaceState.FROZEN or _state == WorkspaceState.READ_ONLY:
+		push_error(
+			"WorkspaceData.add_first_root_node: tree mutation forbidden in %s state. " % \
+			WorkspaceState.find_key(_state) +
+			"No mutations possible after freeze (AC-19)."
+		)
+		return
+	nodes.append(node_data)
+	if _state == WorkspaceState.INACTIVE:
+		_transition_to_active()
+
+
+## Submits the current hypothesis tree: snapshots [member chain_data_snapshot],
+## validates it against the schema allow-list, then transitions ACTIVE → FROZEN.
+##
+## Returns [code]true[/code] on successful freeze; [code]false[/code] if rejected
+## (wrong state or schema violation).
+##
+## AC-24: [member chain_data_snapshot] is an independent copy built by
+## [method build_chain_data]. Post-freeze mutation of [member nodes] or any
+## [HypothesisNodeData] does NOT affect [member chain_data_snapshot].
+##
+## AC-26: [signal workspace_state_changed] emits EXACTLY ONCE (ACTIVE → FROZEN)
+## on a successful submit. On rejection, no signal is emitted and state is unchanged.
+##
+## Validation via [method validate_chain_data] is performed BEFORE the state
+## transition — a schema violation returns [code]false[/code] without transitioning
+## or emitting, and [signal submission_rejected] is emitted by the validator.
+##
+## NOTE (scope-split story-007 data-layer): the submit confirmation dialog (KrDialog,
+## AC-25/AC-27c/AC-27d) and the EvaluationService handoff are DEFERRED.
+## See forward-claim comment inside the method body.
+func submit() -> bool:
+	if _state != WorkspaceState.ACTIVE:
+		push_error(
+			"WorkspaceData.submit: requires ACTIVE state; current=%s" % \
+			WorkspaceState.find_key(_state)
+		)
+		return false
+	var snapshot: Dictionary = build_chain_data()
+	if not validate_chain_data(snapshot):
+		# submission_rejected already emitted by validate_chain_data.
+		return false
+	chain_data_snapshot = snapshot
+	_transition_to_frozen()
+	# DEFERRED (story #9 / Brief Editor epic): EvaluationService.submit(PlayerSubmission)
+	# handoff. PlayerSubmission requires player_disposition + player_citations from the
+	# Brief Editor submit dialog (not yet built). See ADR-0007 §Decision.
+	# NOTE: ADR-0007 specifies submit(PlayerSubmission) while the control-manifest
+	# specifies submit(chain_data: Dictionary) — this discrepancy must be reconciled
+	# when EvaluationService is implemented.
+	return true
+
+
+## Builds and returns a brand-new chain_data Dictionary from the current node tree.
+##
+## AC-23: Returns [code]{}[/code] when state is INACTIVE — no chain_data
+## is meaningful before any interaction.
+##
+## For all other states, performs a full BFS traversal over [member nodes] and
+## constructs a new Dictionary with 5 derivation formulas:
+##   - [code]depth[/code]: 0 for roots, parent.depth + 1 for children (AC-6)
+##   - [code]child_count[/code]: count of nodes where parent_id == this.node_id (AC-7)
+##   - [code]evidence_count[/code]: len(node.evidence) (AC-8)
+##   - [code]total_evidence_count[/code]: sum of all evidence_count (AC-4)
+##   - [code]max_depth_reached[/code]: max(depth) over all nodes; 0 for empty tree (AC-5)
+##
+## AC-9: The returned Dictionary is fully constructed as a new literal — no live
+## reference to WorkspaceData fields. Mutating [member nodes] or any
+## [HypothesisNodeData] after this call does NOT affect the returned Dictionary.
+##
+## AC-11b: nodes[] array follows BFS canonical ordering — roots sorted by
+## node_id lexicographically, then BFS within each root subtree with children
+## sorted by node_id at each depth level.
+##
+## ADR-0007 amend-1 §3.1 Rule 6: evidence Arrays are explicitly .duplicate()d.
+## ADR-0008 §1: BFS canonical ordering ensures deterministic byte-identical output.
+func build_chain_data() -> Dictionary:
+	if _state == WorkspaceState.INACTIVE:
+		return {}
+	var sorted_roots: Array = _roots()
+	sorted_roots.sort_custom(func(a: HypothesisNodeData, b: HypothesisNodeData) -> bool:
+		return a.node_id < b.node_id
+	)
+	var bfs_ordered: Array = []
+	for root: HypothesisNodeData in sorted_roots:
+		_bfs_collect(root, bfs_ordered)
+	var nodes_dict_array: Array = []
+	var edges_array: Array = []
+	var total_ev: int = 0
+	var max_depth: int = 0
+	for n: HypothesisNodeData in bfs_ordered:
+		nodes_dict_array.append({
+			"node_id": n.node_id,
+			"label": n.label,
+			"parent_id": n.parent_id,
+			"evidence": n.evidence.duplicate(),
+			"depth": n.depth,
+			"child_count": _children_of(n.node_id).size(),
+			"evidence_count": n.evidence.size(),
+		})
+		if n.parent_id != "":
+			edges_array.append({"parent_id": n.parent_id, "child_id": n.node_id})
+		total_ev += n.evidence.size()
+		max_depth = max(max_depth, n.depth)
+	return {
+		"schema_version": 1,
+		"nodes": nodes_dict_array,
+		"edges": edges_array,
+		"total_evidence_count": total_ev,
+		"max_depth_reached": max_depth,
+		"submission_timestamp_unix": int(Time.get_unix_time_from_system()),
+	}
+
+
+## Validates a chain_data Dictionary against the schema_version=1 node field allow-list.
+##
+## AC-10 + AC-52: iterates every node dict in [code]cd["nodes"][/code] and checks
+## each key against [constant ALLOWED_NODE_FIELDS]. On any forbidden field:
+##   1. Calls [code]push_error[/code] with a descriptive message.
+##   2. Emits [signal submission_rejected] with reason [code]"schema_violation"[/code].
+##   3. Returns [code]false[/code] immediately (fail-fast; partial validation is not performed).
+##
+## Returns [code]true[/code] if all node fields are in the allow-list (or nodes array is empty).
+## EvaluationService MUST NOT be called when this returns false.
+##
+## ADR-0007 §1 schema lock: any v2+ field addition requires an explicit migration ADR.
+func validate_chain_data(cd: Dictionary) -> bool:
+	for n: Dictionary in cd.get("nodes", []):
+		for k: String in n.keys():
+			if not ALLOWED_NODE_FIELDS.has(k):
+				push_error(
+					"chain_data schema_version=1 violation: forbidden field %s" % k
+				)
+				submission_rejected.emit("schema_violation")
+				return false
+	return true
+
+
+# ─── Tree mutation API (story 003a) ──────────────────────────────────────────
+
+## Adds [param child] as a child of the node identified by [param parent_id].
+##
+## AC-12 guard: rejected when [code]parent.depth + 1 > MAX_TREE_DEPTH[/code].
+## AC-19 guard: rejected in FROZEN or READ_ONLY state.
+##
+## On success: sets [code]child.parent_id[/code] and [code]child.depth[/code] from the
+## parent, then appends [param child] to [member nodes].
+##
+## Returns [code]true[/code] on success; [code]false[/code] on any guard failure.
+## Emits [signal tree_invariant_violation] with reason [code]"max_depth"[/code] or
+## [code]"frozen_state"[/code] on rejection.
+func add_child_to_node(parent_id: String, child: HypothesisNodeData) -> bool:
+	if _state == WorkspaceState.FROZEN or _state == WorkspaceState.READ_ONLY:
+		push_error(
+			"WorkspaceData.add_child_to_node: tree mutation forbidden in %s state (AC-19)." % \
+			WorkspaceState.find_key(_state)
+		)
+		tree_invariant_violation.emit("frozen_state")
+		return false
+	if child == null:
+		push_error("WorkspaceData.add_child_to_node: child must not be null.")
+		return false
+	var parent: HypothesisNodeData = _find_node(parent_id)
+	if parent == null:
+		push_error(
+			"WorkspaceData.add_child_to_node: parent_id '%s' not found in nodes." % parent_id
+		)
+		return false
+	if parent.depth + 1 > MAX_TREE_DEPTH:
+		push_error(
+			"WorkspaceData.add_child_to_node: max tree depth %d exceeded. " % MAX_TREE_DEPTH +
+			"이 분기는 더 깊이 추론할 수 없습니다 (최대 %d단계)" % MAX_TREE_DEPTH
+		)
+		tree_invariant_violation.emit("max_depth")
+		return false
+	child.parent_id = parent_id
+	child.depth = parent.depth + 1
+	nodes.append(child)
+	return true
+
+
+## Moves the node identified by [param node_id] to a new parent identified by
+## [param new_parent_id], updating depth on the entire moved subtree.
+##
+## AC-13 guard: rejected when [param new_parent_id] is a descendant of [param node_id]
+## (cycle detection via BFS) or when [param new_parent_id] == [param node_id] (self-cycle).
+## Depth guard: rejected when reparenting would push any descendant past [constant MAX_TREE_DEPTH].
+## AC-19 guard: rejected in FROZEN or READ_ONLY state.
+##
+## Returns [code]true[/code] on success; [code]false[/code] on any guard failure.
+## Emits [signal tree_invariant_violation] with reason [code]"cycle"[/code],
+## [code]"max_depth"[/code], or [code]"frozen_state"[/code] on rejection.
+## Tree state is unchanged on rejection.
+func reparent(node_id: String, new_parent_id: String) -> bool:
+	if _state == WorkspaceState.FROZEN or _state == WorkspaceState.READ_ONLY:
+		push_error(
+			"WorkspaceData.reparent: tree mutation forbidden in %s state (AC-19)." % \
+			WorkspaceState.find_key(_state)
+		)
+		tree_invariant_violation.emit("frozen_state")
+		return false
+	var node: HypothesisNodeData = _find_node(node_id)
+	if node == null:
+		push_error(
+			"WorkspaceData.reparent: node_id '%s' not found in nodes." % node_id
+		)
+		return false
+	var new_parent: HypothesisNodeData = _find_node(new_parent_id)
+	if new_parent == null:
+		push_error(
+			"WorkspaceData.reparent: new_parent_id '%s' not found in nodes." % new_parent_id
+		)
+		return false
+	# Cycle detection: reject if new_parent is a descendant of node (or is node itself).
+	if node_id == new_parent_id or _is_descendant(node_id, new_parent_id):
+		push_error(
+			"WorkspaceData.reparent: cycle detected — '%s' is an ancestor of '%s'. " \
+			% [node_id, new_parent_id] +
+			"노드를 자신의 하위 노드로 이동할 수 없습니다"
+		)
+		tree_invariant_violation.emit("cycle")
+		return false
+	# Depth guard: the subtree rooted at node will shift by delta_depth.
+	# Reject if any node in the subtree would exceed MAX_TREE_DEPTH.
+	var new_node_depth: int = new_parent.depth + 1
+	var delta_depth: int = new_node_depth - node.depth
+	if delta_depth > 0:
+		# Only need to check when depth increases; BFS to find max current subtree depth.
+		var subtree_max_depth: int = 0
+		var bfs_queue: Array[HypothesisNodeData] = [node]
+		while bfs_queue.size() > 0:
+			var current: HypothesisNodeData = bfs_queue.pop_front()
+			if current.depth > subtree_max_depth:
+				subtree_max_depth = current.depth
+			for child: HypothesisNodeData in nodes:
+				if child.parent_id == current.node_id:
+					bfs_queue.append(child)
+		if subtree_max_depth + delta_depth > MAX_TREE_DEPTH:
+			push_error(
+				"WorkspaceData.reparent: reparenting '%s' to '%s' would push subtree past MAX_TREE_DEPTH=%d." \
+				% [node_id, new_parent_id, MAX_TREE_DEPTH]
+			)
+			tree_invariant_violation.emit("max_depth")
+			return false
+	# Apply: update parent and recursively update depth on the entire subtree.
+	node.parent_id = new_parent_id
+	_update_subtree_depth(node, new_node_depth)
+	return true
+
+
+## Attaches a library citation to the node identified by [param node_id].
+##
+## AC-14 guard: rejected when [code]node.evidence.size() >= EVIDENCE_PER_NODE_CAP[/code].
+## AC-19 guard: rejected in FROZEN or READ_ONLY state.
+##
+## Returns [code]true[/code] on success; [code]false[/code] on any guard failure.
+## Emits [signal tree_invariant_violation] with reason [code]"evidence_cap"[/code] or
+## [code]"frozen_state"[/code] on rejection.
+##
+## Note: deduplication is NOT performed at this layer (deferred to story 004
+## drag-drop pipeline EC-6). Duplicate library_ids are appended.
+func attach_evidence(node_id: String, library_id: String) -> bool:
+	if _state == WorkspaceState.FROZEN or _state == WorkspaceState.READ_ONLY:
+		push_error(
+			"WorkspaceData.attach_evidence: tree mutation forbidden in %s state (AC-19)." % \
+			WorkspaceState.find_key(_state)
+		)
+		tree_invariant_violation.emit("frozen_state")
+		return false
+	var node: HypothesisNodeData = _find_node(node_id)
+	if node == null:
+		push_error(
+			"WorkspaceData.attach_evidence: node_id '%s' not found in nodes." % node_id
+		)
+		return false
+	if node.evidence.size() >= EVIDENCE_PER_NODE_CAP:
+		push_error(
+			"WorkspaceData.attach_evidence: evidence cap reached on node '%s'. " % node_id +
+			"이 노드에는 인용을 %d개까지만 첨부할 수 있습니다" % EVIDENCE_PER_NODE_CAP
+		)
+		tree_invariant_violation.emit("evidence_cap")
+		return false
+	node.evidence.append(library_id)
+	return true
+
+
+## Sets the display label on the node identified by [param node_id].
+##
+## AC-15: If [param label] exceeds [constant NODE_LABEL_CHAR_LIMIT] characters,
+## it is silently truncated to exactly [constant NODE_LABEL_CHAR_LIMIT] chars
+## and [signal tree_invariant_violation] is emitted with reason [code]"label_truncated"[/code].
+## AC-19 guard: no-op in FROZEN or READ_ONLY state.
+##
+## Truncation is a soft cap with feedback — the label IS set (to the truncated value);
+## the mutation is not rejected.
+func update_node_label(node_id: String, label: String) -> void:
+	if _state == WorkspaceState.FROZEN or _state == WorkspaceState.READ_ONLY:
+		push_error(
+			"WorkspaceData.update_node_label: tree mutation forbidden in %s state (AC-19)." % \
+			WorkspaceState.find_key(_state)
+		)
+		tree_invariant_violation.emit("frozen_state")
+		return
+	var node: HypothesisNodeData = _find_node(node_id)
+	if node == null:
+		push_error(
+			"WorkspaceData.update_node_label: node_id '%s' not found in nodes." % node_id
+		)
+		return
+	var effective_label: String = label
+	if label.length() > NODE_LABEL_CHAR_LIMIT:
+		effective_label = label.substr(0, NODE_LABEL_CHAR_LIMIT)
+		tree_invariant_violation.emit("label_truncated")
+	node.label = effective_label
+
+
+## Sets the memo text on the node identified by [param node_id].
+##
+## AC-16: If [param memo] exceeds [constant NODE_MEMO_CHAR_LIMIT] UTF-8 codepoints,
+## it is silently truncated to exactly [constant NODE_MEMO_CHAR_LIMIT] codepoints
+## and [signal tree_invariant_violation] is emitted with reason [code]"memo_truncated"[/code].
+## [code]String.length()[/code] returns codepoint count in Godot 4 — 한글 = 1 codepoint.
+## AC-19 guard: no-op in FROZEN or READ_ONLY state.
+##
+## Truncation is a soft cap with feedback — the memo IS set (to the truncated value);
+## the mutation is not rejected.
+func update_node_memo(node_id: String, memo: String) -> void:
+	if _state == WorkspaceState.FROZEN or _state == WorkspaceState.READ_ONLY:
+		push_error(
+			"WorkspaceData.update_node_memo: tree mutation forbidden in %s state (AC-19)." % \
+			WorkspaceState.find_key(_state)
+		)
+		tree_invariant_violation.emit("frozen_state")
+		return
+	var node: HypothesisNodeData = _find_node(node_id)
+	if node == null:
+		push_error(
+			"WorkspaceData.update_node_memo: node_id '%s' not found in nodes." % node_id
+		)
+		return
+	var effective_memo: String = memo
+	if memo.length() > NODE_MEMO_CHAR_LIMIT:
+		effective_memo = memo.substr(0, NODE_MEMO_CHAR_LIMIT)
+		tree_invariant_violation.emit("memo_truncated")
+	node.memo = effective_memo
+
+
+# ─── Transition functions (only legal state-change API) ───────────────────────
+
+## Transitions INACTIVE → ACTIVE.
+##
+## AC-17: Called by [method add_first_root_node] on first interaction.
+## Rejects any origin state other than INACTIVE with [code]push_error[/code].
+func _transition_to_active() -> void:
+	if _state != WorkspaceState.INACTIVE:
+		push_error(
+			"WorkspaceData._transition_to_active: illegal transition from %s. " % \
+			WorkspaceState.find_key(_state) +
+			"Only INACTIVE → ACTIVE is allowed."
+		)
+		return
+	var old: int = _state
+	_state = WorkspaceState.ACTIVE
+	workspace_state_changed.emit(old, _state)
+
+
+## Transitions ACTIVE → FROZEN.
+##
+## AC-18: Only callable from ACTIVE. FROZEN is irreversible within the session
+## (no transition out of FROZEN except to READ_ONLY via [method _transition_to_read_only]).
+##
+## Callers are responsible for populating [member chain_data_snapshot] BEFORE
+## calling this method. [method submit] does so — it assigns [member chain_data_snapshot]
+## from [method build_chain_data] prior to this call, guaranteeing the snapshot is
+## populated at the moment [signal workspace_state_changed] becomes observable.
+##
+## This method is single-responsibility: state change + signal emit only.
+## It does NOT build or validate chain_data.
+func _transition_to_frozen() -> void:
+	if _state != WorkspaceState.ACTIVE:
+		push_error(
+			"WorkspaceData._transition_to_frozen: illegal transition from %s. " % \
+			WorkspaceState.find_key(_state) +
+			"Only ACTIVE → FROZEN is allowed."
+		)
+		return
+	var old: int = _state
+	_state = WorkspaceState.FROZEN
+	workspace_state_changed.emit(old, _state)
+
+
+## Transitions FROZEN → READ_ONLY on EvaluationResult arrival.
+##
+## AC-19: Tree becomes visible but no mutations are possible.
+## Only callable from FROZEN.
+func _transition_to_read_only() -> void:
+	if _state != WorkspaceState.FROZEN:
+		push_error(
+			"WorkspaceData._transition_to_read_only: illegal transition from %s. " % \
+			WorkspaceState.find_key(_state) +
+			"Only FROZEN → READ_ONLY is allowed."
+		)
+		return
+	var old: int = _state
+	_state = WorkspaceState.READ_ONLY
+	workspace_state_changed.emit(old, _state)
+
+
+# ─── BFS helpers (used by build_chain_data) ───────────────────────────────────
+
+## Returns all root nodes (parent_id == "") from [member nodes].
+## AC-11b: caller sorts the result by node_id before BFS traversal.
+func _roots() -> Array:
+	var result: Array = []
+	for n: HypothesisNodeData in nodes:
+		if n.parent_id == "":
+			result.append(n)
+	return result
+
+
+## Performs a BFS traversal rooted at [param root], appending visited nodes to
+## [param accumulator] in BFS order. Children at each depth are sorted by node_id
+## lexicographically to guarantee deterministic canonical ordering (AC-11b).
+##
+## ADR-0008 §1: same workspace state → byte-identical JSON.stringify output.
+func _bfs_collect(root: HypothesisNodeData, accumulator: Array) -> void:
+	var queue: Array = [root]
+	while queue.size() > 0:
+		var current: HypothesisNodeData = queue.pop_front()
+		accumulator.append(current)
+		var children: Array = _children_of(current.node_id)
+		children.sort_custom(func(a: HypothesisNodeData, b: HypothesisNodeData) -> bool:
+			return a.node_id < b.node_id
+		)
+		for child: HypothesisNodeData in children:
+			queue.append(child)
+
+
+## Returns all direct children of the node with [param node_id].
+## Used by [method _bfs_collect] for BFS traversal and by [method build_chain_data]
+## for the child_count derivation formula (AC-7).
+func _children_of(node_id: String) -> Array:
+	var result: Array = []
+	for n: HypothesisNodeData in nodes:
+		if n.parent_id == node_id:
+			result.append(n)
+	return result
+
+
+# ─── Tree mutation helpers (story 003a) ──────────────────────────────────────
+
+## Returns the first [HypothesisNodeData] in [member nodes] whose [code]node_id[/code]
+## matches [param node_id], or [code]null[/code] if not found.
+## Used by all tree mutation API methods to resolve node references.
+func _find_node(node_id: String) -> HypothesisNodeData:
+	for n: HypothesisNodeData in nodes:
+		if n.node_id == node_id:
+			return n
+	return null
+
+
+## Returns [code]true[/code] if [param candidate_id] is a descendant of
+## [param ancestor_id] (BFS traversal from ancestor).
+##
+## Used by [method reparent] for cycle detection (AC-13):
+## [code]_is_descendant(node_id, new_parent_id)[/code] returns true when the
+## proposed new parent is already within the subtree rooted at node — a cycle.
+func _is_descendant(ancestor_id: String, candidate_id: String) -> bool:
+	var queue: Array[String] = []
+	# Seed the queue with direct children of ancestor_id.
+	for n: HypothesisNodeData in nodes:
+		if n.parent_id == ancestor_id:
+			queue.append(n.node_id)
+	while queue.size() > 0:
+		var current_id: String = queue.pop_front()
+		if current_id == candidate_id:
+			return true
+		for n: HypothesisNodeData in nodes:
+			if n.parent_id == current_id:
+				queue.append(n.node_id)
+	return false
+
+
+## Recursively updates [code]depth[/code] on [param node] and all its descendants
+## so that [param node] lands at [param new_depth].
+## Called by [method reparent] after cycle and max-depth guards pass.
+func _update_subtree_depth(node: HypothesisNodeData, new_depth: int) -> void:
+	node.depth = new_depth
+	for n: HypothesisNodeData in nodes:
+		if n.parent_id == node.node_id:
+			_update_subtree_depth(n, new_depth + 1)

--- a/src/data/workspace_data.gd
+++ b/src/data/workspace_data.gd
@@ -228,9 +228,9 @@ func submit() -> bool:
 	# DEFERRED (story #9 / Brief Editor epic): EvaluationService.submit(PlayerSubmission)
 	# handoff. PlayerSubmission requires player_disposition + player_citations from the
 	# Brief Editor submit dialog (not yet built). See ADR-0007 §Decision.
-	# NOTE: ADR-0007 specifies submit(PlayerSubmission) while the control-manifest
-	# specifies submit(chain_data: Dictionary) — this discrepancy must be reconciled
-	# when EvaluationService is implemented.
+	# TD-001 RESOLVED 2026-05-23: the entry point is submit(submission: PlayerSubmission)
+	# per ADR-0007 (the grading algorithm scores disposition + citations, which are NOT in
+	# chain_data). The control-manifest was corrected to match.
 	return true
 
 

--- a/src/services/evaluation_service.gd
+++ b/src/services/evaluation_service.gd
@@ -142,3 +142,108 @@ func _citation_similarity(p: String, c: String) -> float:
 	if p_whole != c_whole:
 		return 0.5
 	return 0.0
+
+
+# ─── submit() pipeline + state machine — story 004 ────────────────────────────
+
+## Entry point (TD-001: PlayerSubmission). Runs the 5-state pipeline:
+## IDLE → VALIDATING (empty/invalid citation gate) → COMPUTING ([method evaluate]) →
+## REPORTING ([signal evaluation_completed]) → DONE → IDLE.
+##
+## AC-18: re-submit while not IDLE → push_warning + ignored (no second pipeline in flight).
+## AC-1/EC-1: empty player_citations → submission_rejected("empty_citations").
+## AC-2/EC-2: a citation failing LibraryService.validate_citations → submission_rejected("invalid_citation").
+## Missing case → submission_rejected("case_not_found"). Services looked up at /root (guarded).
+func submit(submission: PlayerSubmission) -> void:
+	if current_state != State.IDLE:
+		push_warning("EvaluationService.submit: evaluation in progress — re-submit ignored")
+		return
+	current_state = State.VALIDATING
+	if submission.player_citations.size() < 1:
+		_reject("empty_citations")
+		return
+	var library: Node = get_node_or_null("/root/LibraryService")
+	if library != null:
+		var invalid: Array = library.validate_citations(submission.player_citations)
+		if not invalid.is_empty():
+			_reject("invalid_citation")
+			return
+	var case_service: Node = get_node_or_null("/root/CaseService")
+	var case_file: CaseFile = case_service.get_case(submission.case_id) if case_service != null else null
+	if case_file == null:
+		_reject("case_not_found")
+		return
+	current_state = State.COMPUTING
+	var result: EvaluationResult = evaluate(submission, case_file)
+	current_state = State.REPORTING
+	evaluation_completed.emit(result)
+	current_state = State.DONE
+	current_state = State.IDLE
+
+## Emits submission_rejected and returns the machine to IDLE.
+func _reject(reason: String) -> void:
+	submission_rejected.emit(reason)
+	current_state = State.IDLE
+
+## Pure COMPUTING step: grades [param submission] against [param case_file] and builds the
+## EvaluationResult (subscores + weighted contributions + final_score + verdict + citation sets).
+## Deterministic except [member EvaluationResult.evaluated_at] (timestamp — AC-23 excluded).
+func evaluate(submission: PlayerSubmission, case_file: CaseFile) -> EvaluationResult:
+	var correct_disp: String = case_file.correct_disposition
+	var correct_cites: Array = case_file.correct_citations
+	var weights: Dictionary = case_file.scoring_weights
+	var subs: Dictionary = {
+		"disposition_match": compute_disposition_match(submission.player_disposition, correct_disp),
+		"core_citation_coverage": compute_core_citation_coverage(submission.player_citations, correct_cites),
+		"redundant_citation_penalty": compute_redundant_citation_penalty(submission.player_citations, correct_cites),
+		"chain_coherence": 0.0,            # v1+ (weight-0 in MVP)
+		"precedent_seniority_bonus": 0.0,  # v1+ (weight-0 in MVP)
+	}
+	var final_score: float = compute_final_score(subs, weights)
+	var result := EvaluationResult.new()
+	result.case_id = submission.case_id
+	result.subscores = subs
+	result.weighted_contributions = compute_weighted_contributions(subs, weights)
+	result.final_score = final_score
+	result.verdict = determine_verdict(submission.player_disposition, correct_disp, final_score)
+	result.correct_set = _matched_citations(submission.player_citations, correct_cites)
+	result.missed_set = _missed_citations(submission.player_citations, correct_cites)
+	result.redundant_set = _redundant_citations(submission.player_citations, correct_cites)
+	result.evaluated_at = int(Time.get_unix_time_from_system() * 1000.0)
+	return result
+
+## Player citations that matched a correct citation (similarity > 0).
+func _matched_citations(player_citations: Array, correct_citations: Array) -> Array[String]:
+	var out: Array[String] = []
+	for p: String in player_citations:
+		for c: String in correct_citations:
+			if _citation_similarity(p, c) > 0.0:
+				out.append(p)
+				break
+	return out
+
+## Correct citations the player did not cover (no player citation matched them).
+func _missed_citations(player_citations: Array, correct_citations: Array) -> Array[String]:
+	var out: Array[String] = []
+	for c: String in correct_citations:
+		var covered: bool = false
+		for p: String in player_citations:
+			if _citation_similarity(p, c) > 0.0:
+				covered = true
+				break
+		if not covered:
+			out.append(c)
+	return out
+
+## Player citations that matched nothing correct (irrelevant).
+func _redundant_citations(player_citations: Array, correct_citations: Array) -> Array[String]:
+	var out: Array[String] = []
+	for p: String in player_citations:
+		var matched: bool = false
+		for c: String in correct_citations:
+			if _citation_similarity(p, c) > 0.0:
+				matched = true
+				break
+		if not matched:
+			out.append(p)
+	return out

--- a/src/services/evaluation_service.gd
+++ b/src/services/evaluation_service.gd
@@ -1,0 +1,144 @@
+## EvaluationService — autoload THIRD. Weighted-grading core (Pillar 1, ADR-0007).
+##
+## Stories 001-003 scope: Resource tree (separate files) + autoload skeleton + threshold
+## load + the deterministic scoring algorithm (5 subscores + weighted final_score) +
+## verdict function. The submit() 5-state pipeline + Library/Case integration is story 004;
+## comment-template selection is story 005.
+##
+## [b]Registration[/b]: `project.godot` [autoload] as
+## `EvaluationService="*res://src/services/evaluation_service.gd"` — THIRD per ADR-0007
+## (after LibraryService/CaseService; `entry_count()`/`case_count()` heuristic guards avoid
+## signal pre-fire deadlock). class_name is `EvaluationServiceClass` (autoload-name-collision).
+##
+## [b]Algorithm is code, weights are data[/b] (ADR-0003): the scoring functions are pure;
+## the per-subscore weights come from `case.scoring_weights`. Verdict thresholds are global
+## (`entities.yaml submission_verdict_thresholds` = {pagi:0.7, low:0.3}) — never per-case.
+##
+## ADR: docs/architecture/adr-0007-submission-evaluation-algorithm.md
+## TR:  TR-submission-*
+class_name EvaluationServiceClass extends Node
+
+
+# ─── State machine (story 001; transitions in story 004) ──────────────────────
+
+enum State { IDLE, VALIDATING, COMPUTING, REPORTING, DONE }
+var current_state: State = State.IDLE
+
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+## Verdict thresholds — GLOBAL lock (entities.yaml submission_verdict_thresholds = {pagi:0.7, low:0.3}).
+## Per-case override is forbidden (per_case_verdict_threshold_override — Pillar 1: same rule for all cases).
+const VERDICT_THRESHOLD_PAGI: float = 0.7
+const VERDICT_THRESHOLD_LOW: float = 0.3
+
+## Redundant-citation penalty cap (GDD §7.3 / §4.3).
+const REDUNDANT_PENALTY_CAP: float = -0.3
+const REDUNDANT_PENALTY_SLOPE: float = 0.5
+
+## The 5 subscore keys (ADR-0007 §3.1.3). v1+ keys are computed but weight-0 in MVP.
+const SUBSCORE_KEYS: Array[String] = [
+	"disposition_match",
+	"core_citation_coverage",
+	"redundant_citation_penalty",
+	"chain_coherence",            # v1+ — weight 0 in MVP
+	"precedent_seniority_bonus",  # v1+ — weight 0 in MVP
+]
+
+
+# ─── Signals ──────────────────────────────────────────────────────────────────
+
+signal evaluation_completed(result: EvaluationResult)
+signal submission_rejected(reason: String)
+
+
+# ─── Scoring — story 002 (pure functions) ─────────────────────────────────────
+
+## AC §8.2 — discrete 1.0 (disposition matches) or 0.0.
+func compute_disposition_match(player_disposition: String, correct_disposition: String) -> float:
+	return 1.0 if player_disposition == correct_disposition else 0.0
+
+
+## AC §8.2 — recall over correct citations: Σ_c max_p similarity(p,c) / |C| (natural [0,1]).
+## Iterates the CORRECT side (review BLOCKING #2 fix — avoids >1.0 from |P|>|C|).
+## Empty correct set → 1.0 (no correct citations to miss; vacuously covered).
+func compute_core_citation_coverage(player_citations: Array, correct_citations: Array) -> float:
+	if correct_citations.is_empty():
+		return 1.0
+	var total: float = 0.0
+	for c: String in correct_citations:
+		var best: float = 0.0
+		for p: String in player_citations:
+			best = maxf(best, _citation_similarity(p, c))
+		total += best
+	return total / float(correct_citations.size())
+
+
+## AC §8.2 — negative penalty for cited-but-irrelevant citations. [-0.3, 0.0].
+## redundant_ratio = |unmatched player citations| / |P|; penalty = -min(0.3, ratio × 0.5).
+func compute_redundant_citation_penalty(player_citations: Array, correct_citations: Array) -> float:
+	if player_citations.is_empty():
+		return 0.0
+	var redundant: int = 0
+	for p: String in player_citations:
+		var matched: bool = false
+		for c: String in correct_citations:
+			if _citation_similarity(p, c) > 0.0:
+				matched = true
+				break
+		if not matched:
+			redundant += 1
+	var ratio: float = float(redundant) / float(player_citations.size())
+	return -minf(-REDUNDANT_PENALTY_CAP, ratio * REDUNDANT_PENALTY_SLOPE)
+
+
+## AC §8.3 — weighted sum of all 5 subscores, clamped to [0,1]. v1+ subscores contribute
+## only if their weight is non-zero (MVP locks chain_coherence/precedent_seniority_bonus = 0).
+func compute_final_score(subscores: Dictionary, scoring_weights: Dictionary) -> float:
+	var sum: float = 0.0
+	for k: String in SUBSCORE_KEYS:
+		sum += float(subscores.get(k, 0.0)) * float(scoring_weights.get(k, 0.0))
+	return clampf(sum, 0.0, 1.0)
+
+
+## Per-subscore weighted contribution map (EvaluationResult.weighted_contributions; sum==final_score pre-clamp).
+func compute_weighted_contributions(subscores: Dictionary, scoring_weights: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for k: String in SUBSCORE_KEYS:
+		out[k] = float(subscores.get(k, 0.0)) * float(scoring_weights.get(k, 0.0))
+	return out
+
+
+# ─── Verdict — story 003 (pure function) ──────────────────────────────────────
+
+## AC §4.7 / §8.3 — maps (disposition match, final_score) → verdict. Global thresholds.
+##   파기      : match AND score ≥ 0.7
+##   파기환송  : match AND score ≥ 0.3 (< 0.7)
+##   기각      : NOT match AND score ≥ 0.3
+##   각하      : score < 0.3 (regardless of match)
+func determine_verdict(player_disposition: String, correct_disposition: String, final_score: float) -> String:
+	var matched: bool = player_disposition == correct_disposition
+	if final_score < VERDICT_THRESHOLD_LOW:
+		return "각하"
+	if matched:
+		return "파기" if final_score >= VERDICT_THRESHOLD_PAGI else "파기환송"
+	return "기각"
+
+
+# ─── Citation similarity helper (GDD §4.2) ────────────────────────────────────
+
+## σ(p, c): 1.0 exact; 0.5 same case_id with one whole-case + one holding; else 0.0.
+## (Different holdings of the same case → 0.0 — GDD §4.2 Note.)
+func _citation_similarity(p: String, c: String) -> float:
+	if p == c:
+		return 1.0
+	var p_case: String = p.get_slice("/", 0)
+	var c_case: String = c.get_slice("/", 0)
+	if p_case != c_case:
+		return 0.0
+	var p_whole: bool = not p.contains("/")
+	var c_whole: bool = not c.contains("/")
+	# one whole-case, the other a holding of the same case → partial match
+	if p_whole != c_whole:
+		return 0.5
+	return 0.0

--- a/src/services/evaluation_service.gd
+++ b/src/services/evaluation_service.gd
@@ -52,6 +52,14 @@ signal evaluation_completed(result: EvaluationResult)
 signal submission_rejected(reason: String)
 
 
+# ─── Comment templates (story 005) ────────────────────────────────────────────
+
+## Externalized comment bodies (assets/data/evaluation/comment_templates.tres — content
+## task). Empty default: [method select_comments] then yields no comments (graceful).
+## The algorithm decides WHICH key per subscore; content lives here.
+var _comment_templates: CommentTemplates = CommentTemplates.new()
+
+
 # ─── Scoring — story 002 (pure functions) ─────────────────────────────────────
 
 ## AC §8.2 — discrete 1.0 (disposition matches) or 0.0.
@@ -209,8 +217,42 @@ func evaluate(submission: PlayerSubmission, case_file: CaseFile) -> EvaluationRe
 	result.correct_set = _matched_citations(submission.player_citations, correct_cites)
 	result.missed_set = _missed_citations(submission.player_citations, correct_cites)
 	result.redundant_set = _redundant_citations(submission.player_citations, correct_cites)
+	result.comments = select_comments(compute_comment_keys(subs), _comment_templates)
 	result.evaluated_at = int(Time.get_unix_time_from_system() * 1000.0)
 	return result
+
+
+# ─── Comment decision tree + selection — story 005 ────────────────────────────
+
+## Per-subscore decision tree → one template key each (GDD §3.1.5, 7-key set).
+## disposition_match: 1.0→comment.disp.match / 0.0→comment.disp.miss.
+## core_citation_coverage: ≥0.8→high / 0.4–0.8→mid / <0.4→low.
+## redundant_citation_penalty: ≥-0.05→clean / <-0.05→bloat.
+func compute_comment_keys(subscores: Dictionary) -> Array[String]:
+	var keys: Array[String] = []
+	keys.append("comment.disp.match" if float(subscores.get("disposition_match", 0.0)) >= 1.0 else "comment.disp.miss")
+	var cov: float = float(subscores.get("core_citation_coverage", 0.0))
+	if cov >= 0.8:
+		keys.append("comment.core.high")
+	elif cov >= 0.4:
+		keys.append("comment.core.mid")
+	else:
+		keys.append("comment.core.low")
+	var pen: float = float(subscores.get("redundant_citation_penalty", 0.0))
+	keys.append("comment.redund.clean" if pen >= -0.05 else "comment.redund.bloat")
+	return keys
+
+## Maps selected template keys to their Korean bodies via [param templates]. A key with no
+## body is skipped gracefully (no crash) — the comment_templates.tres content is authored
+## separately, so MVP without it simply yields no comments.
+func select_comments(keys: Array, templates: CommentTemplates) -> Array[String]:
+	var out: Array[String] = []
+	if templates == null:
+		return out
+	for key: String in keys:
+		if templates.templates.has(key):
+			out.append(String(templates.templates[key]))
+	return out
 
 ## Player citations that matched a correct citation (similarity > 0).
 func _matched_citations(player_citations: Array, correct_citations: Array) -> Array[String]:

--- a/src/services/save_load_service.gd
+++ b/src/services/save_load_service.gd
@@ -42,6 +42,9 @@ signal save_corrupted(category: String)
 ## stories 006 / Brief epic) decide whether to auto-resubmit based on the recovered state.
 signal active_case_recovered(workspace_data: WorkspaceData, brief_editor_data: Resource)
 
+## Emitted after a Resolved case is archived to the casebook (story 005 resolution cascade).
+signal casebook_entry_added(entry: CasebookEntry)
+
 
 # ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -79,7 +82,17 @@ const DEBOUNCE_MS: Dictionary = {
 ## crash-recovery entry point. Per-category autosave timers are created lazily (story 003).
 func _ready() -> void:
 	_ensure_saves_dir()
+	# Intercept the window-close so a pending (debounced) save is flushed before quit.
+	# Only affects WM_CLOSE_REQUEST; explicit get_tree().quit() (e.g. test runner) still works.
+	get_tree().set_auto_accept_quit(false)
 	await _boot_load()
+
+
+## Flushes any pending save on window close, then quits (story 008 / ADR-0011 §3.4).
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_WM_CLOSE_REQUEST:
+		_flush_pending_save()
+		get_tree().quit()
 
 
 # ─── Public / internal methods ──────────────────────────────────────────────────
@@ -289,3 +302,89 @@ func _validate_active_case(active: ActiveCaseSaveData) -> bool:
 	if active == null or active.workspace_data == null:
 		return true   # nothing to validate
 	return active.workspace_data.validate_chain_data(active.workspace_data.chain_data_snapshot)
+
+
+# ─── Close-request forced flush (story 008) ───────────────────────────────────
+
+## Drains any pending debounced save synchronously (EC-10) so the final edits are not
+## lost when the app is closing. For every running per-category debounce timer, the save
+## is performed immediately instead of waiting for its timeout. A no-op when nothing is
+## pending (no dirty timer).
+func _flush_pending_save() -> void:
+	for category: String in _debounce_timers:
+		var timer: Timer = _debounce_timers[category]
+		if timer != null and not timer.is_stopped():
+			timer.stop()
+			_perform_save(category)
+
+
+# ─── Resolution cascade + revert guard (story 005) ────────────────────────────
+
+## Returns true if a case with [param case_id] is already archived in the casebook
+## (i.e. Resolved). Used by the anti-save-scumming revert guard.
+func _casebook_has(case_id: String) -> bool:
+	if _casebook == null:
+		return false
+	for entry: CasebookEntry in _casebook.entries:
+		if entry.case_id == case_id:
+			return true
+	return false
+
+## Resolution cascade: archive the Resolved case to the casebook (immediate write),
+## delete the active case (anti-save-scumming), and announce the new entry.
+##
+## AC-3. The [param result] is duck-typed (`case_id` / `verdict` / `final_score`) because
+## the `EvaluationResult` class lives in the Submission/Evaluation epic. This handler is
+## the subscriber for `EvaluationService.evaluation_completed`; that subscription is
+## DEFERRED until EvaluationService exists (TD-001 — submit signature must reconcile first).
+func _on_evaluation_completed(result: Object) -> void:
+	if _casebook == null:
+		_casebook = Casebook.new()
+	var entry := CasebookEntry.new()
+	entry.case_id = result.get("case_id")
+	entry.verdict = result.get("verdict")
+	entry.final_score = result.get("final_score")
+	_casebook.entries.append(entry)
+	_save_resource_atomic(_casebook, CASEBOOK_FILE)   # immediate (0ms) — write casebook BEFORE deleting active
+	if FileAccess.file_exists(ACTIVE_CASE_FILE):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(ACTIVE_CASE_FILE))
+	_active_case = null
+	casebook_entry_added.emit(entry)
+
+## Persists the active case, UNLESS its case_id is already Resolved (in the casebook).
+##
+## AC-4 / EC-5: a Resolved case cannot be re-saved (anti-save-scumming,
+## `save_load_revert_resolved`, Pillar 1 irreversibility). Returns false + push_error
+## without touching `active_case.tres` in that case.
+func save_active_case() -> bool:
+	if _active_case == null:
+		return false
+	if _casebook_has(_active_case.case_id):
+		push_error(
+			"save_load_revert_resolved: case '%s' is Resolved — cannot re-save" \
+			% _active_case.case_id
+		)
+		return false
+	return _save_resource_atomic(_active_case, ACTIVE_CASE_FILE)
+
+
+# ─── Crash-recovery branch contract (story 006) ───────────────────────────────
+
+## Decides which auto-resubmit branch a recovered case takes (ADR-0011 recovery cascade).
+## The actual resubmit (calling EvaluationService.submit) is performed by the Workspace /
+## Brief controllers subscribing to [signal active_case_recovered] — DEFERRED until those
+## controllers + EvaluationService exist. This pure helper locks + tests the decision.
+##
+## Precedence: a FROZEN workspace (committed submission awaiting evaluation) wins over a
+## SUBMITTING brief. Returns "workspace_resubmit" / "brief_resubmit" / "none".
+func recovery_branch_for(workspace_data: WorkspaceData, brief_editor_data: Object) -> String:
+	if workspace_data != null and workspace_data.state == WorkspaceData.WorkspaceState.FROZEN:
+		return "workspace_resubmit"
+	if brief_editor_data != null and brief_editor_data.get("state") == BRIEF_SUBMITTING:
+		return "brief_resubmit"
+	return "none"
+
+## BriefEditorData SUBMITTING state value. The BriefEditorData enum lives in the Brief
+## Editor epic; this mirrors its SUBMITTING ordinal until that class exists. (Brief
+## lifecycle per ADR-0001 amend-2.)
+const BRIEF_SUBMITTING: int = 3

--- a/src/services/save_load_service.gd
+++ b/src/services/save_load_service.gd
@@ -336,7 +336,9 @@ func _casebook_has(case_id: String) -> bool:
 ## AC-3. The [param result] is duck-typed (`case_id` / `verdict` / `final_score`) because
 ## the `EvaluationResult` class lives in the Submission/Evaluation epic. This handler is
 ## the subscriber for `EvaluationService.evaluation_completed`; that subscription is
-## DEFERRED until EvaluationService exists (TD-001 — submit signature must reconcile first).
+## DEFERRED until EvaluationService is implemented. (TD-001 RESOLVED 2026-05-23: the
+## EvaluationService entry point is `submit(submission: PlayerSubmission)` per ADR-0007 —
+## the control-manifest was corrected to match.)
 func _on_evaluation_completed(result: Object) -> void:
 	if _casebook == null:
 		_casebook = Casebook.new()

--- a/src/services/save_load_service.gd
+++ b/src/services/save_load_service.gd
@@ -1,0 +1,291 @@
+## SaveLoadService — autoload SIXTH. Atomic persistence SSOT for save/load.
+##
+## Story 001 scope: autoload skeleton + [code]user://saves/[/code] bootstrap +
+## the atomic write wrapper. Later stories add the save-data Resource classes
+## (002), signal-triggered autosave + debounce (003), boot load + corruption
+## recovery (004), resolution/recovery cascades (005/006), Anti-Pillar guards
+## (007), and the close-request forced flush (008).
+##
+## [b]Registration[/b]: [code]project.godot[/code] [autoload] section as
+## [code]SaveLoadService="*res://src/services/save_load_service.gd"[/code] — SIXTH
+## position per ADR-0011 (after LibraryService / UIService / CaseService; the
+## intermediate EvaluationService THIRD + SettingsService FIFTH slots are not yet
+## implemented — ordering is positional intent, not a hard prerequisite).
+##
+## [b]Class binding note[/b]: class_name is [code]SaveLoadServiceClass[/code] (not
+## SaveLoadService) because Godot 4.6 rejects a script whose class_name equals the
+## autoload node name ("Class X hides an autoload singleton"). The autoload
+## registration publishes the [code]SaveLoadService[/code] global symbol independently.
+## (Same pattern as [code]UIServiceClass[/code].)
+##
+## [b]Atomic write[/b]: [method _save_resource_atomic] writes to a [code].tmp[/code]
+## sibling then [method DirAccess.rename_absolute] over the target — atomic on POSIX
+## within one filesystem; Windows NTFS is best-effort (corruption detected on load
+## via schema_version / loader error, ADR-0011 + current-best-practices.md). Never
+## call [method ResourceSaver.save] directly onto the live target file.
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+class_name SaveLoadServiceClass extends Node
+
+
+# ─── Signals ──────────────────────────────────────────────────────────────────
+
+## Emitted when a save file fails to load (corrupt / wrong type / future version).
+## [param category] identifies which file (e.g. "active_case"). The file is renamed to
+## [code].backup[/code] first. Consumers show a CriticalBanner (UI Foundation
+## announce_text — deferred). AC-7.
+signal save_corrupted(category: String)
+
+## The single crash-recovery entry point (ADR-0011 + ADR-0001 amend-2 §C3): emitted at
+## boot when an in-progress case was loaded. Subscribers (Workspace / Brief controllers —
+## stories 006 / Brief epic) decide whether to auto-resubmit based on the recovered state.
+signal active_case_recovered(workspace_data: WorkspaceData, brief_editor_data: Resource)
+
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+## Root directory for all save data. Created on first [method _ready] if absent (EC-1).
+## Settings are NOT stored here — they live in a separate [code]user://user_settings.cfg[/code]
+## (ADR-0009 / Settings system), per forbidden pattern [code]save_load_settings_inclusion[/code].
+const SAVES_DIR: String = "user://saves/"
+
+## Current on-disk save schema version. Save Resources (story 002) carry a matching
+## [code]save_file_version[/code]; a loaded file with a higher version is treated as
+## corruption (story 002/004). ADR-0011 §Decision.
+const CURRENT_SAVE_FILE_VERSION: int = 1
+
+## Persisted file paths under [constant SAVES_DIR].
+const ACTIVE_CASE_FILE: String = "user://saves/active_case.tres"
+const CASEBOOK_FILE: String = "user://saves/casebook.tres"
+const SESSION_META_FILE: String = "user://saves/session_meta.cfg"
+
+## Per-category autosave debounce in milliseconds (ADR-0011 §Debounce Implementation).
+## A value of 0 means "save immediately" (resolution / recovery-critical categories).
+## Signal-triggered ONLY — never per-frame polling (forbidden: save_load_polling_based_autosave).
+const DEBOUNCE_MS: Dictionary = {
+	"workspace_state_changed": 250,
+	"brief_editor_state_changed": 250,
+	"brief_editor_submitted": 0,
+	"evaluation_completed": 0,
+	"submission_rejected": 0,
+	"case_state_changed": 0,
+}
+
+
+# ─── Built-in virtual methods ─────────────────────────────────────────────────
+
+## Ensures the save directory exists, then boot-loads persisted state and emits the
+## crash-recovery entry point. Per-category autosave timers are created lazily (story 003).
+func _ready() -> void:
+	_ensure_saves_dir()
+	await _boot_load()
+
+
+# ─── Public / internal methods ──────────────────────────────────────────────────
+
+## Creates [constant SAVES_DIR] if it does not already exist.
+##
+## AC-1: silent — no [code]push_warning[/code] on the normal (absent-dir) path.
+## A genuine failure to create the directory is an error worth surfacing.
+func _ensure_saves_dir() -> void:
+	if DirAccess.dir_exists_absolute(SAVES_DIR):
+		return
+	var err: Error = DirAccess.make_dir_recursive_absolute(SAVES_DIR)
+	if err != OK:
+		push_error("SaveLoadService: failed to create %s (error %d)" % [SAVES_DIR, err])
+
+
+## Atomically writes [param res] to [param target_path] via write-to-temp + rename.
+##
+## Steps: (1) [method ResourceSaver.save] to [code]<target>.tmp[/code]; (2)
+## [method DirAccess.rename_absolute] the tmp over the target. Returns [code]true[/code]
+## only when both succeed.
+##
+## AC-8: on success the target is fully replaced and no [code].tmp[/code] remains.
+## AC-9: if the tmp write fails (e.g. disk full / unwritable), returns [code]false[/code]
+## with a [code]push_error[/code] and the existing target file is left untouched —
+## the partial write never reaches the live file.
+##
+## ADR-0011 + docs/engine-reference/godot/current-best-practices.md (atomic write).
+func _save_resource_atomic(res: Resource, target_path: String) -> bool:
+	# IMPORTANT: ResourceSaver.save() picks its format from the file EXTENSION. A bare
+	# ".tmp" suffix yields ERR_FILE_UNRECOGNIZED, so the temp file must keep a recognized
+	# extension. Insert ".tmp" BEFORE the extension: "case.tres" -> "case.tmp.tres".
+	var tmp_path: String = "%s.tmp.%s" % [target_path.get_basename(), target_path.get_extension()]
+	var save_err: Error = ResourceSaver.save(res, tmp_path)
+	if save_err != OK:
+		push_error(
+			"SaveLoadService: temp write failed for %s (error %d) — target preserved" \
+			% [target_path, save_err]
+		)
+		return false
+	var rename_err: Error = DirAccess.rename_absolute(
+		ProjectSettings.globalize_path(tmp_path),
+		ProjectSettings.globalize_path(target_path),
+	)
+	if rename_err != OK:
+		push_error(
+			"SaveLoadService: rename failed %s -> %s (error %d) — target preserved" \
+			% [tmp_path, target_path, rename_err]
+		)
+		# Best-effort cleanup of the stray temp file so it cannot be mistaken for data.
+		if FileAccess.file_exists(tmp_path):
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(tmp_path))
+		return false
+	return true
+
+
+## Returns whether a loaded save Resource's [code]save_file_version[/code] can be read
+## by this build's schema.
+##
+## AC-11: a version greater than [constant CURRENT_SAVE_FILE_VERSION] is a future-format
+## file this build cannot understand — the caller (boot load, story 004) treats it as
+## corruption (rename to .backup + recovery cascade) rather than loading it. A version
+## less than current is forward-compatible — Godot [code]@export[/code] defaults fill any
+## fields the older file lacks (AC-10), so older files load normally. Version 0 / negative
+## is malformed.
+func _is_save_version_supported(version: int) -> bool:
+	return version >= 1 and version <= CURRENT_SAVE_FILE_VERSION
+
+
+# ─── Signal-triggered autosave + debounce (story 003) ─────────────────────────
+
+## The in-progress case snapshot autosaved on workspace/brief changes. Populated by
+## the boot load (story 004) or the runtime controllers; null when no case is active.
+var _active_case: ActiveCaseSaveData = null
+
+## Per-category debounce timers, created lazily. category(String) -> Timer.
+var _debounce_timers: Dictionary = {}
+
+## Handler for `workspace_state_changed` — schedules a debounced active_case save.
+## Connected (subscribe-if-present) to the live WorkspaceData / workspace controller
+## when it exists; for now it is the public entry the workspace side calls.
+func _on_workspace_changed(_old_state: int, _new_state: int) -> void:
+	_schedule_save("workspace_state_changed")
+
+## Schedules a save for [param category]. If the category's [constant DEBOUNCE_MS] is 0,
+## saves immediately; otherwise (re)starts the category's debounce timer so a burst of
+## changes within the window coalesces into a single save (EC-9).
+##
+## Signal-triggered only — there is deliberately no [code]_process[/code] /
+## [code]_physics_process[/code] autosave (forbidden: save_load_polling_based_autosave).
+func _schedule_save(category: String) -> void:
+	var ms: int = int(DEBOUNCE_MS.get(category, 0))
+	if ms == 0:
+		_perform_save(category)
+		return
+	var timer: Timer = _debounce_timer_for(category)
+	timer.wait_time = ms / 1000.0
+	timer.start()   # restarts if already running → debounce coalescing
+
+## Returns (creating on first use) the one-shot debounce Timer for [param category].
+func _debounce_timer_for(category: String) -> Timer:
+	if _debounce_timers.has(category):
+		return _debounce_timers[category]
+	var timer := Timer.new()
+	timer.one_shot = true
+	timer.timeout.connect(func() -> void: _perform_save(category))
+	add_child(timer)
+	_debounce_timers[category] = timer
+	return timer
+
+## Writes the save category to disk via the atomic wrapper. Story 003 implements the
+## active_case path (workspace/brief categories); resolution/recovery categories
+## (casebook/career) are wired in stories 005/006.
+func _perform_save(category: String) -> void:
+	match category:
+		"workspace_state_changed", "brief_editor_state_changed", "brief_editor_submitted":
+			if _active_case == null:
+				return   # nothing to persist yet
+			_save_resource_atomic(_active_case, ACTIVE_CASE_FILE)
+		_:
+			pass   # casebook / career / lifecycle categories — stories 005/006
+
+
+# ─── Boot load + crash-recovery entry (story 004) ─────────────────────────────
+
+## The eager-loaded casebook (story 004). Empty until loaded.
+var _casebook: Casebook = null
+
+## Session-meta values loaded from `session_meta.cfg` (AC-16). Consumers (Browser auto-entry,
+## Workspace F2-toast suppression) read these; they default safely when the file is absent.
+var last_active_case_id: String = ""
+var workspace_f2_hint_seen: bool = false
+
+## Boot sequence: eager-load casebook + session meta, load (or recover) the active case,
+## then emit [signal active_case_recovered] for the crash-recovery subscribers (story 006).
+func _boot_load() -> void:
+	_casebook = _load_casebook()
+	_load_session_meta()
+	_active_case = _load_active_case_or_recover()
+	# Defer the recovery emit one frame so subscriber autoloads/controllers have run
+	# their _ready (ADR-0001 amend-2 §C3 pattern).
+	await get_tree().process_frame
+	if _active_case != null:
+		active_case_recovered.emit(_active_case.workspace_data, _active_case.brief_editor_data)
+
+## Loads the active case, or returns null. On corruption (load failure / wrong type /
+## unsupported version) renames the file to `.backup`, emits [signal save_corrupted],
+## and returns null so the boot continues with a fresh state (AC-7 / EC-3). Absent file
+## → null with no side effects (EC-2 fresh start).
+func _load_active_case_or_recover() -> ActiveCaseSaveData:
+	if not FileAccess.file_exists(ACTIVE_CASE_FILE):
+		return null
+	var res: Resource = ResourceLoader.load(ACTIVE_CASE_FILE, "", ResourceLoader.CACHE_MODE_IGNORE)
+	if res == null or not (res is ActiveCaseSaveData) or not _is_save_version_supported((res as ActiveCaseSaveData).save_file_version):
+		push_error("SaveLoadService: active_case load failed/corrupt — renaming to .backup")
+		_rename_to_backup(ACTIVE_CASE_FILE)
+		save_corrupted.emit("active_case")
+		return null
+	return res as ActiveCaseSaveData
+
+## Eager-loads the casebook, or returns a fresh empty [Casebook] when absent (EC-2).
+## A corrupt casebook is recovered the same way as the active case (.backup + signal).
+func _load_casebook() -> Casebook:
+	if not FileAccess.file_exists(CASEBOOK_FILE):
+		return Casebook.new()
+	var res: Resource = ResourceLoader.load(CASEBOOK_FILE, "", ResourceLoader.CACHE_MODE_IGNORE)
+	if res == null or not (res is Casebook) or not _is_save_version_supported((res as Casebook).save_file_version):
+		push_error("SaveLoadService: casebook load failed/corrupt — renaming to .backup")
+		_rename_to_backup(CASEBOOK_FILE)
+		save_corrupted.emit("casebook")
+		return Casebook.new()
+	return res as Casebook
+
+## Loads session meta (last active case + UI hints) from the `.cfg`. Missing file → defaults.
+func _load_session_meta() -> void:
+	var cfg := ConfigFile.new()
+	if cfg.load(SESSION_META_FILE) != OK:
+		return   # absent / unreadable → keep safe defaults
+	last_active_case_id = cfg.get_value("session", "last_active_case_id", "")
+	workspace_f2_hint_seen = cfg.get_value("hints", "workspace_f2_hint_seen", false)
+
+## Renames [param path] to [code]<path>.backup[/code] (best-effort), so a corrupt file is
+## preserved for diagnostics and not overwritten in place.
+func _rename_to_backup(path: String) -> void:
+	if not FileAccess.file_exists(path):
+		return
+	DirAccess.rename_absolute(
+		ProjectSettings.globalize_path(path),
+		ProjectSettings.globalize_path(path + ".backup"),
+	)
+
+
+# ─── Anti-Pillar serialization guards (story 007) ─────────────────────────────
+
+## Validates an active-case snapshot before it is persisted.
+##
+## AC-13: the embedded chain_data must not contain ephemeral / non-allow-listed fields
+## (`chain_data_include_ephemeral_field`). This delegates to the SINGLE canonical
+## validator [method WorkspaceData.validate_chain_data] — the allow-list is never
+## duplicated here (`chain_data_schema_allow_list_duplication`). On a violation that
+## validator emits `submission_rejected` and returns false.
+##
+## AC-12 (Settings exclusion, `save_load_settings_inclusion`) is structural: an
+## [ActiveCaseSaveData] has no Settings fields — Settings persist separately in
+## `user://user_settings.cfg` (ADR-0009). There is nothing to strip at write time.
+func _validate_active_case(active: ActiveCaseSaveData) -> bool:
+	if active == null or active.workspace_data == null:
+		return true   # nothing to validate
+	return active.workspace_data.validate_chain_data(active.workspace_data.chain_data_snapshot)

--- a/src/services/save_load_service.gd.uid
+++ b/src/services/save_load_service.gd.uid
@@ -1,0 +1,1 @@
+uid://boeesjhjockhb

--- a/src/ui/kr_banner.gd
+++ b/src/ui/kr_banner.gd
@@ -1,0 +1,70 @@
+## KrBanner — non-editable banner / notification strip primitive.
+##
+## Extends [PanelContainer] directly (not a common KrCustomControl base — see ADR-0010
+## §Decision Note on composition + static-helper pattern). Shared behavior is
+## provided via [KrControlHelper.setup].
+##
+## [b]Theme type variation[/b]: [code]&"Banner"[/code] — 32px height + 잉크블랙
+## background + 흰 텍스트 (story 003 populates the actual Theme variation). Subclass
+## variations (ReadOnlyBanner / CriticalBanner / ToastBanner) use more specific tags.
+##
+## [b]AccessKit role[/b]: [code]DisplayServer.AccessibilityRole.ROLE_STATIC_TEXT[/code] (=4).
+## Godot 4.6 has no WAI-ARIA [code]role=status[/code] or [code]role=alert[/code]
+## equivalent in [code]AccessibilityRole[/code]. Live-region semantics are handled
+## separately via [code]UIService.announce_text()[/code] (ADR-0010 amend-1 §G2/§G3).
+## Dynamic banners MUST call [code]UIService.announce_text()[/code] on appearance —
+## see forbidden pattern [code]kr_banner_dynamic_show_without_announce[/code] in
+## [code]docs/registry/architecture.yaml[/code].
+##
+## [b]Role API note (Godot 4.6 deviation)[/b]: There is no [code]Control.set_accessibility_role()[/code]
+## or [code]accessibility_role[/code] property in Godot 4.6. See [constant ACCESSIBILITY_ROLE].
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md
+## TR:  TR-ui-005
+class_name KrBanner extends PanelContainer
+
+## Preloaded to avoid class_name global cache dependency in headless runs.
+const _KrControlHelper: Script = preload("res://src/ui/kr_control_helper.gd")
+
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+## Intended AccessKit role integer for this class.
+##
+## [code]DisplayServer.AccessibilityRole.ROLE_STATIC_TEXT[/code] = 4.
+## Godot 4.6 has no [code]ROLE_STATUS[/code] or [code]ROLE_ALERT[/code]
+## (hallucinated names — see ADR-0010 amend-1 §G1). ROLE_STATIC_TEXT is the
+## correct cap for all KrBanner family members.
+const ACCESSIBILITY_ROLE: int = 4  # DisplayServer.AccessibilityRole.ROLE_STATIC_TEXT
+
+
+# ─── Built-in virtual methods ─────────────────────────────────────────────────
+
+## Applies the [code]&"Banner"[/code] theme type variation and calls
+## [method KrControlHelper.setup], which queues [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code].
+func _ready() -> void:
+	theme_type_variation = &"Banner"
+	_KrControlHelper.setup(self)
+
+
+## Handles [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code] by calling
+## [method _apply_access_kit_role] at the correct engine notification cycle.
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_ACCESSIBILITY_UPDATE:
+		_apply_access_kit_role()
+
+
+# ─── Public methods ────────────────────────────────────────────────────────────
+
+## Assigns the AccessKit role [code]ROLE_STATIC_TEXT[/code] (=4) via
+## [code]DisplayServer.accessibility_update_set_role[/code].
+##
+## Called from [method _notification] when [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code]
+## fires (the RID from [method Control.get_accessibility_element] is only valid inside
+## that notification cycle). The call is silently skipped if the RID is invalid
+## (headless / editor-only contexts). Override in subclasses if a different
+## non-interactive text role is appropriate.
+func _apply_access_kit_role() -> void:
+	var rid: RID = get_accessibility_element()
+	if rid.is_valid():
+		DisplayServer.accessibility_update_set_role(rid, DisplayServer.AccessibilityRole.ROLE_STATIC_TEXT)

--- a/src/ui/kr_button.gd
+++ b/src/ui/kr_button.gd
@@ -1,0 +1,66 @@
+## KrButton — styled button primitive for primary and dialog actions.
+##
+## Extends [Button] directly (not a common KrCustomControl base — see ADR-0010
+## §Decision Note on composition + static-helper pattern). Shared behavior is
+## provided via [KrControlHelper.setup].
+##
+## [b]Theme type variation[/b]: [code]&"Button"[/code] — 잉크블랙 fill + 흰 텍스트
+## Pretendard Medium + 8px padding (story 003 populates the actual Theme variation).
+## Variants (SubmitButton, DialogButton) are additional type variations assigned
+## by subclasses or callers; this class provides the default [code]&"Button"[/code] tag.
+##
+## [b]AccessKit role[/b]: [code]DisplayServer.AccessibilityRole.ROLE_BUTTON[/code] (=7).
+## [Button] already carries native button semantics in Godot, but explicit role
+## assignment ensures AccessKit screen readers receive the correct announcement even
+## when theme type variation is changed.
+##
+## [b]Role API note (Godot 4.6 — runtime-verified)[/b]: Role assignment uses
+## [code]DisplayServer.accessibility_update_set_role[/code] inside
+## [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code]. See [constant ACCESSIBILITY_ROLE].
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md
+## TR:  TR-ui-005
+class_name KrButton extends Button
+
+## Preloaded to avoid class_name global cache dependency in headless runs.
+const _KrControlHelper: Script = preload("res://src/ui/kr_control_helper.gd")
+
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+## Intended AccessKit role integer for this class.
+##
+## [code]DisplayServer.AccessibilityRole.ROLE_BUTTON[/code] = 7.
+## Exposed as a constant so unit tests can verify the intended role without
+## requiring a live display.
+const ACCESSIBILITY_ROLE: int = 7  # DisplayServer.AccessibilityRole.ROLE_BUTTON
+
+
+# ─── Built-in virtual methods ─────────────────────────────────────────────────
+
+## Applies the [code]&"Button"[/code] theme type variation and calls
+## [method KrControlHelper.setup], which queues [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code].
+func _ready() -> void:
+	theme_type_variation = &"Button"
+	_KrControlHelper.setup(self)
+
+
+## Handles [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code] by calling
+## [method _apply_access_kit_role] at the correct engine notification cycle.
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_ACCESSIBILITY_UPDATE:
+		_apply_access_kit_role()
+
+
+# ─── Public methods ────────────────────────────────────────────────────────────
+
+## Assigns the AccessKit role [code]ROLE_BUTTON[/code] (=7) via
+## [code]DisplayServer.accessibility_update_set_role[/code].
+##
+## Called from [method _notification] when [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code]
+## fires. Override in subclasses if a more specific button-family role is required
+## (e.g. [code]ROLE_CHECK_BUTTON[/code] =11 for toggle behavior).
+func _apply_access_kit_role() -> void:
+	var rid: RID = get_accessibility_element()
+	if rid.is_valid():
+		DisplayServer.accessibility_update_set_role(rid, DisplayServer.AccessibilityRole.ROLE_BUTTON)

--- a/src/ui/kr_card.gd
+++ b/src/ui/kr_card.gd
@@ -1,0 +1,69 @@
+## KrCard — base card primitive for content display (LibraryCard, HypothesisNode, etc.).
+##
+## Extends [PanelContainer] directly (not a common KrCustomControl base — see ADR-0010
+## §Decision Note on composition + static-helper pattern). Shared behavior is
+## provided via [KrControlHelper.setup].
+##
+## [b]Theme type variation[/b]: [code]&"Card"[/code] — PanelContainer + 12px padding
+## + 판결지 background + 1.5px outline 미드그레이 (story 003 populates the actual
+## Theme variation).
+##
+## [b]AccessKit role[/b]: [code]DisplayServer.AccessibilityRole.ROLE_PANEL[/code] (=6).
+## Subclasses (LibraryCard, HypothesisNode, EnvelopeCard, GroundsCard) override
+## [method _apply_access_kit_role] with their specific roles (see ADR-0010 §Architecture
+## Diagram + amend-1 §G1 for the full corrected mapping).
+##
+## [b]Role API note (Godot 4.6 — runtime-verified)[/b]: Role assignment uses
+## [code]DisplayServer.accessibility_update_set_role[/code] inside
+## [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code]. See [constant ACCESSIBILITY_ROLE].
+##
+## Note: story 007/008 reference a KrCard subclass (HypothesisNode). This file
+## contains the minimal base per ADR-0010 §Decision Note.
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md
+## TR:  TR-ui-005
+class_name KrCard extends PanelContainer
+
+## Preloaded to avoid class_name global cache dependency in headless runs.
+const _KrControlHelper: Script = preload("res://src/ui/kr_control_helper.gd")
+
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+## Intended AccessKit role integer for this class.
+##
+## [code]DisplayServer.AccessibilityRole.ROLE_PANEL[/code] = 6.
+## Subclasses override [method _apply_access_kit_role] and should define their own
+## [constant ACCESSIBILITY_ROLE] (LibraryCard=30, HypothesisNode=28, EnvelopeCard=7,
+## GroundsCard=9 — ADR-0010 amend-1 §G1).
+const ACCESSIBILITY_ROLE: int = 6  # DisplayServer.AccessibilityRole.ROLE_PANEL
+
+
+# ─── Built-in virtual methods ─────────────────────────────────────────────────
+
+## Applies the [code]&"Card"[/code] theme type variation and calls
+## [method KrControlHelper.setup], which queues [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code].
+func _ready() -> void:
+	theme_type_variation = &"Card"
+	_KrControlHelper.setup(self)
+
+
+## Handles [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code] by calling
+## [method _apply_access_kit_role] at the correct engine notification cycle.
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_ACCESSIBILITY_UPDATE:
+		_apply_access_kit_role()
+
+
+# ─── Public methods ────────────────────────────────────────────────────────────
+
+## Assigns the AccessKit role [code]ROLE_PANEL[/code] (=6) via
+## [code]DisplayServer.accessibility_update_set_role[/code].
+##
+## Called from [method _notification] when [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code]
+## fires. Override in subclasses (LibraryCard → ROLE_LIST_ITEM, HypothesisNode →
+## ROLE_TREE_ITEM, EnvelopeCard → ROLE_BUTTON, GroundsCard → ROLE_CHECK_BOX).
+func _apply_access_kit_role() -> void:
+	var rid: RID = get_accessibility_element()
+	if rid.is_valid():
+		DisplayServer.accessibility_update_set_role(rid, DisplayServer.AccessibilityRole.ROLE_PANEL)

--- a/src/ui/kr_control_helper.gd
+++ b/src/ui/kr_control_helper.gd
@@ -1,0 +1,61 @@
+## KrControlHelper — static utility for shared Kr* Control setup behavior.
+##
+## All Kr* Control classes call [method setup] from their [code]_ready()[/code] to apply
+## SettingsService signal subscriptions and queue the AccessKit role update.
+##
+## Design rationale (ADR-0010 §Decision Note): GDScript does not support multiple
+## inheritance, so Kr* classes each extend their native Godot Control base directly
+## (Container / PanelContainer / Button / …). Shared behavior is reused via this
+## static-helper composition pattern instead of a common KrCustomControl base class.
+##
+## [b]SettingsService wiring[/b]: Real 3-signal subscription (text_scale /
+## reduced_motion / focus_indicator_thickness_px) is deferred to story 005 /
+## workspace 009. This story guards with [code]Engine.has_singleton("SettingsService")[/code]
+## and skips if absent.
+##
+## [b]AccessKit role API (Godot 4.6 — runtime-verified)[/b]:
+## [code]DisplayServer.accessibility_update_set_role()[/code] MUST be called inside
+## [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code] (value 3000). Calling it outside that
+## notification causes an engine ERROR. The correct pattern:
+## [codeblock]
+## # In _ready(): queue the update — engine fires NOTIFICATION_ACCESSIBILITY_UPDATE later
+## func _ready() -> void:
+##     theme_type_variation = &"Pane"
+##     KrControlHelper.setup(self)         # calls queue_accessibility_update()
+##
+## # In _notification(): set the role when the engine requests it
+## func _notification(what: int) -> void:
+##     if what == NOTIFICATION_ACCESSIBILITY_UPDATE:
+##         _apply_access_kit_role()
+## [/codeblock]
+## [method setup] calls [method Control.queue_accessibility_update] to schedule the
+## notification. [method _apply_access_kit_role] is NOT dispatched directly from
+## [method setup] — subclasses call it from [code]_notification[/code] override.
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md
+## TR:  TR-ui-005
+class_name KrControlHelper extends RefCounted
+
+
+## Sets up a Kr* Control instance.
+##
+## Call from [code]_ready()[/code] in every Kr* subclass after setting
+## [member Control.theme_type_variation]:
+## [codeblock]
+## func _ready() -> void:
+##     theme_type_variation = &"Pane"
+##     KrControlHelper.setup(self)
+## [/codeblock]
+##
+## Steps performed:
+## 1. If [code]SettingsService[/code] autoload is registered, subscribes to the
+##    3 settings signals (stub — real wiring in story 005 / workspace 009).
+## 2. Calls [method Control.queue_accessibility_update] to schedule
+##    [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code]. Subclasses respond to this
+##    notification in [code]_notification()[/code] by calling [method _apply_access_kit_role].
+##
+## [param control]: The Kr* Control instance calling setup (pass [code]self[/code]).
+static func setup(control: Control) -> void:
+	if Engine.has_singleton("SettingsService"):
+		pass  # SettingsService 3-signal subscription — real wiring in story 005 / workspace 009
+	control.queue_accessibility_update()

--- a/src/ui/kr_pane.gd
+++ b/src/ui/kr_pane.gd
@@ -1,0 +1,70 @@
+## KrPane — layout panel primitive for 3-pane and section container usage.
+##
+## Extends [Container] directly (not a common KrCustomControl base — see ADR-0010
+## §Decision Note on composition + static-helper pattern). Shared behavior is
+## provided via [KrControlHelper.setup].
+##
+## [b]Theme type variation[/b]: [code]&"Pane"[/code] — PanelContainer + 16px padding
+## + 판결지 #F5F2EC background (story 003 populates the actual Theme variation).
+##
+## [b]AccessKit role[/b]: [code]DisplayServer.AccessibilityRole.ROLE_PANEL[/code] (=6).
+## Maps to WAI-ARIA [code]role=group[/code] — closest available in Godot 4.6 (ROLE_REGION
+## is absent; see ADR-0010 amend-1 §G1 for the corrected mapping rationale).
+##
+## [b]Role API note (Godot 4.6 — runtime-verified)[/b]: Role assignment requires
+## [code]DisplayServer.accessibility_update_set_role(rid, role)[/code] which MUST be
+## called inside [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code] (=3000). The method
+## [code]Control.set_accessibility_role()[/code] and property [code]accessibility_role[/code]
+## do NOT exist in Godot 4.6. [method KrControlHelper.setup] calls
+## [method Control.queue_accessibility_update]; this class handles the notification in
+## [method _notification]. The constant [constant ACCESSIBILITY_ROLE] exposes the
+## intended role integer for testability without requiring a live display.
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md
+## TR:  TR-ui-005
+class_name KrPane extends Container
+
+## Preloaded to avoid class_name global cache dependency in headless runs.
+const _KrControlHelper: Script = preload("res://src/ui/kr_control_helper.gd")
+
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+## Intended AccessKit role integer for this class.
+##
+## [code]DisplayServer.AccessibilityRole.ROLE_PANEL[/code] = 6.
+## Exposed as a constant so unit tests can verify the intended role without
+## requiring a live display (the RID-based API is only available inside
+## [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code]).
+## ADR-0010 amend-1 §G1 corrected mapping: was ROLE_REGION (absent in Godot 4.6).
+const ACCESSIBILITY_ROLE: int = 6  # DisplayServer.AccessibilityRole.ROLE_PANEL
+
+
+# ─── Built-in virtual methods ─────────────────────────────────────────────────
+
+## Applies the [code]&"Pane"[/code] theme type variation and calls
+## [method KrControlHelper.setup], which queues [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code].
+func _ready() -> void:
+	theme_type_variation = &"Pane"
+	_KrControlHelper.setup(self)
+
+
+## Handles [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code] by calling
+## [method _apply_access_kit_role] at the correct engine notification cycle.
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_ACCESSIBILITY_UPDATE:
+		_apply_access_kit_role()
+
+
+# ─── Public methods ────────────────────────────────────────────────────────────
+
+## Assigns the AccessKit role [code]ROLE_PANEL[/code] (=6) via
+## [code]DisplayServer.accessibility_update_set_role[/code].
+##
+## Called from [method _notification] when [code]NOTIFICATION_ACCESSIBILITY_UPDATE[/code]
+## fires. The RID is valid inside this notification cycle. Override in subclasses
+## to assign a more specific role.
+func _apply_access_kit_role() -> void:
+	var rid: RID = get_accessibility_element()
+	if rid.is_valid():
+		DisplayServer.accessibility_update_set_role(rid, DisplayServer.AccessibilityRole.ROLE_PANEL)

--- a/src/ui/ui_service.gd
+++ b/src/ui/ui_service.gd
@@ -1,0 +1,170 @@
+## UIService — autoload SECOND. Theme + Reduced Motion gateway + announce_text SSOT.
+##
+## Story 001 scope: Theme instance + viewport_resized signal + ui_service_initialized signal.
+## Stories 003/004/005 populate Theme variations, add tween_property gateway, announce_text API.
+##
+## [b]Registration[/b]: Add to [code]project.godot[/code] [autoload] section as
+## [code]UIService="*res://src/ui/ui_service.gd"[/code] SECOND position
+## (after LibraryService, before CaseService).
+##
+## [b]Class binding note[/b]: class_name is [code]UIServiceClass[/code] (not UIService)
+## because Godot 4.6 rejects scripts where class_name equals the autoload node name
+## ("Class X hides an autoload singleton" error). The autoload registration publishes
+## the [code]UIService[/code] global symbol independently.
+##
+## [b]Theme access[/b]: [member theme] is a read-only property. Direct assignment is
+## rejected with [code]push_error[/code] and no mutation (Option C guard pattern —
+## same as WorkspaceData.state). Story 003 populates type variations via UIService
+## API methods; story 001 registers an empty Theme as the cascade root.
+##
+## [b]Viewport reflow[/b]: [signal viewport_reflow_needed] is debounced by
+## [constant VIEWPORT_REFLOW_DEBOUNCE_MS] milliseconds. Multiple [code]size_changed[/code]
+## fires within the debounce window coalesce into exactly one [signal viewport_reflow_needed]
+## emit (timer.start() resets an already-running timer).
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md
+## TR:  TR-ui-001
+class_name UIServiceClass extends Node
+
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+## Debounce window in milliseconds for viewport size changes.
+##
+## AC-1.4: Multiple [code]size_changed[/code] fires within this window coalesce
+## into exactly one [signal viewport_reflow_needed] emit.
+## GDD §7.1 source value: 50 ms.
+const VIEWPORT_REFLOW_DEBOUNCE_MS := 50
+
+
+# ─── Signals ──────────────────────────────────────────────────────────────────
+
+## Emitted once at the end of [method _ready], after Theme instantiation and
+## viewport signal connection. Downstream autoloads (CaseService THIRD) and
+## scene Controls should await or connect to this to confirm UIService is live.
+##
+## AC-1: Fires synchronously before any Controls _ready() because UIService is
+## autoload SECOND (LibraryService FIRST → UIService SECOND → CaseService THIRD).
+signal ui_service_initialized()
+
+## Emitted after the debounce timer expires following a viewport size change.
+##
+## AC-1.3: Coalesces rapid [code]size_changed[/code] fires into one emit.
+## KrCustomControl (story 002) and layout nodes connect to this to trigger reflow.
+signal viewport_reflow_needed()
+
+
+# ─── Private state ────────────────────────────────────────────────────────────
+
+## Backing variable for the public [member theme] property.
+## Written once in [method _ready]. Story 003 mutates via Theme API (set_font_size,
+## set_color, add_type) — never reassigns this reference.
+var _theme: Theme = Theme.new()
+
+## One-shot debounce timer. Created in [method _ready], added as child so it
+## participates in the scene tree and its [signal Timer.timeout] fires correctly.
+var _viewport_debounce_timer: Timer
+
+
+# ─── Public read-only property ────────────────────────────────────────────────
+
+## Current theme instance. Read-only via public API.
+##
+## AC-1.2: The setter rejects direct assignment with [code]push_error[/code] and
+## returns without mutation (Option C guard — identical to WorkspaceData.state).
+## Use Theme mutation methods (Theme.set_font_size, Theme.set_color, etc.) to
+## modify the theme; call those through UIService API methods added in story 003.
+var theme: Theme:
+	get:
+		return _theme
+	set(_value):
+		push_error(
+			"UIService.theme is read-only. " +
+			"Use Theme.set_font_size/set_color via UIService methods (story 003)."
+		)
+
+
+# ─── Built-in virtual methods ─────────────────────────────────────────────────
+
+## Initializes the UIService: creates the Theme instance, sets up the debounce
+## Timer, connects the viewport [code]size_changed[/code] signal, and emits
+## [signal ui_service_initialized].
+##
+## AC-1: All setup completes in _ready() before any scene Control nodes initialize.
+func _ready() -> void:
+	_viewport_debounce_timer = Timer.new()
+	_viewport_debounce_timer.wait_time = VIEWPORT_REFLOW_DEBOUNCE_MS / 1000.0
+	_viewport_debounce_timer.one_shot = true
+	_viewport_debounce_timer.timeout.connect(_on_viewport_debounce_timeout)
+	add_child(_viewport_debounce_timer)
+	get_viewport().size_changed.connect(_on_viewport_size_changed)
+	ui_service_initialized.emit()
+
+
+# ─── Signal callbacks ──────────────────────────────────────────────────────────
+
+## Starts (or resets if already running) the debounce timer on every viewport
+## size change.
+##
+## AC-1.3: Calling [method Timer.start] on an already-running timer resets it,
+## so rapid [code]size_changed[/code] fires within [constant VIEWPORT_REFLOW_DEBOUNCE_MS]
+## coalesce into a single [signal viewport_reflow_needed] emit.
+func _on_viewport_size_changed() -> void:
+	_viewport_debounce_timer.start()
+
+
+## Emits [signal viewport_reflow_needed] after the debounce window expires.
+##
+## Called by the one-shot [member _viewport_debounce_timer] timeout. Consumers
+## (KrCustomControl, layout nodes) recalculate layout in response to this signal.
+func _on_viewport_debounce_timeout() -> void:
+	viewport_reflow_needed.emit()
+
+
+# ─── Reduced Motion + animation gateway (story 004) ──────────────────────────
+
+## Whether Reduced Motion is active. When true, [method tween_property] applies the
+## final value immediately and creates no Tween.
+##
+## AC-10: Defaults to [code]false[/code] (animations play) — the safe default when
+## SettingsService is not yet integrated. The real value is driven by the
+## SettingsService [code]display.reduced_motion[/code] signal subscription, wired in
+## story 005 / workspace 009. This state field is the integration seam: the settings
+## subscriber sets it; [method tween_property] reads it.
+##
+## NOTE (deviation from story-004 pseudo-code): the story queried
+## [code]Engine.has_singleton("SettingsService")[/code] + [code]SettingsService.get(...)[/code]
+## synchronously on each call. Autoloads are scene-tree nodes at [code]/root[/code], not
+## Engine singletons, so [code]Engine.has_singleton[/code] is an unreliable presence check
+## for them (story 005/009 to resolve). A settable state field driven by the settings
+## signal is both correct and testable, and avoids a per-call lookup.
+var reduced_motion: bool = false
+
+## Animation gateway — the single sanctioned way to create property tweens.
+##
+## AC-15: With [member reduced_motion] false, creates a [Tween], chains a
+## [code]tween_property[/code] toward [param final_value] over [param duration] seconds,
+## and returns the Tween (callers may chain further on it).
+## AC-16: With [member reduced_motion] true, sets [param property] on [param target]
+## to [param final_value] immediately via [method Object.set_indexed] and returns
+## [code]null[/code] — no Tween is created (zero animation, zero allocation per the
+## performance budget).
+##
+## Forbidden pattern [code]direct_create_tween_bypassing_reduced_motion[/code]
+## (docs/registry/architecture.yaml): all UI animation MUST route through this gateway;
+## never call [method Node.create_tween] directly in UI code.
+func tween_property(
+	target: Object,
+	property: NodePath,
+	final_value: Variant,
+	duration: float
+) -> Tween:
+	if target == null:
+		push_error("UIService.tween_property: target must not be null")
+		return null
+	if reduced_motion:
+		target.set_indexed(property, final_value)
+		return null
+	var tween: Tween = create_tween()
+	tween.tween_property(target, property, final_value, duration)
+	return tween

--- a/tests/integration/save_load/atomic_write_test.gd
+++ b/tests/integration/save_load/atomic_write_test.gd
@@ -1,0 +1,130 @@
+## atomic_write_test.gd — SaveLoadService autoload bootstrap + atomic write wrapper.
+##
+## Covers story-001 Acceptance Criteria:
+##   AC-1  _ready() creates user://saves/ silently when absent (idempotent if present).
+##   AC-8  _save_resource_atomic success → target fully written, no .tmp left, round-trips.
+##   AC-9  _save_resource_atomic with a failing temp write → returns false + existing
+##         target left untouched (partial write never reaches the live file).
+##
+## Test strategy:
+##   Preload the script (bypass class_name global cache — same as ui_service_test.gd).
+##   _save_resource_atomic is pure file I/O; tests instantiate the service, exercise it
+##   against unique user:// paths, and clean up after each test. AC-9 forces a temp-write
+##   failure deterministically by pre-creating a DIRECTORY at the .tmp path, so
+##   ResourceSaver.save cannot write a file there.
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/integration/save_load/atomic_write_test.gd
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+extends GdUnitTestSuite
+
+
+const _SaveLoadServiceScript: Script = preload("res://src/services/save_load_service.gd")
+
+const SAVES_DIR: String = "user://saves/"
+const AC8_TARGET: String = "user://saves/test_ac8_atomic.tres"
+const AC9_TARGET: String = "user://saves/test_ac9_preserve.tres"
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+## Fresh SaveLoadService instance in the tree (so _ready runs), auto-freed.
+func _make_service() -> Node:
+	var svc: Node = _SaveLoadServiceScript.new()
+	get_tree().root.add_child(svc)
+	auto_free(svc)
+	return svc
+
+
+## A WorkspaceData carrying a recognizable marker in an @export field.
+func _marker_resource(marker: String) -> WorkspaceData:
+	var ws: WorkspaceData = WorkspaceData.new()
+	ws.pending_citation = marker   # @export String — round-trips through .tres
+	return ws
+
+
+func _remove_if_exists(path: String) -> void:
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+# ─── AC-1 — saves/ directory bootstrap ────────────────────────────────────────
+
+func test_ready_creates_saves_dir_when_absent() -> void:
+	# Arrange — remove the dir if a prior run left it (best-effort; dir may be non-empty
+	# from other tests, so only assert creation, not pre-absence).
+	# Act — _ready() runs on add_child
+	_make_service()
+
+	# Assert — the saves dir exists after _ready()
+	assert_bool(DirAccess.dir_exists_absolute(SAVES_DIR)).is_true()
+
+
+func test_ensure_saves_dir_is_idempotent_when_present() -> void:
+	# Arrange — service (dir now exists)
+	var svc: Node = _make_service()
+	assert_bool(DirAccess.dir_exists_absolute(SAVES_DIR)).is_true()
+
+	# Act — calling again must not error or recreate
+	svc._ensure_saves_dir()
+
+	# Assert — still present, no crash
+	assert_bool(DirAccess.dir_exists_absolute(SAVES_DIR)).is_true()
+
+
+# ─── AC-8 — atomic write success ──────────────────────────────────────────────
+
+func test_save_resource_atomic_writes_target_and_removes_tmp() -> void:
+	# Arrange
+	var svc: Node = _make_service()
+	# Temp path keeps a recognized extension: "x.tres" -> "x.tmp.tres"
+	var ac8_tmp: String = "%s.tmp.%s" % [AC8_TARGET.get_basename(), AC8_TARGET.get_extension()]
+	_remove_if_exists(AC8_TARGET)
+	_remove_if_exists(ac8_tmp)
+	var res: WorkspaceData = _marker_resource("AC8-marker")
+
+	# Act
+	var ok: bool = svc._save_resource_atomic(res, AC8_TARGET)
+
+	# Assert — success; target exists; no leftover .tmp; round-trips the marker
+	assert_bool(ok).is_true()
+	assert_bool(FileAccess.file_exists(AC8_TARGET)).is_true()
+	assert_bool(FileAccess.file_exists(ac8_tmp)).is_false()
+	var loaded: WorkspaceData = ResourceLoader.load(AC8_TARGET, "", ResourceLoader.CACHE_MODE_IGNORE) as WorkspaceData
+	assert_object(loaded).is_not_null()
+	assert_str(loaded.pending_citation).is_equal("AC8-marker")
+
+	# Cleanup
+	_remove_if_exists(AC8_TARGET)
+
+
+# ─── AC-9 — temp write failure preserves existing target ──────────────────────
+
+func test_save_resource_atomic_failure_preserves_existing_target() -> void:
+	# Arrange — write a valid target (marker A) via the atomic wrapper
+	var svc: Node = _make_service()
+	_remove_if_exists(AC9_TARGET)
+	var first_ok: bool = svc._save_resource_atomic(_marker_resource("AC9-original"), AC9_TARGET)
+	assert_bool(first_ok).is_true()
+
+	# Force a temp-write failure: create a DIRECTORY at the .tmp path so
+	# ResourceSaver.save cannot write a file there. (Temp path: "x.tres" -> "x.tmp.tres".)
+	var tmp_path: String = "%s.tmp.%s" % [AC9_TARGET.get_basename(), AC9_TARGET.get_extension()]
+	DirAccess.make_dir_recursive_absolute(tmp_path)
+	assert_bool(DirAccess.dir_exists_absolute(tmp_path)).is_true()
+
+	# Act — attempt to overwrite with marker B; temp write must fail
+	var second_ok: bool = svc._save_resource_atomic(_marker_resource("AC9-NEW-should-not-land"), AC9_TARGET)
+
+	# Assert — returned false; the existing target still holds marker A (untouched)
+	assert_bool(second_ok).is_false()
+	var loaded: WorkspaceData = ResourceLoader.load(AC9_TARGET, "", ResourceLoader.CACHE_MODE_IGNORE) as WorkspaceData
+	assert_object(loaded).is_not_null()
+	assert_str(loaded.pending_citation).is_equal("AC9-original")
+
+	# Cleanup — remove the blocking dir + target
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(tmp_path))
+	_remove_if_exists(AC9_TARGET)

--- a/tests/integration/save_load/atomic_write_test.gd.uid
+++ b/tests/integration/save_load/atomic_write_test.gd.uid
@@ -1,0 +1,1 @@
+uid://d2qf8b1gitiha

--- a/tests/integration/save_load/autosave_debounce_test.gd
+++ b/tests/integration/save_load/autosave_debounce_test.gd
@@ -1,0 +1,130 @@
+## autosave_debounce_test.gd — SaveLoadService signal-triggered autosave + debounce.
+##
+## Covers story-003 Acceptance Criteria:
+##   AC-2   workspace_state_changed → debounced active_case save (_perform_save writes
+##          active_case.tres via the atomic wrapper).
+##   Coalescing — repeated change handlers within the window reuse one timer (EC-9).
+##   No-polling — autosave is signal-triggered only; the forbidden pattern
+##          `save_load_polling_based_autosave` is registered, and the service has no
+##          _process/_physics_process save loop.
+##
+## Headless note: gdunit4 does not reliably advance a real Timer tick in isolation
+## (see ui_service_test.gd debounce note), so debounce timing is verified structurally
+## (timer running + time_left reset) plus a direct _perform_save write for the actual
+## persistence assertion.
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/integration/save_load/autosave_debounce_test.gd
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+extends GdUnitTestSuite
+
+
+const _SaveLoadServiceScript: Script = preload("res://src/services/save_load_service.gd")
+const _ActiveCaseScript: Script = preload("res://src/data/active_case_save_data.gd")
+
+const ACTIVE_CASE_FILE: String = "user://saves/active_case.tres"
+
+
+func _service() -> Node:
+	var svc: Node = _SaveLoadServiceScript.new()
+	get_tree().root.add_child(svc)
+	auto_free(svc)
+	return svc
+
+
+func _remove_active_case() -> void:
+	if FileAccess.file_exists(ACTIVE_CASE_FILE):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(ACTIVE_CASE_FILE))
+	var tmp: String = "%s.tmp.%s" % [ACTIVE_CASE_FILE.get_basename(), ACTIVE_CASE_FILE.get_extension()]
+	if FileAccess.file_exists(tmp):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(tmp))
+
+
+# ─── AC-2 — workspace change → debounced active_case save ─────────────────────
+
+func test_workspace_change_starts_debounce_timer() -> void:
+	# Arrange — active case present
+	var svc: Node = _service()
+	svc._active_case = _ActiveCaseScript.new()
+	svc._active_case.case_id = "case:autosave"
+
+	# Act — workspace changed
+	svc._on_workspace_changed(1, 2)
+
+	# Assert — a debounce timer exists for the workspace category, running, with 250ms wait
+	var timer: Timer = svc._debounce_timer_for("workspace_state_changed")
+	assert_object(timer).is_not_null()
+	assert_bool(timer.is_stopped()).is_false()
+	assert_float(timer.wait_time).is_equal_approx(0.25, 0.001)
+	timer.stop()
+
+
+func test_perform_save_writes_active_case_atomically() -> void:
+	# Arrange
+	var svc: Node = _service()
+	_remove_active_case()
+	svc._active_case = _ActiveCaseScript.new()
+	svc._active_case.case_id = "case:perform-save"
+
+	# Act — the debounce timeout target writes the active case
+	svc._perform_save("workspace_state_changed")
+
+	# Assert — active_case.tres written + round-trips case_id
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE)).is_true()
+	var loaded: Resource = ResourceLoader.load(ACTIVE_CASE_FILE, "", ResourceLoader.CACHE_MODE_IGNORE) as Resource
+	assert_object(loaded).is_not_null()
+	assert_str(loaded.case_id).is_equal("case:perform-save")
+	_remove_active_case()
+
+
+func test_perform_save_noop_when_no_active_case() -> void:
+	# Arrange — no active case set
+	var svc: Node = _service()
+	_remove_active_case()
+	svc._active_case = null
+
+	# Act — must not crash, must not write
+	svc._perform_save("workspace_state_changed")
+
+	# Assert — no file written
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE)).is_false()
+
+
+# ─── Debounce coalescing (EC-9) ───────────────────────────────────────────────
+
+func test_repeated_changes_reuse_one_timer_and_reset() -> void:
+	# Arrange
+	var svc: Node = _service()
+	svc._active_case = _ActiveCaseScript.new()
+
+	# Act — three rapid workspace changes
+	svc._on_workspace_changed(1, 2)
+	var t1: Timer = svc._debounce_timer_for("workspace_state_changed")
+	var first_left: float = t1.time_left
+	svc._on_workspace_changed(2, 1)
+	var second_left: float = t1.time_left
+	svc._on_workspace_changed(1, 2)
+	var third_left: float = t1.time_left
+
+	# Assert — same single Timer instance reused; each start resets time_left (debounce)
+	assert_object(svc._debounce_timer_for("workspace_state_changed")).is_same(t1)
+	assert_float(first_left).is_greater(0.0)
+	assert_float(second_left).is_greater(0.0)
+	assert_float(third_left).is_greater(0.0)
+	t1.stop()
+
+
+# ─── No-polling guard ─────────────────────────────────────────────────────────
+
+func test_no_per_frame_polling_autosave() -> void:
+	# Autosave must be signal-triggered, never per-frame polling. The forbidden pattern
+	# enforces this at PR review; assert it is registered (automated gate). (A has_method
+	# check on _process is unreliable — Node declares it as a virtual regardless of override.)
+	var file: FileAccess = FileAccess.open("res://docs/registry/architecture.yaml", FileAccess.READ)
+	assert_object(file).is_not_null()
+	var content: String = file.get_as_text()
+	file.close()
+	assert_bool(content.contains("save_load_polling_based_autosave")).is_true()

--- a/tests/integration/save_load/autosave_debounce_test.gd.uid
+++ b/tests/integration/save_load/autosave_debounce_test.gd.uid
@@ -1,0 +1,1 @@
+uid://dp5qf8svwnenh

--- a/tests/integration/save_load/boot_load_recovery_test.gd
+++ b/tests/integration/save_load/boot_load_recovery_test.gd
@@ -1,0 +1,154 @@
+## boot_load_recovery_test.gd — SaveLoadService boot load + corruption recovery.
+##
+## Covers story-004 Acceptance Criteria:
+##   AC-7   active_case.tres corrupt → renamed to .backup + save_corrupted("active_case")
+##          emitted + load returns null (boot continues fresh). EC-3.
+##   AC-15  casebook.tres with 5 entries → _load_casebook() returns Casebook with 5 entries.
+##   AC-16  session_meta.cfg → last_active_case_id + workspace_f2_hint_seen read back. AC-16.
+##
+## Strategy: create the service (boots on whatever is in user://saves/), then CLEAN the
+## canonical files, write a pristine fixture, and call the specific load method directly
+## so the assertion is deterministic (independent of the autoload's boot timing).
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/integration/save_load/boot_load_recovery_test.gd
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+extends GdUnitTestSuite
+
+
+const _SaveLoadServiceScript: Script = preload("res://src/services/save_load_service.gd")
+const _ActiveCaseScript: Script = preload("res://src/data/active_case_save_data.gd")
+const _CasebookScript: Script = preload("res://src/data/casebook.gd")
+const _CasebookEntryScript: Script = preload("res://src/data/casebook_entry.gd")
+
+const ACTIVE_CASE_FILE: String = "user://saves/active_case.tres"
+const CASEBOOK_FILE: String = "user://saves/casebook.tres"
+const SESSION_META_FILE: String = "user://saves/session_meta.cfg"
+
+
+func _service() -> Node:
+	var svc: Node = _SaveLoadServiceScript.new()
+	get_tree().root.add_child(svc)
+	auto_free(svc)
+	return svc
+
+
+func _rm(path: String) -> void:
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+# ─── AC-7 — corrupt active_case → .backup + save_corrupted ───────────────────
+
+func test_corrupt_active_case_renamed_to_backup_and_signals() -> void:
+	# Arrange — service (boots on whatever exists), then write a pristine corrupt file
+	var svc: Node = _service()
+	_rm(ACTIVE_CASE_FILE)
+	_rm(ACTIVE_CASE_FILE + ".backup")
+	var f: FileAccess = FileAccess.open(ACTIVE_CASE_FILE, FileAccess.WRITE)
+	f.store_string("this is not a valid .tres {{{ garbage")
+	f.close()
+
+	var corrupted: Array = []
+	var cb: Callable = func(category: String) -> void: corrupted.append(category)
+	svc.save_corrupted.connect(cb)
+
+	# Act — load attempt detects corruption
+	var result: Variant = svc._load_active_case_or_recover()
+
+	# Assert — null returned; original renamed to .backup; signal emitted once
+	svc.save_corrupted.disconnect(cb)
+	assert_object(result).is_null()
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE)).is_false()
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE + ".backup")).is_true()
+	assert_int(corrupted.size()).is_equal(1)
+	assert_str(corrupted[0]).is_equal("active_case")
+
+	# Cleanup
+	_rm(ACTIVE_CASE_FILE + ".backup")
+
+
+func test_absent_active_case_returns_null_without_backup() -> void:
+	# EC-2 fresh start: no file → null, no backup, no signal
+	var svc: Node = _service()
+	_rm(ACTIVE_CASE_FILE)
+	_rm(ACTIVE_CASE_FILE + ".backup")
+	var corrupted: Array = []
+	var cb: Callable = func(_c: String) -> void: corrupted.append(true)
+	svc.save_corrupted.connect(cb)
+
+	var result: Variant = svc._load_active_case_or_recover()
+
+	svc.save_corrupted.disconnect(cb)
+	assert_object(result).is_null()
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE + ".backup")).is_false()
+	assert_int(corrupted.size()).is_equal(0)
+
+
+# ─── AC-15 — casebook eager load ──────────────────────────────────────────────
+
+func test_casebook_loads_five_entries() -> void:
+	# Arrange — write a casebook with 5 entries
+	var svc: Node = _service()
+	_rm(CASEBOOK_FILE)
+	var book: Resource = _CasebookScript.new()
+	for i: int in range(5):
+		var entry: Resource = _CasebookEntryScript.new()
+		entry.case_id = "case:2026-%03d" % i
+		entry.verdict = "파기"
+		entry.final_score = 0.5 + i * 0.1
+		book.entries.append(entry)
+	assert_int(ResourceSaver.save(book, CASEBOOK_FILE)).is_equal(OK)
+
+	# Act
+	var loaded: Resource = svc._load_casebook()
+
+	# Assert — 5 entries, sampled fields correct
+	assert_object(loaded).is_not_null()
+	assert_int(loaded.entries.size()).is_equal(5)
+	assert_str(loaded.entries[0].case_id).is_equal("case:2026-000")
+	assert_str(loaded.entries[4].case_id).is_equal("case:2026-004")
+	assert_float(loaded.entries[2].final_score).is_equal_approx(0.7, 0.0001)
+
+	_rm(CASEBOOK_FILE)
+
+
+func test_absent_casebook_returns_empty() -> void:
+	# EC-2: no casebook → fresh empty Casebook (not null, no error)
+	var svc: Node = _service()
+	_rm(CASEBOOK_FILE)
+	var loaded: Resource = svc._load_casebook()
+	assert_object(loaded).is_not_null()
+	assert_int(loaded.entries.size()).is_equal(0)
+
+
+# ─── AC-16 — session meta load ────────────────────────────────────────────────
+
+func test_session_meta_values_read_back() -> void:
+	# Arrange — write session_meta.cfg
+	var svc: Node = _service()
+	_rm(SESSION_META_FILE)
+	var cfg := ConfigFile.new()
+	cfg.set_value("session", "last_active_case_id", "case:2026-001")
+	cfg.set_value("hints", "workspace_f2_hint_seen", true)
+	assert_int(cfg.save(SESSION_META_FILE)).is_equal(OK)
+
+	# Act
+	svc._load_session_meta()
+
+	# Assert
+	assert_str(svc.last_active_case_id).is_equal("case:2026-001")
+	assert_bool(svc.workspace_f2_hint_seen).is_true()
+
+	_rm(SESSION_META_FILE)
+
+
+func test_absent_session_meta_keeps_defaults() -> void:
+	var svc: Node = _service()
+	_rm(SESSION_META_FILE)
+	svc._load_session_meta()
+	assert_str(svc.last_active_case_id).is_equal("")
+	assert_bool(svc.workspace_f2_hint_seen).is_false()

--- a/tests/integration/save_load/close_flush_persistence_test.gd
+++ b/tests/integration/save_load/close_flush_persistence_test.gd
@@ -1,0 +1,102 @@
+## close_flush_persistence_test.gd — SaveLoadService close-request flush + full-session round-trip.
+##
+## Covers story-008 Acceptance Criteria:
+##   AC-14  Full-session reconstruction: edits made through the debounced autosave are
+##          recoverable after a flush + reload (only the final < 250ms window may be lost).
+##   Close-flush: a pending (dirty) debounced save is performed synchronously on flush;
+##          a no-op when nothing is pending (EC-10).
+##
+## Note: NOTIFICATION_WM_CLOSE_REQUEST itself calls get_tree().quit() and cannot be
+## exercised in-process, so the flush LOGIC (_flush_pending_save) is tested directly.
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/integration/save_load/close_flush_persistence_test.gd
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md (§3.4 game-exit flush)
+## TR:  TR-save-*
+extends GdUnitTestSuite
+
+
+const _SaveLoadServiceScript: Script = preload("res://src/services/save_load_service.gd")
+const _ActiveCaseScript: Script = preload("res://src/data/active_case_save_data.gd")
+
+const ACTIVE_CASE_FILE: String = "user://saves/active_case.tres"
+
+
+func _service() -> Node:
+	var svc: Node = _SaveLoadServiceScript.new()
+	get_tree().root.add_child(svc)
+	auto_free(svc)
+	return svc
+
+
+func _rm_active_case() -> void:
+	for p: String in [ACTIVE_CASE_FILE, "%s.tmp.%s" % [ACTIVE_CASE_FILE.get_basename(), ACTIVE_CASE_FILE.get_extension()]]:
+		if FileAccess.file_exists(p):
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(p))
+
+
+# ─── Close-flush drains a pending debounced save ──────────────────────────────
+
+func test_flush_writes_pending_dirty_save() -> void:
+	# Arrange — active case + a pending (running) debounce timer
+	var svc: Node = _service()
+	_rm_active_case()
+	svc._active_case = _ActiveCaseScript.new()
+	svc._active_case.case_id = "case:flush"
+	svc._on_workspace_changed(1, 2)   # starts the workspace debounce timer (dirty)
+	var timer: Timer = svc._debounce_timer_for("workspace_state_changed")
+	assert_bool(timer.is_stopped()).is_false()
+
+	# Act — flush (simulates the close-request path without quitting)
+	svc._flush_pending_save()
+
+	# Assert — timer drained (stopped) + active_case written
+	assert_bool(timer.is_stopped()).is_true()
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE)).is_true()
+	var loaded: Resource = ResourceLoader.load(ACTIVE_CASE_FILE, "", ResourceLoader.CACHE_MODE_IGNORE) as Resource
+	assert_object(loaded).is_not_null()
+	assert_str(loaded.case_id).is_equal("case:flush")
+	_rm_active_case()
+
+
+func test_flush_is_noop_when_nothing_pending() -> void:
+	# Arrange — active case set but NO pending change (no running timer)
+	var svc: Node = _service()
+	_rm_active_case()
+	svc._active_case = _ActiveCaseScript.new()
+	svc._active_case.case_id = "case:clean"
+
+	# Act — flush with no dirty timer
+	svc._flush_pending_save()
+
+	# Assert — nothing written (no spurious save)
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE)).is_false()
+
+
+# ─── AC-14 — full-session reconstruction round-trip ───────────────────────────
+
+func test_full_session_reconstructs_latest_edits_after_flush() -> void:
+	# Arrange — simulate a session: several debounced edits to the active case, the last
+	# of which is still pending in the debounce window when the app closes.
+	var svc: Node = _service()
+	_rm_active_case()
+	var active: Resource = _ActiveCaseScript.new()
+	active.case_id = "case:2026-session"
+	svc._active_case = active
+
+	# Edit 1 committed (simulate the debounce having fired earlier)
+	svc._perform_save("workspace_state_changed")
+	# Edit 2 mutates the in-memory state and is still pending (dirty) at close
+	active.case_id = "case:2026-session-EDIT2"
+	svc._on_workspace_changed(2, 1)   # dirty
+
+	# Act — close flush drains the pending edit
+	svc._flush_pending_save()
+
+	# Assert — reloaded state reflects the LATEST edit (not the earlier committed one)
+	var loaded: Resource = ResourceLoader.load(ACTIVE_CASE_FILE, "", ResourceLoader.CACHE_MODE_IGNORE) as Resource
+	assert_object(loaded).is_not_null()
+	assert_str(loaded.case_id).is_equal("case:2026-session-EDIT2")
+	_rm_active_case()

--- a/tests/integration/save_load/crash_recovery_cascade_test.gd
+++ b/tests/integration/save_load/crash_recovery_cascade_test.gd
@@ -1,0 +1,105 @@
+## crash_recovery_cascade_test.gd — SaveLoadService crash-recovery branch contract.
+##
+## Covers story-006 Acceptance Criteria (decision contract — end-to-end auto-resubmit
+## DEFERRED until Workspace/Brief controllers + EvaluationService exist, TD-001):
+##   AC-5   recovered workspace_data.state == FROZEN → "workspace_resubmit" branch.
+##   AC-6   recovered brief_editor_data.state == SUBMITTING → "brief_resubmit" branch.
+##   Single entry point — recovery dispatches from one active_case_recovered signal.
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/integration/save_load/crash_recovery_cascade_test.gd
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md (+ ADR-0001 amend-2 §C3)
+## TR:  TR-save-*
+extends GdUnitTestSuite
+
+
+const _SaveLoadServiceScript: Script = preload("res://src/services/save_load_service.gd")
+
+
+## Duck-typed stand-in for the (not-yet-existing) BriefEditorData (state enum).
+class MockBrief extends RefCounted:
+	var state: int = 0   # 3 == SUBMITTING (SaveLoadService.BRIEF_SUBMITTING)
+
+
+func _service() -> Node:
+	var svc: Node = _SaveLoadServiceScript.new()
+	get_tree().root.add_child(svc)
+	auto_free(svc)
+	return svc
+
+
+func _frozen_workspace() -> WorkspaceData:
+	var ws := WorkspaceData.new()
+	ws._transition_to_active()
+	ws._transition_to_frozen()
+	return ws
+
+
+func _active_workspace() -> WorkspaceData:
+	var ws := WorkspaceData.new()
+	ws._transition_to_active()
+	return ws
+
+
+# ─── AC-5 — FROZEN workspace → workspace_resubmit ─────────────────────────────
+
+func test_frozen_workspace_selects_workspace_resubmit() -> void:
+	var svc: Node = _service()
+	var ws: WorkspaceData = _frozen_workspace()
+	assert_int(ws.state).is_equal(WorkspaceData.WorkspaceState.FROZEN)
+
+	assert_str(svc.recovery_branch_for(ws, null)).is_equal("workspace_resubmit")
+
+
+func test_active_workspace_not_workspace_resubmit() -> void:
+	var svc: Node = _service()
+	var ws: WorkspaceData = _active_workspace()   # ACTIVE, not FROZEN
+	assert_str(svc.recovery_branch_for(ws, null)).is_equal("none")
+
+
+# ─── AC-6 — SUBMITTING brief → brief_resubmit ─────────────────────────────────
+
+func test_submitting_brief_selects_brief_resubmit() -> void:
+	var svc: Node = _service()
+	var brief := MockBrief.new()
+	brief.state = svc.BRIEF_SUBMITTING   # 3
+	# workspace not frozen (null) → brief branch
+	assert_str(svc.recovery_branch_for(null, brief)).is_equal("brief_resubmit")
+
+
+func test_non_submitting_brief_is_none() -> void:
+	var svc: Node = _service()
+	var brief := MockBrief.new()
+	brief.state = 0   # not SUBMITTING
+	assert_str(svc.recovery_branch_for(null, brief)).is_equal("none")
+
+
+# ─── Precedence + none ────────────────────────────────────────────────────────
+
+func test_frozen_workspace_wins_over_submitting_brief() -> void:
+	var svc: Node = _service()
+	var ws: WorkspaceData = _frozen_workspace()
+	var brief := MockBrief.new()
+	brief.state = svc.BRIEF_SUBMITTING
+	# Both eligible → workspace precedence (committed submission awaiting evaluation)
+	assert_str(svc.recovery_branch_for(ws, brief)).is_equal("workspace_resubmit")
+
+
+func test_neither_recovers_to_none() -> void:
+	var svc: Node = _service()
+	assert_str(svc.recovery_branch_for(null, null)).is_equal("none")
+
+
+# ─── Single entry point — active_case_recovered emitted once at boot ──────────
+
+func test_active_case_recovered_is_a_single_signal() -> void:
+	# The recovery cascade has ONE entry point: the active_case_recovered signal exists
+	# on the service (emitted once by boot load, story 004). Structural check that the
+	# single-signal contract holds (no second recovery signal).
+	var svc: Node = _service()
+	assert_bool(svc.has_signal("active_case_recovered")).is_true()
+	# No alternate/duplicate recovery signal
+	assert_bool(svc.has_signal("brief_recovered")).is_false()
+	assert_bool(svc.has_signal("workspace_recovered")).is_false()

--- a/tests/integration/save_load/resolution_cascade_test.gd
+++ b/tests/integration/save_load/resolution_cascade_test.gd
@@ -1,0 +1,119 @@
+## resolution_cascade_test.gd — SaveLoadService resolution cascade + revert guard.
+##
+## Covers story-005 Acceptance Criteria:
+##   AC-3   evaluation_completed → casebook append + immediate write + active_case delete
+##          + casebook_entry_added emit. (Handler tested directly; the EvaluationService
+##          subscription is DEFERRED — TD-001.)
+##   AC-4   save_active_case() on a Resolved case → push_error + false + active_case
+##          untouched (save_load_revert_resolved, EC-5).
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/integration/save_load/resolution_cascade_test.gd
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+extends GdUnitTestSuite
+
+
+const _SaveLoadServiceScript: Script = preload("res://src/services/save_load_service.gd")
+const _ActiveCaseScript: Script = preload("res://src/data/active_case_save_data.gd")
+const _CasebookScript: Script = preload("res://src/data/casebook.gd")
+const _CasebookEntryScript: Script = preload("res://src/data/casebook_entry.gd")
+
+const ACTIVE_CASE_FILE: String = "user://saves/active_case.tres"
+const CASEBOOK_FILE: String = "user://saves/casebook.tres"
+
+
+## Duck-typed stand-in for the (not-yet-existing) EvaluationResult Resource.
+class MockResult extends RefCounted:
+	var case_id: String = ""
+	var verdict: String = ""
+	var final_score: float = 0.0
+
+
+func _service() -> Node:
+	var svc: Node = _SaveLoadServiceScript.new()
+	get_tree().root.add_child(svc)
+	auto_free(svc)
+	return svc
+
+
+func _rm(path: String) -> void:
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+# ─── AC-3 — evaluation_completed resolution cascade ───────────────────────────
+
+func test_evaluation_completed_archives_and_deletes_active() -> void:
+	# Arrange — active case present + empty casebook + a written active_case file
+	var svc: Node = _service()
+	_rm(ACTIVE_CASE_FILE)
+	_rm(CASEBOOK_FILE)
+	svc._casebook = _CasebookScript.new()
+	svc._active_case = _ActiveCaseScript.new()
+	svc._active_case.case_id = "case:resolve-1"
+	ResourceSaver.save(svc._active_case, ACTIVE_CASE_FILE)   # active file exists pre-resolution
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE)).is_true()
+
+	var added: Array = []
+	var cb: Callable = func(entry: Object) -> void: added.append(entry)
+	svc.casebook_entry_added.connect(cb)
+
+	# Act — resolution
+	var result := MockResult.new()
+	result.case_id = "case:resolve-1"
+	result.verdict = "파기"
+	result.final_score = 0.91
+	svc._on_evaluation_completed(result)
+
+	# Assert — casebook has the entry; active_case deleted; casebook.tres written; signal fired
+	svc.casebook_entry_added.disconnect(cb)
+	assert_int(svc._casebook.entries.size()).is_equal(1)
+	assert_str(svc._casebook.entries[0].case_id).is_equal("case:resolve-1")
+	assert_float(svc._casebook.entries[0].final_score).is_equal_approx(0.91, 0.0001)
+	assert_bool(FileAccess.file_exists(CASEBOOK_FILE)).is_true()
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE)).is_false()
+	assert_object(svc._active_case).is_null()
+	assert_int(added.size()).is_equal(1)
+
+	_rm(CASEBOOK_FILE)
+
+
+# ─── AC-4 — revert guard (anti-save-scumming) ─────────────────────────────────
+
+func test_save_active_case_blocked_when_resolved() -> void:
+	# Arrange — casebook already contains case:X; active_case has the same id
+	var svc: Node = _service()
+	_rm(ACTIVE_CASE_FILE)
+	svc._casebook = _CasebookScript.new()
+	var resolved: Resource = _CasebookEntryScript.new()
+	resolved.case_id = "case:X"
+	svc._casebook.entries.append(resolved)
+	svc._active_case = _ActiveCaseScript.new()
+	svc._active_case.case_id = "case:X"
+
+	# Act — attempt to (re)save the Resolved case
+	var ok: bool = svc.save_active_case()
+
+	# Assert — rejected; no active_case file written
+	assert_bool(ok).is_false()
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE)).is_false()
+
+
+func test_save_active_case_allowed_when_not_resolved() -> void:
+	# Arrange — casebook empty; active_case is in progress
+	var svc: Node = _service()
+	_rm(ACTIVE_CASE_FILE)
+	svc._casebook = _CasebookScript.new()
+	svc._active_case = _ActiveCaseScript.new()
+	svc._active_case.case_id = "case:in-progress"
+
+	# Act
+	var ok: bool = svc.save_active_case()
+
+	# Assert — saved
+	assert_bool(ok).is_true()
+	assert_bool(FileAccess.file_exists(ACTIVE_CASE_FILE)).is_true()
+	_rm(ACTIVE_CASE_FILE)

--- a/tests/integration/submission_evaluation/submit_pipeline_test.gd
+++ b/tests/integration/submission_evaluation/submit_pipeline_test.gd
@@ -1,0 +1,101 @@
+## submit_pipeline_test.gd — story-004: submit() 5-state machine + Validating gate + emit.
+##
+## Loads Library + Case fixtures into the autoloads (mirrors case_service_load_test) so the
+## Validating gate (LibraryService.validate_citations) and COMPUTING (CaseService.get_case)
+## run against real data.
+extends GdUnitTestSuite
+
+const _EvalScript: Script = preload("res://src/services/evaluation_service.gd")
+const _PlayerSubScript: Script = preload("res://src/data/player_submission.gd")
+
+const LIBRARY_FIXTURES: String = "res://tests/fixtures/library/seed/"
+const CASE_FIXTURES: String = "res://tests/fixtures/cases/seed/"
+const SAMPLE_CASE_ID: String = "case_data:2026-001"
+const CORRECT_CITATIONS: Array[String] = [
+	"law:criminal-act-art-250", "law:criminal-act-art-35",
+	"case:2025do10910/holding-1", "case:2025do10910/holding-2",
+]
+
+var _lib: Node
+var _cases: Node
+
+func before_test() -> void:
+	_lib = get_tree().root.get_node("LibraryService")
+	_lib.load_all(LIBRARY_FIXTURES)
+	_cases = get_tree().root.get_node("CaseService")
+	_cases.load_all(CASE_FIXTURES)
+
+func _svc() -> Node:
+	var s: Node = _EvalScript.new()
+	get_tree().root.add_child(s)
+	auto_free(s)
+	return s
+
+func _submission(case_id: String, disp: String, cites: Array[String]) -> Resource:
+	var sub: Resource = _PlayerSubScript.new()
+	sub.case_id = case_id
+	sub.player_disposition = disp
+	sub.player_citations = cites
+	return sub
+
+# ─── AC-18 double-submit ───
+func test_resubmit_while_busy_ignored() -> void:
+	var svc: Node = _svc()
+	svc.current_state = _EvalScript.State.VALIDATING   # simulate in-flight
+	var emitted: Array = []
+	svc.evaluation_completed.connect(func(_r: Object) -> void: emitted.append(true))
+	svc.submit(_submission(SAMPLE_CASE_ID, "파기환송", CORRECT_CITATIONS.duplicate()))
+	assert_int(svc.current_state).is_equal(_EvalScript.State.VALIDATING)  # unchanged
+	assert_int(emitted.size()).is_equal(0)
+
+# ─── AC-1 empty citations ───
+func test_empty_citations_rejected() -> void:
+	var svc: Node = _svc()
+	var rejected: Array = []
+	svc.submission_rejected.connect(func(reason: String) -> void: rejected.append(reason))
+	var empty: Array[String] = []
+	svc.submit(_submission(SAMPLE_CASE_ID, "파기환송", empty))
+	assert_int(rejected.size()).is_equal(1)
+	assert_str(rejected[0]).is_equal("empty_citations")
+	assert_int(svc.current_state).is_equal(_EvalScript.State.IDLE)
+
+# ─── AC-2 invalid citation ───
+func test_invalid_citation_rejected() -> void:
+	var svc: Node = _svc()
+	var rejected: Array = []
+	svc.submission_rejected.connect(func(reason: String) -> void: rejected.append(reason))
+	var bad: Array[String] = ["law:does-not-exist-99999"]
+	svc.submit(_submission(SAMPLE_CASE_ID, "파기환송", bad))
+	assert_int(rejected.size()).is_equal(1)
+	assert_str(rejected[0]).is_equal("invalid_citation")
+	assert_int(svc.current_state).is_equal(_EvalScript.State.IDLE)
+
+# ─── case not found ───
+func test_unknown_case_rejected() -> void:
+	var svc: Node = _svc()
+	var rejected: Array = []
+	svc.submission_rejected.connect(func(reason: String) -> void: rejected.append(reason))
+	svc.submit(_submission("case_data:does-not-exist", "파기환송", CORRECT_CITATIONS.duplicate()))
+	assert_int(rejected.size()).is_equal(1)
+	assert_str(rejected[0]).is_equal("case_not_found")
+	assert_int(svc.current_state).is_equal(_EvalScript.State.IDLE)
+
+# ─── happy path ───
+func test_valid_submission_emits_evaluation_completed_and_returns_idle() -> void:
+	var svc: Node = _svc()
+	var results: Array = []
+	svc.evaluation_completed.connect(func(r: Object) -> void: results.append(r))
+	svc.submit(_submission(SAMPLE_CASE_ID, "파기환송", CORRECT_CITATIONS.duplicate()))
+	assert_int(results.size()).is_equal(1)
+	var result: Object = results[0]
+	assert_str(result.case_id).is_equal(SAMPLE_CASE_ID)
+	assert_str(result.verdict).is_not_empty()
+	assert_bool(result.subscores.has("disposition_match")).is_true()
+	# disposition matches (파기환송 == correct) → disposition_match subscore 1.0
+	assert_float(result.subscores["disposition_match"]).is_equal_approx(1.0, 0.0001)
+	# all 4 correct citations covered → coverage 1.0, redundant 0
+	assert_float(result.subscores["core_citation_coverage"]).is_equal_approx(1.0, 0.0001)
+	assert_int(result.missed_set.size()).is_equal(0)
+	assert_int(result.redundant_set.size()).is_equal(0)
+	# state returned to IDLE after the pipeline
+	assert_int(svc.current_state).is_equal(_EvalScript.State.IDLE)

--- a/tests/unit/save_load/anti_pillar_guards_test.gd
+++ b/tests/unit/save_load/anti_pillar_guards_test.gd
@@ -1,0 +1,122 @@
+## anti_pillar_guards_test.gd — SaveLoadService Anti-Pillar serialization guards.
+##
+## Covers story-007 Acceptance Criteria:
+##   AC-12  active_case excludes Settings values (save_load_settings_inclusion) — structural:
+##          ActiveCaseSaveData has no Settings fields; Settings persist separately (ADR-0009).
+##   AC-13  chain_data with an ephemeral field is rejected by the canonical validator
+##          (chain_data_include_ephemeral_field), via _validate_active_case.
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/unit/save_load/anti_pillar_guards_test.gd
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+##      docs/architecture/adr-0008-amend-1-cycle-3-4-closure.md §A6 (ephemeral field ban)
+## TR:  TR-save-*
+extends GdUnitTestSuite
+
+
+const _SaveLoadServiceScript: Script = preload("res://src/services/save_load_service.gd")
+const _ActiveCaseScript: Script = preload("res://src/data/active_case_save_data.gd")
+
+
+func _service() -> Node:
+	var svc: Node = _SaveLoadServiceScript.new()
+	get_tree().root.add_child(svc)
+	auto_free(svc)
+	return svc
+
+
+# ─── AC-12 — active_case carries no Settings fields (structural) ──────────────
+
+func test_active_case_save_data_has_no_settings_fields() -> void:
+	# Settings keys must never appear in the active-case Resource — they live in a
+	# separate user_settings.cfg (ADR-0009 / save_load_settings_inclusion).
+	var active: Resource = _ActiveCaseScript.new()
+	var settings_prefixes: PackedStringArray = ["display.", "audio.", "input.", "accessibility."]
+	for prop: Dictionary in active.get_property_list():
+		var name: String = prop["name"]
+		for prefix: String in settings_prefixes:
+			assert_bool(name.begins_with(prefix)).is_false()
+
+
+func test_active_case_property_set_is_the_expected_save_fields() -> void:
+	# Positive shape: the script-declared @export fields are exactly the save fields.
+	var active: Resource = _ActiveCaseScript.new()
+	var script_props: PackedStringArray = PackedStringArray()
+	for prop: Dictionary in active.get_property_list():
+		# Script variables carry PROPERTY_USAGE_SCRIPT_VARIABLE (bit 4096).
+		if (int(prop["usage"]) & PROPERTY_USAGE_SCRIPT_VARIABLE) != 0:
+			script_props.append(prop["name"])
+	assert_bool(script_props.has("save_file_version")).is_true()
+	assert_bool(script_props.has("case_id")).is_true()
+	assert_bool(script_props.has("workspace_data")).is_true()
+	assert_bool(script_props.has("brief_editor_data")).is_true()
+	# No settings field leaked into the declared set
+	assert_bool(script_props.has("text_scale")).is_false()
+	assert_bool(script_props.has("reduced_motion")).is_false()
+
+
+# ─── AC-13 — ephemeral field in chain_data rejected ───────────────────────────
+
+func test_active_case_with_ephemeral_chain_data_field_rejected() -> void:
+	# Arrange — an active case whose workspace_data.chain_data_snapshot carries a
+	# forbidden ephemeral field (last_touched_usec) in a node dict.
+	var svc: Node = _service()
+	var ws := WorkspaceData.new()
+	ws.chain_data_snapshot = {
+		"schema_version": 1,
+		"nodes": [
+			{
+				"node_id": "n1", "label": "x", "parent_id": "", "evidence": [],
+				"depth": 0, "child_count": 0, "evidence_count": 0,
+				"last_touched_usec": 123456,   # forbidden ephemeral field (ADR-0008 amend-1 §A6)
+			}
+		],
+		"edges": [], "total_evidence_count": 0, "max_depth_reached": 0,
+		"submission_timestamp_unix": 1747500000,
+	}
+	var active: Resource = _ActiveCaseScript.new()
+	active.workspace_data = ws
+
+	var rejections: Array = []
+	var cb: Callable = func(reason: String) -> void: rejections.append(reason)
+	ws.submission_rejected.connect(cb)
+
+	# Act
+	var ok: bool = svc._validate_active_case(active)
+
+	# Assert — rejected via the canonical validator + schema_violation emitted
+	ws.submission_rejected.disconnect(cb)
+	assert_bool(ok).is_false()
+	assert_int(rejections.size()).is_equal(1)
+	assert_str(rejections[0]).is_equal("schema_violation")
+
+
+func test_active_case_with_clean_chain_data_validates() -> void:
+	# A clean (allow-listed) chain_data passes.
+	var svc: Node = _service()
+	var ws := WorkspaceData.new()
+	ws.chain_data_snapshot = {
+		"schema_version": 1,
+		"nodes": [
+			{
+				"node_id": "n1", "label": "x", "parent_id": "", "evidence": [],
+				"depth": 0, "child_count": 0, "evidence_count": 0,
+			}
+		],
+		"edges": [], "total_evidence_count": 0, "max_depth_reached": 0,
+		"submission_timestamp_unix": 1747500000,
+	}
+	var active: Resource = _ActiveCaseScript.new()
+	active.workspace_data = ws
+
+	assert_bool(svc._validate_active_case(active)).is_true()
+
+
+func test_validate_active_case_null_safe() -> void:
+	# No active case / no workspace_data → nothing to validate → true.
+	var svc: Node = _service()
+	assert_bool(svc._validate_active_case(null)).is_true()
+	var active: Resource = _ActiveCaseScript.new()  # workspace_data null by default
+	assert_bool(svc._validate_active_case(active)).is_true()

--- a/tests/unit/save_load/save_data_schema_test.gd
+++ b/tests/unit/save_load/save_data_schema_test.gd
@@ -1,0 +1,128 @@
+## save_data_schema_test.gd — Save-data Resource classes + schema versioning.
+##
+## Covers story-002 Acceptance Criteria:
+##   AC-10  Loading a save Resource that is MISSING a field → the field takes its
+##          @export default (forward-compat for newly-added fields). EC-8.
+##   AC-11  save_file_version greater than CURRENT_SAVE_FILE_VERSION → treated as
+##          unsupported (corruption path); current/older versions are supported. EC-12.
+##
+## Strategy:
+##   AC-10 is tested robustly without hand-crafting fragile .tres text: save a real
+##   Resource via ResourceSaver, strip ONE field line from the serialized text, reload,
+##   and assert that field is back at its @export default.
+##   AC-11 is tested via SaveLoadService._is_save_version_supported(version).
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/unit/save_load/save_data_schema_test.gd
+##
+## ADR: docs/architecture/adr-0011-save-load-storage-format.md
+## TR:  TR-save-*
+extends GdUnitTestSuite
+
+
+const _SaveLoadServiceScript: Script = preload("res://src/services/save_load_service.gd")
+const _CasebookEntryScript: Script = preload("res://src/data/casebook_entry.gd")
+const _ActiveCaseScript: Script = preload("res://src/data/active_case_save_data.gd")
+
+const TMP_PATH: String = "user://saves/test_schema_entry.tres"
+
+
+func _service() -> Node:
+	var svc: Node = _SaveLoadServiceScript.new()
+	get_tree().root.add_child(svc)   # _ready creates user://saves/
+	auto_free(svc)
+	return svc
+
+
+func _remove_if_exists(path: String) -> void:
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+# ─── AC-10 — missing field falls back to @export default ──────────────────────
+
+func test_loading_resource_with_missing_field_uses_export_default() -> void:
+	# Arrange — a fully-populated CasebookEntry, saved to .tres
+	_service()  # ensures saves/ exists
+	_remove_if_exists(TMP_PATH)
+	var entry: Resource = _CasebookEntryScript.new()
+	entry.case_id = "case:schema-test"
+	entry.verdict = "파기"
+	entry.final_score = 0.87
+	var save_err: Error = ResourceSaver.save(entry, TMP_PATH)
+	assert_int(save_err).is_equal(OK)
+
+	# Strip the `final_score = ...` line to simulate a file written by an OLDER class
+	# that did not yet have that field.
+	var f_read: FileAccess = FileAccess.open(TMP_PATH, FileAccess.READ)
+	var text: String = f_read.get_as_text()
+	f_read.close()
+	var stripped_lines: PackedStringArray = PackedStringArray()
+	for line: String in text.split("\n"):
+		if not line.begins_with("final_score"):
+			stripped_lines.append(line)
+	var f_write: FileAccess = FileAccess.open(TMP_PATH, FileAccess.WRITE)
+	f_write.store_string("\n".join(stripped_lines))
+	f_write.close()
+
+	# Act — load the field-stripped resource
+	var loaded: Resource = ResourceLoader.load(TMP_PATH, "", ResourceLoader.CACHE_MODE_IGNORE) as Resource
+
+	# Assert — load succeeded; preserved fields intact; the missing field == @export default (0.0)
+	assert_object(loaded).is_not_null()
+	assert_str(loaded.case_id).is_equal("case:schema-test")
+	assert_str(loaded.verdict).is_equal("파기")
+	assert_float(loaded.final_score).is_equal_approx(0.0, 0.0001)   # @export default
+	assert_int(loaded.save_file_version).is_equal(1)
+
+	# Cleanup
+	_remove_if_exists(TMP_PATH)
+
+
+# ─── AC-11 — future save_file_version treated as unsupported (corruption) ─────
+
+func test_future_save_version_is_unsupported() -> void:
+	# Arrange
+	var svc: Node = _service()
+
+	# Assert — version gate: future > current is unsupported; current/older supported
+	assert_bool(svc._is_save_version_supported(svc.CURRENT_SAVE_FILE_VERSION + 1)).is_false()
+	assert_bool(svc._is_save_version_supported(svc.CURRENT_SAVE_FILE_VERSION)).is_true()
+	assert_bool(svc._is_save_version_supported(1)).is_true()
+	# Malformed versions
+	assert_bool(svc._is_save_version_supported(0)).is_false()
+	assert_bool(svc._is_save_version_supported(-1)).is_false()
+
+
+func test_loaded_future_version_resource_reports_its_version() -> void:
+	# A resource serialized with a future version round-trips its version field, so the
+	# load path (story 004) can detect it via _is_save_version_supported.
+	_service()
+	_remove_if_exists(TMP_PATH)
+	var entry: Resource = _CasebookEntryScript.new()
+	entry.save_file_version = 99
+	entry.case_id = "case:future"
+	ResourceSaver.save(entry, TMP_PATH)
+
+	var svc: Node = _service()
+	var loaded: Resource = ResourceLoader.load(TMP_PATH, "", ResourceLoader.CACHE_MODE_IGNORE) as Resource
+	assert_object(loaded).is_not_null()
+	assert_int(loaded.save_file_version).is_equal(99)
+	assert_bool(svc._is_save_version_supported(loaded.save_file_version)).is_false()
+
+	_remove_if_exists(TMP_PATH)
+
+
+# ─── Resource class shape sanity ──────────────────────────────────────────────
+
+func test_save_data_classes_carry_version_and_defaults() -> void:
+	# Each save Resource declares save_file_version defaulting to 1.
+	var entry: Resource = _CasebookEntryScript.new()
+	assert_int(entry.save_file_version).is_equal(1)
+	assert_float(entry.final_score).is_equal_approx(0.0, 0.0001)
+
+	var active: Resource = _ActiveCaseScript.new()
+	assert_int(active.save_file_version).is_equal(1)
+	assert_str(active.case_id).is_equal("")
+	assert_object(active.workspace_data).is_null()

--- a/tests/unit/save_load/save_data_schema_test.gd.uid
+++ b/tests/unit/save_load/save_data_schema_test.gd.uid
@@ -1,0 +1,1 @@
+uid://drwishdxkavwj

--- a/tests/unit/submission_evaluation/comment_generation_test.gd
+++ b/tests/unit/submission_evaluation/comment_generation_test.gd
@@ -1,0 +1,71 @@
+## comment_generation_test.gd — story-005: comment-template decision tree + selection.
+extends GdUnitTestSuite
+
+const _EvalScript: Script = preload("res://src/services/evaluation_service.gd")
+const _CommentTemplatesScript: Script = preload("res://src/data/comment_templates.gd")
+
+func _svc() -> Node:
+	var s: Node = _EvalScript.new()
+	get_tree().root.add_child(s)
+	auto_free(s)
+	return s
+
+func _all_template_keys() -> Dictionary:
+	return {
+		"comment.disp.match": "처분 일치", "comment.disp.miss": "처분 불일치",
+		"comment.core.high": "핵심 인용 충실", "comment.core.mid": "인용 일부 누락", "comment.core.low": "핵심 인용 대부분 누락",
+		"comment.redund.clean": "무관 인용 거의 없음", "comment.redund.bloat": "무관 인용 다수",
+	}
+
+# ─── decision tree (GDD §3.1.5 boundaries) ───
+func test_keys_disposition_match() -> void:
+	var k: Array = _svc().compute_comment_keys({"disposition_match": 1.0, "core_citation_coverage": 0.9, "redundant_citation_penalty": 0.0})
+	assert_bool(k.has("comment.disp.match")).is_true()
+	assert_bool(k.has("comment.core.high")).is_true()
+	assert_bool(k.has("comment.redund.clean")).is_true()
+
+func test_keys_disposition_miss() -> void:
+	assert_bool(_svc().compute_comment_keys({"disposition_match": 0.0}).has("comment.disp.miss")).is_true()
+
+func test_keys_coverage_boundaries() -> void:
+	var svc: Node = _svc()
+	assert_bool(svc.compute_comment_keys({"core_citation_coverage": 0.8}).has("comment.core.high")).is_true()   # ≥0.8
+	assert_bool(svc.compute_comment_keys({"core_citation_coverage": 0.79}).has("comment.core.mid")).is_true()   # 0.4–0.8
+	assert_bool(svc.compute_comment_keys({"core_citation_coverage": 0.4}).has("comment.core.mid")).is_true()    # ≥0.4
+	assert_bool(svc.compute_comment_keys({"core_citation_coverage": 0.39}).has("comment.core.low")).is_true()   # <0.4
+
+func test_keys_redundant_boundaries() -> void:
+	var svc: Node = _svc()
+	assert_bool(svc.compute_comment_keys({"redundant_citation_penalty": -0.05}).has("comment.redund.clean")).is_true()  # ≥-0.05
+	assert_bool(svc.compute_comment_keys({"redundant_citation_penalty": -0.06}).has("comment.redund.bloat")).is_true()  # <-0.05
+
+func test_keys_exactly_three() -> void:
+	# one key per active subscore (disp + core + redund)
+	assert_int(_svc().compute_comment_keys({"disposition_match": 1.0, "core_citation_coverage": 0.5, "redundant_citation_penalty": -0.1}).size()).is_equal(3)
+
+# ─── selection ───
+func test_select_comments_maps_keys_to_bodies() -> void:
+	var svc: Node = _svc()
+	var ct: Resource = _CommentTemplatesScript.new()
+	ct.templates = _all_template_keys()
+	var comments: Array = svc.select_comments(["comment.disp.match", "comment.core.high"], ct)
+	assert_int(comments.size()).is_equal(2)
+	assert_bool(comments.has("처분 일치")).is_true()
+	assert_bool(comments.has("핵심 인용 충실")).is_true()
+
+func test_select_comments_skips_absent_keys_gracefully() -> void:
+	var svc: Node = _svc()
+	var ct: Resource = _CommentTemplatesScript.new()   # empty templates
+	var comments: Array = svc.select_comments(["comment.disp.match"], ct)
+	assert_int(comments.size()).is_equal(0)   # absent → skipped, no crash
+
+func test_select_comments_null_templates_safe() -> void:
+	assert_int(_svc().select_comments(["comment.disp.match"], null).size()).is_equal(0)
+
+# ─── per-case-override forbidden pattern registered ───
+func test_per_case_verdict_threshold_override_registered() -> void:
+	var f: FileAccess = FileAccess.open("res://docs/registry/architecture.yaml", FileAccess.READ)
+	assert_object(f).is_not_null()
+	var content: String = f.get_as_text()
+	f.close()
+	assert_bool(content.contains("per_case_verdict_threshold_override")).is_true()

--- a/tests/unit/submission_evaluation/resource_tree_test.gd
+++ b/tests/unit/submission_evaluation/resource_tree_test.gd
@@ -1,0 +1,42 @@
+## resource_tree_test.gd — story-001: Resource tree + EvaluationService skeleton + thresholds.
+extends GdUnitTestSuite
+
+const _EvalScript: Script = preload("res://src/services/evaluation_service.gd")
+const _PlayerSubScript: Script = preload("res://src/data/player_submission.gd")
+const _EvalResultScript: Script = preload("res://src/data/evaluation_result.gd")
+const _CommentTemplatesScript: Script = preload("res://src/data/comment_templates.gd")
+
+func _svc() -> Node:
+	var s: Node = _EvalScript.new()
+	get_tree().root.add_child(s)
+	auto_free(s)
+	return s
+
+func test_player_submission_resource_defaults() -> void:
+	var sub: Resource = _PlayerSubScript.new()
+	assert_str(sub.case_id).is_equal("")
+	assert_str(sub.player_disposition).is_equal("")
+	assert_int(sub.player_citations.size()).is_equal(0)
+	assert_int(sub.submission_time_ms).is_equal(0)
+
+func test_evaluation_result_resource_defaults() -> void:
+	var r: Resource = _EvalResultScript.new()
+	assert_float(r.final_score).is_equal_approx(0.0, 0.0001)
+	assert_str(r.verdict).is_equal("")
+	assert_int(r.subscores.size()).is_equal(0)
+
+func test_comment_templates_resource_defaults() -> void:
+	var ct: Resource = _CommentTemplatesScript.new()
+	assert_int(ct.templates.size()).is_equal(0)
+
+func test_evaluation_service_skeleton_state_and_thresholds() -> void:
+	var svc: Node = _svc()
+	assert_int(svc.current_state).is_equal(_EvalScript.State.IDLE)
+	assert_float(svc.VERDICT_THRESHOLD_PAGI).is_equal_approx(0.7, 0.0001)
+	assert_float(svc.VERDICT_THRESHOLD_LOW).is_equal_approx(0.3, 0.0001)
+	assert_bool(svc.has_signal("evaluation_completed")).is_true()
+	assert_bool(svc.has_signal("submission_rejected")).is_true()
+
+func test_evaluation_service_autoload_registered() -> void:
+	var autoload: Node = get_tree().root.get_node_or_null("EvaluationService")
+	assert_object(autoload).is_not_null()

--- a/tests/unit/submission_evaluation/scoring_test.gd
+++ b/tests/unit/submission_evaluation/scoring_test.gd
@@ -1,0 +1,76 @@
+## scoring_test.gd — story-002: 5 subscores + weighted final_score (deterministic).
+extends GdUnitTestSuite
+
+const _EvalScript: Script = preload("res://src/services/evaluation_service.gd")
+
+func _svc() -> Node:
+	var s: Node = _EvalScript.new()
+	get_tree().root.add_child(s)
+	auto_free(s)
+	return s
+
+# ─── disposition_match ───
+func test_disposition_match_exact() -> void:
+	assert_float(_svc().compute_disposition_match("파기", "파기")).is_equal_approx(1.0, 0.0001)
+
+func test_disposition_mismatch_zero() -> void:
+	assert_float(_svc().compute_disposition_match("기각", "파기")).is_equal_approx(0.0, 0.0001)
+
+# ─── core_citation_coverage (GDD §4.2 example) ───
+func test_coverage_gdd_example_half() -> void:
+	# correct [law-100, case/holding-1, case-do], player [law-100, case (whole), case-99999]
+	# → [1.0, 0.5 (whole vs holding), 0.0] / 3 = 0.5
+	var svc: Node = _svc()
+	var correct: Array = ["law:civil-act-art-100", "case:2024da12345/holding-1", "case:2024do6789"]
+	var player: Array = ["law:civil-act-art-100", "case:2024da12345", "case:2024da99999"]
+	assert_float(svc.compute_core_citation_coverage(player, correct)).is_equal_approx(0.5, 0.0001)
+
+func test_coverage_all_exact_one() -> void:
+	var svc: Node = _svc()
+	var c: Array = ["law:a", "law:b", "case:x/holding-1"]
+	assert_float(svc.compute_core_citation_coverage(c.duplicate(), c)).is_equal_approx(1.0, 0.0001)
+
+func test_coverage_none_zero() -> void:
+	assert_float(_svc().compute_core_citation_coverage(["law:z"], ["law:a", "law:b"])).is_equal_approx(0.0, 0.0001)
+
+func test_coverage_empty_correct_is_one() -> void:
+	assert_float(_svc().compute_core_citation_coverage(["law:a"], [])).is_equal_approx(1.0, 0.0001)
+
+func test_coverage_different_holdings_no_match() -> void:
+	# holding-1 vs holding-2 same case → 0.0 (GDD §4.2 Note)
+	assert_float(_svc().compute_core_citation_coverage(["case:x/holding-2"], ["case:x/holding-1"])).is_equal_approx(0.0, 0.0001)
+
+# ─── redundant_citation_penalty (GDD §4.3 examples) ───
+func test_penalty_50pct_redundant() -> void:
+	# 6 player, 3 matched + 3 redundant → ratio 0.5 → -min(0.3, 0.25) = -0.25
+	var svc: Node = _svc()
+	var correct: Array = ["law:a", "law:b", "law:c"]
+	var player: Array = ["law:a", "law:b", "law:c", "law:x", "law:y", "law:z"]
+	assert_float(svc.compute_redundant_citation_penalty(player, correct)).is_equal_approx(-0.25, 0.0001)
+
+func test_penalty_100pct_redundant_caps() -> void:
+	# all 5 redundant → ratio 1.0 → -min(0.3, 0.5) = -0.3 (cap)
+	assert_float(_svc().compute_redundant_citation_penalty(["a", "b", "c", "d", "e"], ["q"])).is_equal_approx(-0.3, 0.0001)
+
+func test_penalty_none_redundant_zero() -> void:
+	assert_float(_svc().compute_redundant_citation_penalty(["law:a"], ["law:a", "law:b"])).is_equal_approx(0.0, 0.0001)
+
+# ─── final_score weighted sum + clamp + v1+ weight-0 ───
+func test_final_score_weighted_sum() -> void:
+	var svc: Node = _svc()
+	var subs: Dictionary = {"disposition_match": 1.0, "core_citation_coverage": 0.5, "redundant_citation_penalty": -0.25, "chain_coherence": 0.9, "precedent_seniority_bonus": 0.9}
+	var weights: Dictionary = {"disposition_match": 0.4, "core_citation_coverage": 0.4, "redundant_citation_penalty": 0.2, "chain_coherence": 0.0, "precedent_seniority_bonus": 0.0}
+	# 1.0*0.4 + 0.5*0.4 + (-0.25)*0.2 + 0 + 0 = 0.4 + 0.2 - 0.05 = 0.55 ; v1+ weight-0 ignored
+	assert_float(svc.compute_final_score(subs, weights)).is_equal_approx(0.55, 0.0001)
+
+func test_final_score_clamped_to_one() -> void:
+	var svc: Node = _svc()
+	var subs: Dictionary = {"disposition_match": 1.0, "core_citation_coverage": 1.0}
+	var weights: Dictionary = {"disposition_match": 0.8, "core_citation_coverage": 0.8}  # 1.6 → clamp 1.0
+	assert_float(svc.compute_final_score(subs, weights)).is_equal_approx(1.0, 0.0001)
+
+func test_final_score_clamped_to_zero() -> void:
+	var svc: Node = _svc()
+	var subs: Dictionary = {"redundant_citation_penalty": -0.3}
+	var weights: Dictionary = {"redundant_citation_penalty": 1.0}  # -0.3 → clamp 0.0
+	assert_float(svc.compute_final_score(subs, weights)).is_equal_approx(0.0, 0.0001)

--- a/tests/unit/submission_evaluation/verdict_test.gd
+++ b/tests/unit/submission_evaluation/verdict_test.gd
@@ -1,0 +1,45 @@
+## verdict_test.gd — story-003: verdict function (파기/파기환송/기각/각하), GDD §4.7.
+extends GdUnitTestSuite
+
+const _EvalScript: Script = preload("res://src/services/evaluation_service.gd")
+
+func _svc() -> Node:
+	var s: Node = _EvalScript.new()
+	get_tree().root.add_child(s)
+	auto_free(s)
+	return s
+
+func test_match_high_is_pagi() -> void:
+	assert_str(_svc().determine_verdict("파기", "파기", 0.7)).is_equal("파기")
+
+func test_match_just_below_pagi_is_hwansong() -> void:
+	assert_str(_svc().determine_verdict("파기", "파기", 0.69)).is_equal("파기환송")
+
+func test_match_at_low_is_hwansong() -> void:
+	assert_str(_svc().determine_verdict("파기", "파기", 0.3)).is_equal("파기환송")
+
+func test_match_just_below_low_is_gakha() -> void:
+	assert_str(_svc().determine_verdict("파기", "파기", 0.29)).is_equal("각하")
+
+func test_mismatch_at_low_is_gigak() -> void:
+	assert_str(_svc().determine_verdict("기각", "파기", 0.3)).is_equal("기각")
+
+func test_mismatch_high_is_gigak_never_pagi() -> void:
+	# mismatch can never reach 파기 even at high score
+	assert_str(_svc().determine_verdict("기각", "파기", 0.95)).is_equal("기각")
+
+func test_mismatch_below_low_is_gakha() -> void:
+	assert_str(_svc().determine_verdict("기각", "파기", 0.1)).is_equal("각하")
+
+func test_all_four_verdicts_reachable() -> void:
+	var svc: Node = _svc()
+	var verdicts: Array = [
+		svc.determine_verdict("파기", "파기", 0.8),   # 파기
+		svc.determine_verdict("파기", "파기", 0.4),   # 파기환송
+		svc.determine_verdict("기각", "파기", 0.4),   # 기각
+		svc.determine_verdict("파기", "파기", 0.1),   # 각하
+	]
+	assert_bool(verdicts.has("파기")).is_true()
+	assert_bool(verdicts.has("파기환송")).is_true()
+	assert_bool(verdicts.has("기각")).is_true()
+	assert_bool(verdicts.has("각하")).is_true()

--- a/tests/unit/ui_foundation/kr_custom_control_test.gd
+++ b/tests/unit/ui_foundation/kr_custom_control_test.gd
@@ -1,0 +1,224 @@
+## kr_custom_control_test.gd — KrControlHelper + 4 Kr* subclass scaffold unit tests.
+##
+## Covers story-002 Acceptance Criteria:
+##   AC-5   KrControlHelper.setup(control) queues NOTIFICATION_ACCESSIBILITY_UPDATE
+##          (via Control.queue_accessibility_update) without error. Subclasses apply
+##          the role in their _notification(NOTIFICATION_ACCESSIBILITY_UPDATE) override.
+##   AC-5   Each Kr* subclass _ready() sets theme_type_variation correctly.
+##   AC-5   Each Kr* subclass declares the correct ACCESSIBILITY_ROLE constant integer.
+##   AC-5a  setup() with SettingsService absent → no error/crash (headless: singleton absent).
+##   AC-7   docs/registry/architecture.yaml contains "custom_control_outside_kr_hierarchy".
+##
+## Subclass role expectations (ADR-0010 amend-1 §G1 — corrected mapping):
+##   KrPane   → theme_type_variation &"Pane"   + ACCESSIBILITY_ROLE 6 (ROLE_PANEL)
+##   KrCard   → theme_type_variation &"Card"   + ACCESSIBILITY_ROLE 6 (ROLE_PANEL)
+##   KrButton → theme_type_variation &"Button" + ACCESSIBILITY_ROLE 7 (ROLE_BUTTON)
+##   KrBanner → theme_type_variation &"Banner" + ACCESSIBILITY_ROLE 4 (ROLE_STATIC_TEXT)
+##
+## Godot 4.6 API deviation (runtime-verified 2026-05-23):
+##   Control has NO set_accessibility_role() method and NO accessibility_role property.
+##   Role assignment uses DisplayServer.accessibility_update_set_role(rid, role), which
+##   requires a valid RID only available in a live (non-headless) scene tree. In headless
+##   runs the RID is invalid; the call is silently skipped via rid.is_valid() guard.
+##   Tests verify role intent via the ACCESSIBILITY_ROLE constant on each class instead
+##   of reading back a runtime property. DisplayServer.AccessibilityRole enum IS accessible
+##   in headless (it is a compile-time constant, not a runtime object).
+##
+## Test strategy:
+##   Preload each script directly to bypass class_name global cache (not registered
+##   in headless runs without editor scan — same pattern as ui_service_test.gd).
+##   Instantiate via Script.new(), add_child() to fire _ready(), auto_free() for cleanup.
+##   KrControlHelper.setup() is tested as a direct static call without add_child().
+##   FileAccess read verifies AC-7 registry gate (YAML is a static project file;
+##   test is read-only + deterministic).
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/unit/ui_foundation/kr_custom_control_test.gd
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md
+## TR:  TR-ui-005
+extends GdUnitTestSuite
+
+
+# ─── Preloaded scripts ────────────────────────────────────────────────────────
+# Bypass class_name global cache (requires editor scan; may not resolve in headless).
+
+const KrControlHelperScript: Script = preload("res://src/ui/kr_control_helper.gd")
+const KrPaneScript: Script = preload("res://src/ui/kr_pane.gd")
+const KrCardScript: Script = preload("res://src/ui/kr_card.gd")
+const KrButtonScript: Script = preload("res://src/ui/kr_button.gd")
+const KrBannerScript: Script = preload("res://src/ui/kr_banner.gd")
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+## Instantiate a Kr* node, add it to the tree so _ready() fires, and register
+## for automatic cleanup. Returns the node typed as Control.
+func _make_kr_node(script: Script) -> Control:
+	var node: Control = script.new() as Control
+	get_tree().root.add_child(node)
+	auto_free(node)
+	return node
+
+
+# ─── AC-5 — KrPane: theme_type_variation + ACCESSIBILITY_ROLE constant ────────
+
+func test_kr_pane_ready_sets_theme_type_variation_pane() -> void:
+	# Arrange + Act
+	var pane: Control = _make_kr_node(KrPaneScript)
+
+	# Assert
+	assert_str(str(pane.theme_type_variation)).is_equal("Pane")
+
+
+func test_kr_pane_accessibility_role_constant_is_role_panel() -> void:
+	# Assert — ACCESSIBILITY_ROLE constant encodes ROLE_PANEL = 6.
+	# Control has no accessibility_role property in Godot 4.6 (runtime-verified):
+	# role assignment uses DisplayServer.accessibility_update_set_role(rid, role)
+	# which requires a valid RID unavailable in headless. The constant is the
+	# authoritative intent source.
+	assert_int(KrPaneScript.ACCESSIBILITY_ROLE).is_equal(DisplayServer.AccessibilityRole.ROLE_PANEL)
+
+
+func test_kr_pane_accessibility_role_constant_matches_expected_integer() -> void:
+	# Belt-and-suspenders: verify the integer value directly (=6) so a future
+	# enum renumbering would also fail this test.
+	assert_int(KrPaneScript.ACCESSIBILITY_ROLE).is_equal(6)
+
+
+# ─── AC-5 — KrCard: theme_type_variation + ACCESSIBILITY_ROLE constant ────────
+
+func test_kr_card_ready_sets_theme_type_variation_card() -> void:
+	# Arrange + Act
+	var card: Control = _make_kr_node(KrCardScript)
+
+	# Assert
+	assert_str(str(card.theme_type_variation)).is_equal("Card")
+
+
+func test_kr_card_accessibility_role_constant_is_role_panel() -> void:
+	# Assert — base KrCard is ROLE_PANEL (=6). Subclasses override with
+	# ROLE_LIST_ITEM / ROLE_TREE_ITEM / ROLE_BUTTON / ROLE_CHECK_BOX.
+	assert_int(KrCardScript.ACCESSIBILITY_ROLE).is_equal(DisplayServer.AccessibilityRole.ROLE_PANEL)
+
+
+func test_kr_card_accessibility_role_constant_matches_expected_integer() -> void:
+	assert_int(KrCardScript.ACCESSIBILITY_ROLE).is_equal(6)
+
+
+# ─── AC-5 — KrButton: theme_type_variation + ACCESSIBILITY_ROLE constant ──────
+
+func test_kr_button_ready_sets_theme_type_variation_button() -> void:
+	# Arrange + Act
+	var button: Control = _make_kr_node(KrButtonScript)
+
+	# Assert
+	assert_str(str(button.theme_type_variation)).is_equal("Button")
+
+
+func test_kr_button_accessibility_role_constant_is_role_button() -> void:
+	# Assert — ROLE_BUTTON = 7 (DisplayServer.AccessibilityRole — ADR-0010 amend-1 §G1)
+	assert_int(KrButtonScript.ACCESSIBILITY_ROLE).is_equal(DisplayServer.AccessibilityRole.ROLE_BUTTON)
+
+
+func test_kr_button_accessibility_role_constant_matches_expected_integer() -> void:
+	assert_int(KrButtonScript.ACCESSIBILITY_ROLE).is_equal(7)
+
+
+# ─── AC-5 — KrBanner: theme_type_variation + ACCESSIBILITY_ROLE constant ──────
+
+func test_kr_banner_ready_sets_theme_type_variation_banner() -> void:
+	# Arrange + Act
+	var banner: Control = _make_kr_node(KrBannerScript)
+
+	# Assert
+	assert_str(str(banner.theme_type_variation)).is_equal("Banner")
+
+
+func test_kr_banner_accessibility_role_constant_is_role_static_text() -> void:
+	# Assert — ROLE_STATIC_TEXT = 4. Godot 4.6 has no ROLE_STATUS/ROLE_ALERT —
+	# ROLE_STATIC_TEXT is the correct cap (ADR-0010 amend-1 §G1 correction).
+	assert_int(KrBannerScript.ACCESSIBILITY_ROLE).is_equal(DisplayServer.AccessibilityRole.ROLE_STATIC_TEXT)
+
+
+func test_kr_banner_accessibility_role_constant_matches_expected_integer() -> void:
+	assert_int(KrBannerScript.ACCESSIBILITY_ROLE).is_equal(4)
+
+
+# ─── AC-5a — KrControlHelper.setup() with SettingsService absent ──────────────
+
+func test_kr_control_helper_setup_no_crash_when_settings_service_absent() -> void:
+	# Arrange — bare Control; SettingsService singleton NOT registered in headless tests.
+	# Engine.has_singleton("SettingsService") returns false → the stub branch is skipped.
+	var bare: Control = Control.new()
+	get_tree().root.add_child(bare)
+	auto_free(bare)
+
+	# Act — must not raise an error or crash
+	KrControlHelperScript.setup(bare)
+
+	# Assert — no crash; bare Control has no _apply_access_kit_role method.
+	# has_method check inside setup() returns false → no dispatch attempt.
+	assert_bool(bare.has_method("_apply_access_kit_role")).is_false()
+
+
+func test_kr_subclass_declares_apply_access_kit_role_override() -> void:
+	# A Kr* subclass must declare _apply_access_kit_role(), which its
+	# _notification(NOTIFICATION_ACCESSIBILITY_UPDATE) override invokes when the
+	# engine rebuilds the accessibility tree. (setup() itself only QUEUES the update
+	# via Control.queue_accessibility_update — it does NOT call the role setter
+	# directly; the RID is only valid inside the notification cycle.)
+	var pane: Control = KrPaneScript.new() as Control
+	get_tree().root.add_child(pane)
+	auto_free(pane)
+
+	# Assert — the override hook the _notification path depends on is present.
+	assert_bool(pane.has_method("_apply_access_kit_role")).is_true()
+
+
+func test_kr_control_helper_setup_queues_accessibility_update_without_error() -> void:
+	# setup() calls Control.queue_accessibility_update() to schedule
+	# NOTIFICATION_ACCESSIBILITY_UPDATE; it must complete without error on a real
+	# Kr* node (headless: the queued notification's RID work is a no-op).
+	var pane: Control = KrPaneScript.new() as Control
+	get_tree().root.add_child(pane)
+	auto_free(pane)
+
+	# Act — direct static call must not raise
+	KrControlHelperScript.setup(pane)
+
+	# Assert — reached here without crash; the override hook exists for the
+	# notification cycle to dispatch.
+	assert_bool(pane.has_method("_apply_access_kit_role")).is_true()
+
+
+func test_kr_control_helper_setup_is_callable_as_static_method() -> void:
+	# Arrange
+	var bare: Control = Control.new()
+	get_tree().root.add_child(bare)
+	auto_free(bare)
+
+	# Act — static dispatch must not raise errors. If we reach the assert,
+	# no fatal crash or parse error occurred.
+	KrControlHelperScript.setup(bare)
+	assert_bool(true).is_true()
+
+
+# ─── AC-7 — Registry gate: custom_control_outside_kr_hierarchy ───────────────
+
+func test_architecture_yaml_contains_custom_control_outside_kr_hierarchy() -> void:
+	# Arrange — read the forbidden_patterns registry.
+	# The YAML is a static project file committed to version control;
+	# reading it in tests is deterministic and requires no mock.
+	const REGISTRY_PATH: String = "res://docs/registry/architecture.yaml"
+	var file: FileAccess = FileAccess.open(REGISTRY_PATH, FileAccess.READ)
+	assert_object(file).is_not_null()
+
+	# Act
+	var content: String = file.get_as_text()
+	file.close()
+
+	# Assert — forbidden pattern must be registered (AC-7 automated gate).
+	# Confirmed present at line 1851 of architecture.yaml (verified pre-implementation).
+	assert_bool(content.contains("custom_control_outside_kr_hierarchy")).is_true()

--- a/tests/unit/ui_foundation/kr_custom_control_test.gd.uid
+++ b/tests/unit/ui_foundation/kr_custom_control_test.gd.uid
@@ -1,0 +1,1 @@
+uid://dbne7hhro4trr

--- a/tests/unit/ui_foundation/tween_property_test.gd
+++ b/tests/unit/ui_foundation/tween_property_test.gd
@@ -1,0 +1,151 @@
+## tween_property_test.gd — UIService.tween_property animation gateway unit tests.
+##
+## Covers story-004 Acceptance Criteria:
+##   AC-15  reduced_motion == false → creates a Tween, chains tween_property, returns the Tween.
+##   AC-16  reduced_motion == true  → returns null + applies final value immediately (set_indexed).
+##   AC-10  reduced_motion defaults to false (safe default; SettingsService not yet integrated).
+##   Forbidden-pattern gate: direct_create_tween_bypassing_reduced_motion registered in
+##          docs/registry/architecture.yaml (all animation must route through the gateway).
+##
+## Design note (deviation from story-004 pseudo-code): reduced motion is read from the
+## settable UIService.reduced_motion state field (the SettingsService subscription seam,
+## wired in story 005/009), NOT a per-call Engine.has_singleton lookup. Tests drive the
+## reduced-motion path by setting that field directly. See ui_service.gd for rationale.
+##
+## Test strategy (isolation — fresh instance per test):
+##   Create a fresh _UIServiceScript.new() (preloaded to bypass class_name cache, same as
+##   ui_service_test.gd), add_child() so create_tween() has a tree, auto_free() for cleanup.
+##   This avoids mutating the shared autoload's reduced_motion state across tests.
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/unit/ui_foundation/tween_property_test.gd
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md (§Decision + §Risk R7)
+## TR:  TR-ui-010
+extends GdUnitTestSuite
+
+
+const _UIServiceScript: Script = preload("res://src/ui/ui_service.gd")
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+## Fresh UIService instance in the tree (so create_tween() works), auto-freed.
+func _make_service() -> Node:
+	var svc: Node = _UIServiceScript.new()
+	get_tree().root.add_child(svc)
+	auto_free(svc)
+	return svc
+
+
+## A bare Control with modulate.a pre-set to 0.0, added to the tree + auto-freed.
+func _make_target() -> Control:
+	var c: Control = Control.new()
+	c.modulate.a = 0.0
+	get_tree().root.add_child(c)
+	auto_free(c)
+	return c
+
+
+# ─── AC-10 — reduced_motion default ───────────────────────────────────────────
+
+func test_reduced_motion_defaults_to_false() -> void:
+	# Arrange + Act
+	var svc: Node = _make_service()
+
+	# Assert — safe default: animations play until SettingsService wires the real value
+	assert_bool(svc.reduced_motion).is_false()
+
+
+# ─── AC-15 — reduced_motion false → real Tween ────────────────────────────────
+
+func test_tween_property_returns_valid_tween_when_motion_enabled() -> void:
+	# Arrange
+	var svc: Node = _make_service()
+	svc.reduced_motion = false
+	var target: Control = _make_target()
+
+	# Act
+	var tween: Tween = svc.tween_property(target, "modulate:a", 1.0, 0.05)
+
+	# Assert — a Tween instance is returned and is live (AC-15 contract: creates + returns Tween)
+	assert_object(tween).is_not_null()
+	assert_bool(tween is Tween).is_true()
+	assert_bool(tween.is_valid()).is_true()
+
+
+func test_tween_property_interpolates_target_to_final_value() -> void:
+	# Arrange
+	var svc: Node = _make_service()
+	svc.reduced_motion = false
+	var target: Control = _make_target()
+	assert_float(target.modulate.a).is_equal_approx(0.0, 0.001)
+
+	# Act — start a short tween, then let real time pass beyond its duration
+	svc.tween_property(target, "modulate:a", 1.0, 0.05)
+	await get_tree().create_timer(0.15).timeout
+
+	# Assert — target reached the final value (best-effort real-timing; the
+	# deterministic contract is covered by the returns_valid_tween test above)
+	assert_float(target.modulate.a).is_equal_approx(1.0, 0.01)
+
+
+# ─── AC-16 — reduced_motion true → null + immediate set ───────────────────────
+
+func test_tween_property_returns_null_and_sets_value_immediately_when_reduced() -> void:
+	# Arrange — reduced motion ON
+	var svc: Node = _make_service()
+	svc.reduced_motion = true
+	var target: Control = _make_target()
+	assert_float(target.modulate.a).is_equal_approx(0.0, 0.001)
+
+	# Act
+	var tween: Tween = svc.tween_property(target, "modulate:a", 1.0, 0.05)
+
+	# Assert — no Tween created; final value applied immediately
+	assert_object(tween).is_null()
+	assert_float(target.modulate.a).is_equal_approx(1.0, 0.001)
+
+
+func test_tween_property_reduced_motion_does_not_create_tween() -> void:
+	# AC-16: confirm no Tween allocation path when reduced motion is on, by checking
+	# the immediate value application happens within the same frame (no await needed).
+	var svc: Node = _make_service()
+	svc.reduced_motion = true
+	var target: Control = _make_target()
+
+	# Act
+	var result: Variant = svc.tween_property(target, "modulate:a", 0.42, 1.0)
+
+	# Assert — returned null and value is set this frame (no time passage)
+	assert_object(result).is_null()
+	assert_float(target.modulate.a).is_equal_approx(0.42, 0.001)
+
+
+# ─── Null-target guard ────────────────────────────────────────────────────────
+
+func test_tween_property_null_target_returns_null_without_crash() -> void:
+	# Arrange
+	var svc: Node = _make_service()
+
+	# Act — null target must not crash (push_error fires internally; gdunit4 does
+	# not auto-fail on push_error). Returns null.
+	var result: Variant = svc.tween_property(null, "modulate:a", 1.0, 0.05)
+
+	# Assert
+	assert_object(result).is_null()
+
+
+# ─── Forbidden-pattern registry gate ──────────────────────────────────────────
+
+func test_architecture_yaml_contains_direct_create_tween_forbidden_pattern() -> void:
+	# All UI animation must route through UIService.tween_property; the forbidden
+	# pattern enforces this at PR review. Verify it is registered (automated gate).
+	const REGISTRY_PATH: String = "res://docs/registry/architecture.yaml"
+	var file: FileAccess = FileAccess.open(REGISTRY_PATH, FileAccess.READ)
+	assert_object(file).is_not_null()
+
+	var content: String = file.get_as_text()
+	file.close()
+	assert_bool(content.contains("direct_create_tween_bypassing_reduced_motion")).is_true()

--- a/tests/unit/ui_foundation/tween_property_test.gd.uid
+++ b/tests/unit/ui_foundation/tween_property_test.gd.uid
@@ -1,0 +1,1 @@
+uid://cnfpvm7rgj5qo

--- a/tests/unit/ui_foundation/ui_service_test.gd
+++ b/tests/unit/ui_foundation/ui_service_test.gd
@@ -1,0 +1,217 @@
+## ui_service_test.gd — UIService autoload unit tests.
+##
+## Covers story-001 Acceptance Criteria:
+##   AC-1   _ready() loads Theme + connects viewport size_changed + emits ui_service_initialized.
+##   AC-1.2 UIService.theme read-only: direct assignment fires push_error, ref unchanged.
+##   AC-1.3 viewport_reflow_needed debounce: 3 size_changed fires within 30ms → exactly 1 emit.
+##   AC-1.4 VIEWPORT_REFLOW_DEBOUNCE_MS constant == 50.
+##   AC-1.5 _UIServiceScript extends Node (not Resource).
+##   AC-1.6 Theme initially empty: get_type_variation_list("Label") returns [].
+##
+## Test strategy (isolation — option b):
+##   Create a fresh _UIServiceScript.new() instance, add_child() it to the test
+##   suite node (GdUnitTestSuite extends Node, so it is in the scene tree).
+##   _ready() fires automatically on add_child. This avoids autoload-singleton
+##   state contamination and satisfies the "unit tests must not depend on
+##   external state" project standard.
+##
+## Signal assertions use the manual connect+counter pattern (proven by
+## workspace_state_machine_test.gd): connect BEFORE the act, check counter AFTER.
+## Node signals are synchronous for same-frame emits; the Timer debounce tests
+## use `await get_tree().create_timer(...)` to cross the 50ms window.
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary godot \
+##     -a tests/unit/ui_foundation/ui_service_test.gd
+##
+## ADR: docs/architecture/adr-0010-ui-foundation-architecture.md
+## TR:  TR-ui-001
+extends GdUnitTestSuite
+
+
+# Preload bypasses GDScript class_name cache (which requires editor scan to register
+# global symbols). Test references the Script directly via preload constant — works
+# in headless test runs without requiring `godot --editor` cache population.
+const _UIServiceScript: Script = preload("res://src/ui/ui_service.gd")
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+## Creates a fresh _UIServiceScript instance, adds it to the test suite node so
+## _ready() fires and the Timer child can access the scene tree.
+## auto_free() registers it for cleanup after each test.
+func _make_service() -> Node:
+	var svc: Node = _UIServiceScript.new()
+	get_tree().root.add_child(svc)
+	auto_free(svc)
+	return svc
+
+
+# ─── AC-1.4 — Constant value ──────────────────────────────────────────────────
+
+func test_viewport_reflow_debounce_ms_constant_is_50() -> void:
+	# Arrange + Act (constant — no instance needed)
+	# Assert
+	assert_int(_UIServiceScript.VIEWPORT_REFLOW_DEBOUNCE_MS).is_equal(50)
+
+
+# ─── AC-1.5 — Extends Node ────────────────────────────────────────────────────
+
+func test_ui_service_class_extends_node() -> void:
+	# Arrange
+	var svc: Node = _make_service()
+
+	# Assert — _UIServiceScript must be a Node (not a Resource) for viewport access
+	assert_bool(svc is Node).is_true()
+
+
+# ─── AC-1 — _ready() initializes Theme + emits ui_service_initialized ─────────
+
+func test_ready_theme_is_theme_instance() -> void:
+	# Arrange
+	var svc: Node = _make_service()
+
+	# Assert — theme property holds a Theme object after _ready()
+	assert_bool(svc.theme is Theme).is_true()
+
+
+func test_autoload_ui_service_registered_in_tree() -> void:
+	# AC-1 (autoload-verified): UIService autoload is registered + in scene tree
+	# (verifies project.godot [autoload] entry; _ready() already ran at game start
+	# so ui_service_initialized signal cannot be re-captured here — it's a one-shot
+	# init signal. This test confirms the autoload registration succeeded.)
+	var autoload: Node = get_tree().root.get_node_or_null("UIService")
+	assert_object(autoload).is_not_null()
+
+
+func test_autoload_ui_service_theme_is_initialized() -> void:
+	# AC-1 (theme created during _ready on autoload): autoload's theme is Theme instance
+	var autoload: Node = get_tree().root.get_node_or_null("UIService")
+	assert_object(autoload).is_not_null()
+	assert_bool(autoload.theme is Theme).is_true()
+
+
+func test_autoload_ui_service_viewport_debounce_timer_child_exists() -> void:
+	# AC-1 (debounce timer child added during _ready): autoload has Timer child
+	var autoload: Node = get_tree().root.get_node_or_null("UIService")
+	assert_object(autoload).is_not_null()
+	var timer_count: int = 0
+	for child in autoload.get_children():
+		if child is Timer:
+			timer_count += 1
+	assert_int(timer_count).is_greater_equal(1)
+
+
+# ─── AC-1.2 — Theme read-only property guard ─────────────────────────────────
+
+func test_theme_direct_assignment_does_not_mutate() -> void:
+	# Arrange
+	var svc: Node = _make_service()
+	var original_theme: Theme = svc.theme
+
+	# Act — direct assignment fires push_error internally; gdunit4 does not
+	# auto-fail on push_error. Theme reference integrity is the assertion.
+	svc.theme = Theme.new()
+
+	# Assert — reference unchanged (setter rejected the write)
+	assert_object(svc.theme).is_same(original_theme)
+
+
+func test_theme_getter_returns_same_reference_on_repeated_access() -> void:
+	# Arrange
+	var svc: Node = _make_service()
+
+	# Act + Assert — two gets return the same object (no copy-on-read)
+	assert_object(svc.theme).is_same(svc.theme)
+
+
+# ─── AC-1.6 — Theme initially empty ──────────────────────────────────────────
+
+func test_theme_initially_has_no_label_type_variations() -> void:
+	# Arrange
+	var svc: Node = _make_service()
+
+	# Assert — story 003 populates type variations; story 001 is empty
+	assert_array(svc.theme.get_type_variation_list("Label")).is_empty()
+
+
+# ─── AC-1.3 — viewport_reflow_needed callback chain (autoload-based) ─────────
+# Note: Timer Node's _process tick may not advance in gdunit4 headless test
+# isolation, so tests below verify the callback chain structurally rather than
+# the actual 50ms debounce timing. Real timing verification belongs in
+# integration tests (deferred — would require manual headless run with
+# scene tree process explicitly ticked).
+
+func test_size_changed_handler_starts_debounce_timer() -> void:
+	# AC-1.3 (structural): _on_viewport_size_changed calls Timer.start()
+	var svc: Node = get_tree().root.get_node_or_null("UIService")
+	assert_object(svc).is_not_null()
+
+	# Find the debounce Timer child (added during _ready)
+	var timer: Timer = null
+	for child in svc.get_children():
+		if child is Timer:
+			timer = child
+			break
+	assert_object(timer).is_not_null()
+
+	# Stop timer initially (may have been running from prior tests)
+	timer.stop()
+	assert_bool(timer.is_stopped()).is_true()
+
+	# Act — fire size_changed
+	svc._on_viewport_size_changed()
+
+	# Assert — timer started + wait_time matches constant
+	assert_bool(timer.is_stopped()).is_false()
+	assert_float(timer.wait_time).is_equal_approx(0.05, 0.001)  # 50ms
+	timer.stop()
+
+
+func test_debounce_timeout_callback_emits_viewport_reflow_needed() -> void:
+	# AC-1.3 (callback chain): _on_viewport_debounce_timeout emits the signal
+	var svc: Node = get_tree().root.get_node_or_null("UIService")
+	assert_object(svc).is_not_null()
+	# Use an Array accumulator (reference type), NOT a plain int: GDScript lambdas
+	# capture primitives BY VALUE, so `count += 1` inside a lambda increments a copy
+	# and the outer int stays 0. Arrays are shared by reference with the outer scope.
+	# (Same hazard documented in freeze_contract_test.gd header lines 25-34.)
+	var captured: Array = []
+	var cb: Callable = func() -> void: captured.append(true)
+	svc.viewport_reflow_needed.connect(cb)
+
+	# Act — call the timeout callback directly (bypass Timer tick which may not
+	# advance in headless test isolation)
+	svc._on_viewport_debounce_timeout()
+	await get_tree().process_frame
+
+	# Assert
+	svc.viewport_reflow_needed.disconnect(cb)
+	assert_int(captured.size()).is_equal(1)
+
+
+func test_debounce_multiple_starts_reset_timer() -> void:
+	# AC-1.3 (coalescing structural): Timer.start() resets running timer
+	var svc: Node = get_tree().root.get_node_or_null("UIService")
+	assert_object(svc).is_not_null()
+	var timer: Timer = null
+	for child in svc.get_children():
+		if child is Timer:
+			timer = child
+			break
+	assert_object(timer).is_not_null()
+	timer.stop()
+
+	# Act — start timer 3 times in succession; each start resets time_left
+	svc._on_viewport_size_changed()
+	var first_time_left: float = timer.time_left
+	svc._on_viewport_size_changed()  # reset
+	var second_time_left: float = timer.time_left
+	svc._on_viewport_size_changed()  # reset again
+	var third_time_left: float = timer.time_left
+
+	# Assert — each start sets time_left back to ~wait_time (50ms)
+	assert_float(first_time_left).is_greater(0.0)
+	assert_float(second_time_left).is_greater(0.0)
+	assert_float(third_time_left).is_greater(0.0)
+	timer.stop()

--- a/tests/unit/ui_foundation/ui_service_test.gd.uid
+++ b/tests/unit/ui_foundation/ui_service_test.gd.uid
@@ -1,0 +1,1 @@
+uid://cx35jyl822jhq

--- a/tests/unit/workspace/edge_cases_test.gd
+++ b/tests/unit/workspace/edge_cases_test.gd
@@ -1,0 +1,669 @@
+## edge_cases_test.gd — WorkspaceData tree-structural edge cases + chain_data validation suite.
+##
+## Covers story-012 Edge Cases and Performance Gates (scope-split mirror of story-007):
+##
+## REAL TESTS (implemented — testable against existing WorkspaceData + HypothesisNodeData):
+##   EC-1   Empty tree: INACTIVE → {} ; ACTIVE with no nodes → {schema_version:1, nodes:[], ...}
+##   EC-2   Single root + single evidence → chain_data counts verified
+##   EC-3   Max tree builds + JSON round-trip: 3 roots × 2-branch × depth-3 × 5 ev/node (45 nodes)
+##   EC-4   Depth-4 rejected: add_child_to_node on depth-3 node → false + "max_depth" (AC-12)
+##   EC-5   Cycle rejected: reparent ancestor onto descendant → false + "cycle" (AC-13)
+##   EC-12  Memo at exactly 500 codepoints: no truncation, no signal
+##   EC-13  Memo at 501 codepoints: truncated to 500 + "memo_truncated" emitted
+##   EC-16  Pillar 1 — memo_text field injected into chain_data node → validate returns false
+##   EC-17  Pillar 1 — settings key injected into chain_data node → validate returns false
+##   AC-52  Forbidden-field fuzz: 5 forbidden ephemeral names all rejected
+##   AC-52b Settings-inclusion fuzz: 5 settings keys all rejected
+##
+## SKIP-STUB TESTS (deferred — feature/service not yet implemented):
+##   EC-6   Dedup (drag-drop pipeline — story 004)
+##   EC-7   Drop non-existent library_id + announce (LibraryService + UIService.announce_text)
+##   EC-8   Drop on non-ACTIVE state guard (drag-drop — story 004)
+##   EC-9   Window resize mid-drag (UI drag-drop)
+##   EC-10  State transition during pending citation (story 004)
+##   EC-11  Corrupted active_case.tres → .backup recovery (SaveLoadService)
+##   EC-14  Korean IME composition at cap boundary (VR-D7 dependent)
+##   EC-15  Memo focus loss mid-IME (UI/IME)
+##   EC-18  WorkspaceData reference after case unload (Case Browser)
+##   EC-19  Drag while Browser scene swapping (Case Browser)
+##   EC-20  Auto-resubmit schema_version mismatch → CriticalBanner (story 008)
+##   EC-21  Camera2D pan clamp (UI — camera)
+##   EC-22  Gamepad two-step with mid-process transition (story 004)
+##   EC-23  Focus loss off-window → restore (UI focus)
+##   EC-24  Simultaneous SettingsService changes race (SettingsService)
+##
+## Signal assertion pattern (synchronous Resource signals):
+##   Manual connect() + Array accumulator BEFORE act, assert AFTER, disconnect AFTER.
+##   Use Array (reference type) — never a plain int (lambda captures primitives by value).
+##   See freeze_contract_test.gd header lines 25-34.
+##
+## Determinism note: build_chain_data() embeds submission_timestamp_unix.
+##   When comparing whole dicts, strip that key first (see EC-3).
+##
+## ADR: docs/architecture/adr-0007-amend-1-chain-data-primitive-only.md
+##      docs/architecture/adr-0008-workspace-layout.md §1
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/unit/workspace/edge_cases_test.gd
+extends GdUnitTestSuite
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+## Returns a fresh WorkspaceData in INACTIVE state.
+func _make_data() -> WorkspaceData:
+	return WorkspaceData.new()
+
+
+## Returns a HypothesisNodeData with the given fields pre-set.
+## depth must be set by the caller to match the intended tree level (story 003
+## enforces the invariant at construction; here we set it manually for fixtures).
+func _make_node(
+	id: String,
+	parent: String = "",
+	depth: int = 0,
+	evidence: Array[String] = []
+) -> HypothesisNodeData:
+	var n := HypothesisNodeData.new()
+	n.node_id = id
+	n.label = "label-%s" % id
+	n.parent_id = parent
+	n.depth = depth
+	n.evidence = evidence
+	return n
+
+
+## Drives WorkspaceData to ACTIVE state with the given nodes already appended.
+## Circumvents add_first_root_node so we can build arbitrary trees including child nodes.
+func _data_with_nodes(node_list: Array[HypothesisNodeData]) -> WorkspaceData:
+	var data: WorkspaceData = _make_data()
+	for n: HypothesisNodeData in node_list:
+		data.nodes.append(n)
+	data._transition_to_active()
+	return data
+
+
+# ─── EC-1 — Empty tree ────────────────────────────────────────────────────────
+
+func test_ec_1_inactive_state_build_chain_data_returns_empty_dict() -> void:
+	# Arrange
+	var data: WorkspaceData = _make_data()
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.INACTIVE)
+
+	# Act
+	var cd: Dictionary = data.build_chain_data()
+
+	# Assert — INACTIVE must return {} per AC-23
+	assert_bool(cd.is_empty()).is_true()
+
+
+func test_ec_1_active_empty_tree_returns_valid_structure_with_zeros() -> void:
+	# Arrange — ACTIVE state but zero nodes added
+	var data: WorkspaceData = _make_data()
+	data._transition_to_active()
+
+	# Act
+	var cd: Dictionary = data.build_chain_data()
+
+	# Assert — structure is present with correct zero-state values
+	assert_int(cd.get("schema_version", -1)).is_equal(1)
+	assert_int((cd["nodes"] as Array).size()).is_equal(0)
+	assert_int((cd["edges"] as Array).size()).is_equal(0)
+	assert_int(cd["total_evidence_count"]).is_equal(0)
+	assert_int(cd["max_depth_reached"]).is_equal(0)
+	assert_bool(cd.has("submission_timestamp_unix")).is_true()
+	# No errors emitted
+	var rejection_captures: Array = []
+	var cb: Callable = func(reason: String) -> void: rejection_captures.append(reason)
+	data.submission_rejected.connect(cb)
+	var valid: bool = data.validate_chain_data(cd)
+	data.submission_rejected.disconnect(cb)
+	assert_bool(valid).is_true()
+	assert_int(rejection_captures.size()).is_equal(0)
+
+
+# ─── EC-2 — Single root + single evidence ────────────────────────────────────
+
+func test_ec_2_single_root_single_evidence_chain_data_counts() -> void:
+	# Arrange — one root, one evidence item
+	var root: HypothesisNodeData = _make_node("root-A", "", 0, ["ev-001"])
+	var data: WorkspaceData = _data_with_nodes([root])
+
+	# Act
+	var cd: Dictionary = data.build_chain_data()
+
+	# Assert — exactly 1 node, no edges, counts are 1
+	assert_int((cd["nodes"] as Array).size()).is_equal(1)
+	assert_int((cd["edges"] as Array).size()).is_equal(0)
+	assert_int(cd["total_evidence_count"]).is_equal(1)
+
+	var node_dict: Dictionary = cd["nodes"][0]
+	assert_int(node_dict["evidence_count"]).is_equal(1)
+	assert_int(node_dict["child_count"]).is_equal(0)
+	assert_str(node_dict["node_id"]).is_equal("root-A")
+
+
+# ─── EC-3 — Max tree builds + JSON round-trip ────────────────────────────────
+#
+# Tree shape: 3 roots (depth 0), each root has 2 children (depth 1),
+# each child has 2 children (depth 2), each of those has 2 children (depth 3).
+# Node count:
+#   depth 0: 3 roots
+#   depth 1: 3 * 2 = 6 children
+#   depth 2: 6 * 2 = 12 grandchildren
+#   depth 3: 12 * 2 = 24 great-grandchildren
+#   TOTAL: 3 + 6 + 12 + 24 = 45 nodes
+# Evidence: 5 per node × 45 = 225 total
+
+func test_ec_3_max_tree_builds_and_serializes_correctly() -> void:
+	# Arrange — build the deepest valid tree using the public mutation API
+	var data: WorkspaceData = WorkspaceData.new()
+	var ev_ids: Array[String] = ["ev-1", "ev-2", "ev-3", "ev-4", "ev-5"]
+
+	# Lay down 3 roots at depth 0
+	for r: int in range(3):
+		var root_id: String = "r%d" % r
+		var root: HypothesisNodeData = HypothesisNodeData.new()
+		root.node_id = root_id
+		root.label = "root-%d" % r
+		data.add_first_root_node(root)  # transitions INACTIVE→ACTIVE on first call
+		for ev: String in ev_ids:
+			data.attach_evidence(root_id, ev)
+
+		# 2 children at depth 1 per root
+		for c: int in range(2):
+			var child_id: String = "r%dc%d" % [r, c]
+			var child: HypothesisNodeData = HypothesisNodeData.new()
+			child.node_id = child_id
+			child.label = "child-%d-%d" % [r, c]
+			var ok_c: bool = data.add_child_to_node(root_id, child)
+			assert_bool(ok_c).is_true()
+			for ev: String in ev_ids:
+				data.attach_evidence(child_id, ev)
+
+			# 2 grandchildren at depth 2 per child
+			for gc: int in range(2):
+				var gc_id: String = "r%dc%dgc%d" % [r, c, gc]
+				var grandchild: HypothesisNodeData = HypothesisNodeData.new()
+				grandchild.node_id = gc_id
+				grandchild.label = "gc-%d-%d-%d" % [r, c, gc]
+				var ok_gc: bool = data.add_child_to_node(child_id, grandchild)
+				assert_bool(ok_gc).is_true()
+				for ev: String in ev_ids:
+					data.attach_evidence(gc_id, ev)
+
+				# 2 great-grandchildren at depth 3 (MAX_TREE_DEPTH) per grandchild
+				for ggc: int in range(2):
+					var ggc_id: String = "r%dc%dgc%dggc%d" % [r, c, gc, ggc]
+					var ggchild: HypothesisNodeData = HypothesisNodeData.new()
+					ggchild.node_id = ggc_id
+					ggchild.label = "ggc-%d-%d-%d-%d" % [r, c, gc, ggc]
+					var ok_ggc: bool = data.add_child_to_node(gc_id, ggchild)
+					assert_bool(ok_ggc).is_true()
+					for ev: String in ev_ids:
+						data.attach_evidence(ggc_id, ev)
+
+	# Act
+	var cd: Dictionary = data.build_chain_data()
+
+	# Assert — node count: 3 + 6 + 12 + 24 = 45
+	assert_int((cd["nodes"] as Array).size()).is_equal(45)
+	# Total evidence: 45 nodes × 5 = 225
+	assert_int(cd["total_evidence_count"]).is_equal(225)
+	# Max depth reached: 3 (MAX_TREE_DEPTH)
+	assert_int(cd["max_depth_reached"]).is_equal(3)
+
+	# JSON round-trip: stringify → parse_string must succeed without data loss.
+	# Note: Godot's JSON.parse_string returns all numbers as float (Godot JSON
+	# round-trips ints as floats). We therefore verify structural integrity —
+	# that the parse succeeds and the top-level keys survive — rather than
+	# asserting byte-identical re-stringified output.
+	var json_str: String = JSON.stringify(cd, "", true)
+	assert_bool(json_str.is_empty()).is_false()
+	var parsed: Variant = JSON.parse_string(json_str)
+	assert_bool(parsed != null).is_true()
+	var parsed_dict: Dictionary = parsed as Dictionary
+	# Top-level keys must survive the round-trip
+	assert_bool(parsed_dict.has("schema_version")).is_true()
+	assert_bool(parsed_dict.has("nodes")).is_true()
+	assert_bool(parsed_dict.has("edges")).is_true()
+	assert_bool(parsed_dict.has("total_evidence_count")).is_true()
+	assert_bool(parsed_dict.has("max_depth_reached")).is_true()
+	# Key presence only (no value comparison — purely structural, zero time-sensitivity)
+	assert_bool(parsed_dict.has("submission_timestamp_unix")).is_true()
+	# Node count must survive (JSON.parse_string converts int → float, so cast)
+	assert_int((parsed_dict["nodes"] as Array).size()).is_equal(45)
+	# total_evidence_count must survive (cast from float)
+	assert_int(int(parsed_dict["total_evidence_count"])).is_equal(225)
+
+
+# ─── EC-4 — Depth-4 rejected ─────────────────────────────────────────────────
+
+func test_ec_4_add_child_to_depth3_node_rejected_emits_max_depth() -> void:
+	# Arrange — build chain to depth 3 (maximum allowed)
+	var data: WorkspaceData = WorkspaceData.new()
+	var a: HypothesisNodeData = HypothesisNodeData.new()
+	a.node_id = "A"
+	data.add_first_root_node(a)       # depth 0
+	var b: HypothesisNodeData = HypothesisNodeData.new()
+	b.node_id = "B"
+	data.add_child_to_node("A", b)    # depth 1
+	var c: HypothesisNodeData = HypothesisNodeData.new()
+	c.node_id = "C"
+	data.add_child_to_node("B", c)    # depth 2
+	var d: HypothesisNodeData = HypothesisNodeData.new()
+	d.node_id = "D"
+	data.add_child_to_node("C", d)    # depth 3 — should succeed
+
+	# Connect signal accumulator BEFORE the act
+	var violation_captures: Array = []
+	var cb: Callable = func(reason: String) -> void: violation_captures.append(reason)
+	data.tree_invariant_violation.connect(cb)
+
+	# Act — attempt depth 4: parent D is at depth 3
+	var e: HypothesisNodeData = HypothesisNodeData.new()
+	e.node_id = "E"
+	var result: bool = data.add_child_to_node("D", e)
+
+	# Assert — rejected; "max_depth" emitted; E not in nodes; cross-link AC-12
+	data.tree_invariant_violation.disconnect(cb)
+	assert_bool(result).is_false()
+	assert_int(violation_captures.size()).is_equal(1)
+	assert_str(violation_captures[0]).is_equal("max_depth")
+	assert_int(data.nodes.size()).is_equal(4)  # A, B, C, D — E not added
+
+
+# ─── EC-5 — Cycle rejected ───────────────────────────────────────────────────
+
+func test_ec_5_reparent_ancestor_onto_descendant_rejected_emits_cycle() -> void:
+	# Arrange — build A→B (B is child of A), then reparent A to be a child of B (cycle)
+	var data: WorkspaceData = WorkspaceData.new()
+	var a: HypothesisNodeData = HypothesisNodeData.new()
+	a.node_id = "A"
+	data.add_first_root_node(a)       # A is root, depth 0
+	var b: HypothesisNodeData = HypothesisNodeData.new()
+	b.node_id = "B"
+	data.add_child_to_node("A", b)    # B is child of A, depth 1
+
+	# Connect signal accumulator BEFORE the act
+	var violation_captures: Array = []
+	var cb: Callable = func(reason: String) -> void: violation_captures.append(reason)
+	data.tree_invariant_violation.connect(cb)
+
+	# Act — reparent("A", "B"): make A a child of its own descendant B → cycle
+	var result: bool = data.reparent("A", "B")
+
+	# Assert — rejected; "cycle" emitted; cross-link AC-13
+	data.tree_invariant_violation.disconnect(cb)
+	assert_bool(result).is_false()
+	assert_int(violation_captures.size()).is_equal(1)
+	assert_str(violation_captures[0]).is_equal("cycle")
+	# Tree state must be unchanged
+	assert_str(a.parent_id).is_equal("")   # A is still a root
+	assert_str(b.parent_id).is_equal("A")  # B still under A
+	assert_int(a.depth).is_equal(0)
+	assert_int(b.depth).is_equal(1)
+
+
+# ─── EC-6 — DEDUP (skip-stub) ────────────────────────────────────────────────
+
+func test_ec_6_evidence_dedup_on_drop(_do_skip := true, _skip_reason := "deferred: drag-drop pipeline (story 004) not implemented") -> void:
+	# Blocking dependency: drag-drop pipeline + LibraryService dedup (story 004).
+	# attach_evidence does NOT deduplicate at this layer (duplicates are appended).
+	# Dedup logic lives in story 004's DragDrop controller.
+	pass
+
+
+# ─── EC-7 — Drop non-existent library_id + announce (skip-stub) ──────────────
+
+func test_ec_7_drop_nonexistent_library_id_announce(_do_skip := true, _skip_reason := "deferred: LibraryService.validate + UIService.announce_text not implemented") -> void:
+	# Blocking dependency: LibraryService (validates library_id exists) +
+	# UIService.announce_text (accessibility announcement on invalid drop).
+	pass
+
+
+# ─── EC-8 — Drop on non-ACTIVE state guard (skip-stub) ───────────────────────
+
+func test_ec_8_drop_on_non_active_state_guard(_do_skip := true, _skip_reason := "deferred: drag-drop pipeline (story 004) not implemented") -> void:
+	# Blocking dependency: drag-drop state guard is in story 004 DragDrop controller.
+	pass
+
+
+# ─── EC-9 — Window resize mid-drag (skip-stub) ───────────────────────────────
+
+func test_ec_9_window_resize_mid_drag(_do_skip := true, _skip_reason := "deferred: drag-drop UI (story 004) not implemented") -> void:
+	# Blocking dependency: drag-drop UI layer (story 004).
+	pass
+
+
+# ─── EC-10 — State transition during pending citation (skip-stub) ─────────────
+
+func test_ec_10_state_transition_during_pending_citation(_do_skip := true, _skip_reason := "deferred: pending_citation flow (story 004) not implemented") -> void:
+	# Blocking dependency: pending_citation two-step KB/gamepad flow (story 004).
+	pass
+
+
+# ─── EC-11 — Corrupted active_case.tres → backup recovery (skip-stub) ────────
+
+func test_ec_11_corrupted_save_backup_recovery(_do_skip := true, _skip_reason := "deferred: SaveLoadService (ADR-0011) not implemented") -> void:
+	# Blocking dependency: SaveLoadService + crash-recovery backup logic (story 008).
+	pass
+
+
+# ─── EC-12 — Memo at exactly 500 codepoints: no truncation ───────────────────
+
+func test_ec_12_memo_at_exactly_500_ascii_codepoints_no_truncation() -> void:
+	# Arrange — root node; memo of exactly 500 ASCII chars (500 codepoints)
+	var data: WorkspaceData = WorkspaceData.new()
+	var root: HypothesisNodeData = HypothesisNodeData.new()
+	root.node_id = "root-A"
+	data.add_first_root_node(root)
+	var memo_500: String = "X".repeat(500)
+	assert_int(memo_500.length()).is_equal(500)  # fixture sanity
+
+	# Connect accumulator BEFORE act
+	var violation_captures: Array = []
+	var cb: Callable = func(reason: String) -> void: violation_captures.append(reason)
+	data.tree_invariant_violation.connect(cb)
+
+	# Act
+	data.update_node_memo("root-A", memo_500)
+
+	# Assert — memo set to the full 500 chars; NO memo_truncated signal
+	data.tree_invariant_violation.disconnect(cb)
+	assert_int(data._find_node("root-A").memo.length()).is_equal(500)
+	assert_int(violation_captures.size()).is_equal(0)
+
+
+func test_ec_12_memo_at_exactly_500_hangul_codepoints_no_truncation() -> void:
+	# Korean Hangul (가-힣) is 1 codepoint per char in GDScript String.length().
+	# Using ASCII for the cap test is sufficient; this variant confirms Korean
+	# codepoint counting works identically. Use plain Hangul (가 = U+AC00) —
+	# no CJK Compatibility Ideograph hazard here (test-standards.md).
+	var data: WorkspaceData = WorkspaceData.new()
+	var root: HypothesisNodeData = HypothesisNodeData.new()
+	root.node_id = "root-K"
+	data.add_first_root_node(root)
+	var korean_500: String = ""
+	for _i: int in range(500):
+		korean_500 += "가"
+	assert_int(korean_500.length()).is_equal(500)  # fixture sanity
+
+	var violation_captures: Array = []
+	var cb: Callable = func(reason: String) -> void: violation_captures.append(reason)
+	data.tree_invariant_violation.connect(cb)
+
+	# Act
+	data.update_node_memo("root-K", korean_500)
+
+	# Assert — 500 Korean codepoints: no truncation, no signal
+	data.tree_invariant_violation.disconnect(cb)
+	assert_int(data._find_node("root-K").memo.length()).is_equal(500)
+	assert_int(violation_captures.size()).is_equal(0)
+
+
+# ─── EC-13 — Memo 501 codepoints → truncated + signal ────────────────────────
+
+func test_ec_13_memo_at_501_codepoints_truncated_to_500_emits_signal() -> void:
+	# Arrange — 501 ASCII chars = 501 codepoints → must truncate to 500
+	# Note: announce (UIService.announce_text) is out of scope — test only truncation + signal
+	var data: WorkspaceData = WorkspaceData.new()
+	var root: HypothesisNodeData = HypothesisNodeData.new()
+	root.node_id = "root-A"
+	data.add_first_root_node(root)
+	var memo_501: String = "Y".repeat(501)
+
+	# Connect accumulator BEFORE act
+	var violation_captures: Array = []
+	var cb: Callable = func(reason: String) -> void: violation_captures.append(reason)
+	data.tree_invariant_violation.connect(cb)
+
+	# Act
+	data.update_node_memo("root-A", memo_501)
+
+	# Assert — truncated to 500; "memo_truncated" emitted exactly once
+	data.tree_invariant_violation.disconnect(cb)
+	assert_int(data._find_node("root-A").memo.length()).is_equal(500)
+	assert_int(violation_captures.size()).is_equal(1)
+	assert_str(violation_captures[0]).is_equal("memo_truncated")
+
+
+# ─── EC-14 — Korean IME composition at cap boundary (skip-stub) ──────────────
+
+func test_ec_14_korean_ime_composition_at_cap_boundary(_do_skip := true, _skip_reason := "deferred: VR-D7 Korean IME composition event handling not implemented") -> void:
+	# Blocking dependency: IME composition events (VR-D7 requirement).
+	pass
+
+
+# ─── EC-15 — Memo focus loss mid-IME (skip-stub) ─────────────────────────────
+
+func test_ec_15_memo_focus_loss_mid_ime(_do_skip := true, _skip_reason := "deferred: UI/IME focus-loss commit behavior not implemented") -> void:
+	# Blocking dependency: UI/IME focus handling (memo input UI node).
+	pass
+
+
+# ─── EC-16 — Pillar 1: memo_body field injected into chain_data ───────────────
+
+func test_ec_16_pillar1_memo_body_field_injection_rejected() -> void:
+	# Arrange — manually construct a poisoned chain_data with memo_text
+	# plus all 7 valid fields (making an 8-field node dict)
+	var data: WorkspaceData = _make_data()
+	var rejection_captures: Array = []
+	var cb: Callable = func(reason: String) -> void: rejection_captures.append(reason)
+	data.submission_rejected.connect(cb)
+
+	var poisoned_cd: Dictionary = {
+		"schema_version": 1,
+		"nodes": [
+			{
+				"node_id": "root-A",
+				"label": "test label",
+				"parent_id": "",
+				"evidence": [],
+				"depth": 0,
+				"child_count": 0,
+				"evidence_count": 0,
+				"memo_text": "INJECTED Pillar-1 violation",
+			}
+		],
+		"edges": [],
+		"total_evidence_count": 0,
+		"max_depth_reached": 0,
+		"submission_timestamp_unix": 1747500000,
+	}
+
+	# Act
+	var result: bool = data.validate_chain_data(poisoned_cd)
+
+	# Assert — cross-link AC-10/AC-52
+	data.submission_rejected.disconnect(cb)
+	assert_bool(result).is_false()
+	assert_int(rejection_captures.size()).is_equal(1)
+	assert_str(rejection_captures[0]).is_equal("schema_violation")
+
+
+# ─── EC-17 — Pillar 1: settings key injected into chain_data ─────────────────
+
+func test_ec_17_pillar1_settings_key_injection_rejected() -> void:
+	# Arrange — settings keys are not in ALLOWED_NODE_FIELDS; they must be caught
+	var data: WorkspaceData = _make_data()
+	var rejection_captures: Array = []
+	var cb: Callable = func(reason: String) -> void: rejection_captures.append(reason)
+	data.submission_rejected.connect(cb)
+
+	var poisoned_cd: Dictionary = {
+		"schema_version": 1,
+		"nodes": [
+			{
+				"node_id": "root-A",
+				"label": "test label",
+				"parent_id": "",
+				"evidence": [],
+				"depth": 0,
+				"child_count": 0,
+				"evidence_count": 0,
+				"display.text_scale": 1.0,
+			}
+		],
+		"edges": [],
+		"total_evidence_count": 0,
+		"max_depth_reached": 0,
+		"submission_timestamp_unix": 1747500000,
+	}
+
+	# Act
+	var result: bool = data.validate_chain_data(poisoned_cd)
+
+	# Assert
+	data.submission_rejected.disconnect(cb)
+	assert_bool(result).is_false()
+	assert_int(rejection_captures.size()).is_equal(1)
+	assert_str(rejection_captures[0]).is_equal("schema_violation")
+
+
+# ─── EC-18 — WorkspaceData reference after case unload (skip-stub) ────────────
+
+func test_ec_18_workspace_data_reference_after_case_unload(_do_skip := true, _skip_reason := "deferred: Case Browser unload lifecycle not implemented") -> void:
+	# Blocking dependency: Case Browser scene management + WorkspaceData lifecycle
+	# boundary logging (Case Browser epic).
+	pass
+
+
+# ─── EC-19 — Drag while Browser scene swapping (skip-stub) ───────────────────
+
+func test_ec_19_drag_during_browser_scene_swap(_do_skip := true, _skip_reason := "deferred: Case Browser scene transition during drag-drop not implemented") -> void:
+	# Blocking dependency: Case Browser scene transitions (Case Browser epic).
+	pass
+
+
+# ─── EC-20 — Auto-resubmit schema_version mismatch → CriticalBanner (skip-stub)
+
+func test_ec_20_auto_resubmit_schema_version_mismatch(_do_skip := true, _skip_reason := "deferred: SaveLoadService (ADR-0011) + UIService.announce_text (story 008) not implemented") -> void:
+	# Blocking dependency: SaveLoadService schema_version migration check +
+	# UIService.announce_text CriticalBanner (story 008).
+	pass
+
+
+# ─── EC-21 — Camera2D pan clamp (skip-stub) ──────────────────────────────────
+
+func test_ec_21_camera2d_pan_clamp(_do_skip := true, _skip_reason := "deferred: UI camera pan/clamp not implemented") -> void:
+	# Blocking dependency: Camera2D pan clamp implementation (UI epic).
+	pass
+
+
+# ─── EC-22 — Gamepad two-step with mid-process transition (skip-stub) ─────────
+
+func test_ec_22_gamepad_two_step_mid_process_transition(_do_skip := true, _skip_reason := "deferred: gamepad two-step citation attach (story 004) not implemented") -> void:
+	# Blocking dependency: KB/gamepad two-step pending_citation flow (story 004).
+	pass
+
+
+# ─── EC-23 — Focus loss off-window → restore (skip-stub) ─────────────────────
+
+func test_ec_23_focus_loss_off_window_restore(_do_skip := true, _skip_reason := "deferred: UI focus restoration on window re-focus not implemented") -> void:
+	# Blocking dependency: UI focus management (UI epic).
+	pass
+
+
+# ─── EC-24 — Simultaneous SettingsService changes race (skip-stub) ────────────
+
+func test_ec_24_simultaneous_settings_service_race(_do_skip := true, _skip_reason := "deferred: SettingsService not implemented") -> void:
+	# Blocking dependency: SettingsService (not yet implemented).
+	pass
+
+
+# ─── AC-52 — Forbidden-field fuzz: 5 ephemeral names ────────────────────────
+
+func test_ac_52_forbidden_ephemeral_field_fuzz_all_5_rejected() -> void:
+	# AC-52: each of the 5 forbidden ephemeral field names must individually cause
+	# validate_chain_data to return false and emit submission_rejected("schema_violation").
+	# Tested in isolation so a failure points to the exact field name.
+	var forbidden_fields: Array[String] = [
+		"memo_text",
+		"chain_data_internal",
+		"__debug_payload",
+		"evaluator_hint",
+		"cached_score",
+	]
+	for forbidden_field: String in forbidden_fields:
+		var data: WorkspaceData = _make_data()
+		var rejection_captures: Array = []
+		var cb: Callable = func(reason: String) -> void: rejection_captures.append(reason)
+		data.submission_rejected.connect(cb)
+
+		# Build a node dict with all 7 valid fields plus the forbidden field
+		var poisoned_node: Dictionary = {
+			"node_id": "root-X",
+			"label": "x",
+			"parent_id": "",
+			"evidence": [],
+			"depth": 0,
+			"child_count": 0,
+			"evidence_count": 0,
+		}
+		poisoned_node[forbidden_field] = "INJECTED"
+		var cd: Dictionary = {
+			"schema_version": 1,
+			"nodes": [poisoned_node],
+			"edges": [],
+			"total_evidence_count": 0,
+			"max_depth_reached": 0,
+			"submission_timestamp_unix": 1747500000,
+		}
+
+		# Act
+		var result: bool = data.validate_chain_data(cd)
+
+		# Assert
+		data.submission_rejected.disconnect(cb)
+		assert_bool(result).is_false()
+		assert_int(rejection_captures.size()).is_equal(1)
+		assert_str(rejection_captures[0]).is_equal("schema_violation")
+
+
+# ─── AC-52b — Settings-inclusion fuzz: 5 settings keys ──────────────────────
+
+func test_ac_52b_settings_key_fuzz_all_5_rejected() -> void:
+	# AC-52b: settings keys are not in ALLOWED_NODE_FIELDS and must ALL be rejected.
+	# These represent Pillar 1 data-isolation: settings state must never enter chain_data.
+	var settings_keys: Array[String] = [
+		"display.text_scale",
+		"display.reduced_motion",
+		"display.high_contrast",
+		"audio.master_volume",
+		"input.gamepad_stick_deadzone",
+	]
+	for settings_key: String in settings_keys:
+		var data: WorkspaceData = _make_data()
+		var rejection_captures: Array = []
+		var cb: Callable = func(reason: String) -> void: rejection_captures.append(reason)
+		data.submission_rejected.connect(cb)
+
+		var poisoned_node: Dictionary = {
+			"node_id": "root-S",
+			"label": "s",
+			"parent_id": "",
+			"evidence": [],
+			"depth": 0,
+			"child_count": 0,
+			"evidence_count": 0,
+		}
+		poisoned_node[settings_key] = "INJECTED_SETTINGS"
+		var cd: Dictionary = {
+			"schema_version": 1,
+			"nodes": [poisoned_node],
+			"edges": [],
+			"total_evidence_count": 0,
+			"max_depth_reached": 0,
+			"submission_timestamp_unix": 1747500000,
+		}
+
+		# Act
+		var result: bool = data.validate_chain_data(cd)
+
+		# Assert
+		data.submission_rejected.disconnect(cb)
+		assert_bool(result).is_false()
+		assert_int(rejection_captures.size()).is_equal(1)
+		assert_str(rejection_captures[0]).is_equal("schema_violation")

--- a/tests/unit/workspace/freeze_contract_test.gd
+++ b/tests/unit/workspace/freeze_contract_test.gd
@@ -1,0 +1,329 @@
+## freeze_contract_test.gd — WorkspaceData.submit() freeze contract unit tests.
+##
+## Covers story-007 Acceptance Criteria (data-layer scope):
+##   AC-24  chain_data_snapshot immutable post-freeze: the snapshot is an
+##          independent copy. Mutating nodes (or any HypothesisNodeData) after
+##          freeze does NOT affect chain_data_snapshot.
+##          Verified via:
+##            (3) mutation blocking — post-freeze tree mutations are AC-19 rejected,
+##                AND direct HypothesisNodeData field mutation does not affect snapshot.
+##            (4) instance distinctness — snapshot's nested evidence arrays are
+##                independent copies; snapshot is not the same Dictionary instance
+##                as a subsequent build_chain_data() call.
+##          NOTE on AC-24 protocol step (1) JSON.stringify deep-equality vs fresh rebuild:
+##            build_chain_data() embeds submission_timestamp_unix = Time.get_unix_time_from_system().
+##            Two calls may produce different timestamps, making whole-dict JSON equality
+##            non-deterministic. This test file therefore verifies independence via mutation
+##            (steps 3 & 4) rather than whole-dict equality. AC-27b (byte-equality round-trip
+##            of the SAME snapshot) is covered in freeze_recovery_test.gd.
+##   AC-26  workspace_state_changed(ACTIVE, FROZEN) emits EXACTLY ONCE on submit().
+##          Verified with a connected counter + captured args.
+##
+## ADR: docs/architecture/adr-0007-amend-1-chain-data-primitive-only.md
+##      docs/architecture/adr-0008-workspace-layout.md §1
+##
+## Signal assertions use the project pattern for Resource signals (synchronous emit):
+##   Manual connect + Array accumulator BEFORE the act — avoids gdunit4 v5.x polling-window miss.
+##   IMPORTANT: use Array (reference type) as the accumulator, not a plain int counter.
+##   GDScript lambda captures are by VALUE for primitives (int, float, bool) — a lambda
+##   that does `count += 1` increments a captured copy, not the outer variable.
+##   Arrays are reference types and ARE shared with the outer scope via the lambda.
+##   Pattern matches workspace_state_machine_test.gd line 188 (captures: Array[Array]).
+##   Ref: tests/unit/library/library_service_autoload_test.gd line 159.
+##   Ref: tests/unit/workspace/chain_data_test.gd header note.
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/unit/workspace/freeze_contract_test.gd
+extends GdUnitTestSuite
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+## Returns a fresh WorkspaceData in INACTIVE state.
+func _make_data() -> WorkspaceData:
+	return WorkspaceData.new()
+
+
+## Returns a HypothesisNodeData with the given fields pre-set.
+## depth must be set by the caller to match the intended tree level.
+func _make_node(
+	id: String,
+	parent: String = "",
+	depth: int = 0,
+	evidence: Array[String] = []
+) -> HypothesisNodeData:
+	var n := HypothesisNodeData.new()
+	n.node_id = id
+	n.label = "label-%s" % id
+	n.parent_id = parent
+	n.depth = depth
+	n.evidence = evidence
+	return n
+
+
+## Drives WorkspaceData to ACTIVE state with the given nodes already appended.
+## Mirrors the helper in chain_data_test.gd — independent copy, no shared state.
+func _data_with_nodes(node_list: Array) -> WorkspaceData:
+	var data: WorkspaceData = _make_data()
+	for n: HypothesisNodeData in node_list:
+		data.nodes.append(n)
+	data._transition_to_active()
+	return data
+
+
+# ─── AC-26 — workspace_state_changed emits EXACTLY ONCE on submit() ──────────
+
+func test_submit_emits_workspace_state_changed_exactly_once() -> void:
+	# Arrange — small tree in ACTIVE state; connect capture BEFORE act
+	var root: HypothesisNodeData = _make_node("root-A")
+	var data: WorkspaceData = _data_with_nodes([root])
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.ACTIVE)
+
+	# NOTE: use Array (reference type) for the counter — int is a value type and
+	# GDScript lambda captures are by value for primitives. captured.size() serves
+	# as the emit count. Pattern matches workspace_state_machine_test.gd line 188.
+	var captured: Array = []
+	var cb: Callable = func(old_s: int, new_s: int) -> void:
+		captured.append([old_s, new_s])
+	data.workspace_state_changed.connect(cb)
+
+	# Act
+	var result: bool = data.submit()
+
+	# Assert
+	data.workspace_state_changed.disconnect(cb)
+	assert_bool(result).is_true()
+	assert_int(captured.size()).is_equal(1)
+	assert_int(captured[0][0]).is_equal(WorkspaceData.WorkspaceState.ACTIVE)
+	assert_int(captured[0][1]).is_equal(WorkspaceData.WorkspaceState.FROZEN)
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.FROZEN)
+
+
+func test_submit_from_non_active_state_does_not_emit() -> void:
+	# Arrange — fresh INACTIVE data; connect capture BEFORE act
+	var data: WorkspaceData = _make_data()
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.INACTIVE)
+
+	var captured: Array = []
+	var cb: Callable = func(_old_s: int, _new_s: int) -> void:
+		captured.append(true)
+	data.workspace_state_changed.connect(cb)
+
+	# Act — submit() on INACTIVE must be rejected
+	var result: bool = data.submit()
+
+	# Assert — no emit, no state change, returns false
+	data.workspace_state_changed.disconnect(cb)
+	assert_bool(result).is_false()
+	assert_int(captured.size()).is_equal(0)
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.INACTIVE)
+	# Snapshot must never be populated on the reject path (assigned only after validation passes).
+	assert_bool(data.chain_data_snapshot.is_empty()).is_true()
+
+
+func test_submit_from_frozen_state_does_not_emit() -> void:
+	# Arrange — legitimately reach FROZEN, then attempt second submit
+	var root: HypothesisNodeData = _make_node("root-A")
+	var data: WorkspaceData = _data_with_nodes([root])
+	var first_result: bool = data.submit()
+	assert_bool(first_result).is_true()
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.FROZEN)
+	# Capture the valid snapshot produced by the first freeze (canonical JSON).
+	var snapshot_json_before: String = JSON.stringify(data.chain_data_snapshot, "", true)
+
+	# Connect AFTER first freeze (only monitors second attempt)
+	var captured: Array = []
+	var cb: Callable = func(_old_s: int, _new_s: int) -> void:
+		captured.append(true)
+	data.workspace_state_changed.connect(cb)
+
+	# Act — second submit from FROZEN must be rejected
+	var result: bool = data.submit()
+
+	# Assert
+	data.workspace_state_changed.disconnect(cb)
+	assert_bool(result).is_false()
+	assert_int(captured.size()).is_equal(0)
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.FROZEN)
+	# The first freeze's snapshot must survive the rejected second submit unchanged
+	# (the state guard returns before reaching the snapshot assignment).
+	assert_str(JSON.stringify(data.chain_data_snapshot, "", true)).is_equal(snapshot_json_before)
+
+
+# ─── AC-24 — chain_data_snapshot independence ────────────────────────────────
+
+func test_chain_data_snapshot_populated_at_freeze() -> void:
+	# Arrange — small tree with evidence
+	var root: HypothesisNodeData = _make_node("root-A", "", 0, ["ev-1", "ev-2"])
+	var data: WorkspaceData = _data_with_nodes([root])
+
+	# Act
+	var result: bool = data.submit()
+
+	# Assert — snapshot is non-empty and has schema_version=1
+	assert_bool(result).is_true()
+	assert_bool(data.chain_data_snapshot.is_empty()).is_false()
+	assert_int(data.chain_data_snapshot.get("schema_version", -1)).is_equal(1)
+	assert_bool(data.chain_data_snapshot.has("nodes")).is_true()
+
+
+func test_chain_data_snapshot_is_distinct_instance() -> void:
+	# Arrange — ACTIVE tree
+	var root: HypothesisNodeData = _make_node("root-A", "", 0, ["ev-1"])
+	var data: WorkspaceData = _data_with_nodes([root])
+
+	# Act
+	data.submit()
+	# Build a fresh chain_data after freeze (build_chain_data works from all non-INACTIVE states)
+	var rebuilt: Dictionary = data.build_chain_data()
+
+	# AC-24 step 1 (deterministic structural deep-equality vs a fresh rebuild).
+	# submission_timestamp_unix is stripped from BOTH sides first: it is stamped from
+	# Time.get_unix_time_from_system() per build, so two builds straddling a 1-second
+	# boundary would differ — comparing it is a time-dependent assertion, forbidden by
+	# test-standards.md. Stripping it leaves the structural content, which is byte-stable.
+	var snap_stripped: Dictionary = data.chain_data_snapshot.duplicate(true)
+	snap_stripped.erase("submission_timestamp_unix")
+	var rebuilt_stripped: Dictionary = rebuilt.duplicate(true)
+	rebuilt_stripped.erase("submission_timestamp_unix")
+	assert_str(JSON.stringify(snap_stripped, "", true)).is_equal(
+		JSON.stringify(rebuilt_stripped, "", true)
+	)
+	# AC-24 step 4 (instance distinctness): mutating the rebuilt dict's nodes array does
+	# not affect the snapshot — they are independent Dictionary allocations.
+	var snapshot_nodes_size_before: int = (data.chain_data_snapshot["nodes"] as Array).size()
+	(rebuilt["nodes"] as Array).append({"injected": true})
+	var snapshot_nodes_size_after: int = (data.chain_data_snapshot["nodes"] as Array).size()
+	assert_int(snapshot_nodes_size_after).is_equal(snapshot_nodes_size_before)
+
+
+func test_chain_data_snapshot_independent_of_post_freeze_node_mutation() -> void:
+	# Arrange — tree with a root node whose label we will mutate after freeze
+	var root: HypothesisNodeData = _make_node("root-A")
+	root.label = "original-label"
+	var data: WorkspaceData = _data_with_nodes([root])
+
+	# Act — freeze; capture snapshot label
+	data.submit()
+	var snapshot_label_before: String = ""
+	for nd: Dictionary in data.chain_data_snapshot["nodes"]:
+		if nd["node_id"] == "root-A":
+			snapshot_label_before = nd["label"]
+			break
+	assert_str(snapshot_label_before).is_equal("original-label")
+
+	# Attempt mutation via WorkspaceData API (AC-19 guard will reject this; that is expected)
+	data.update_node_label("root-A", "mutated-via-api")
+	# ALSO directly mutate the HypothesisNodeData Resource field (bypasses AC-19 guard —
+	# HypothesisNodeData fields are plain @export vars with no protection at the Resource level)
+	data.nodes[0].label = "mutated-directly"
+
+	# Assert — snapshot node label is unchanged by either mutation path
+	var snapshot_label_after: String = ""
+	for nd: Dictionary in data.chain_data_snapshot["nodes"]:
+		if nd["node_id"] == "root-A":
+			snapshot_label_after = nd["label"]
+			break
+	assert_str(snapshot_label_after).is_equal("original-label")
+	# Confirm the live node was actually mutated (so we know we're testing the right thing)
+	assert_str(data.nodes[0].label).is_equal("mutated-directly")
+
+
+func test_chain_data_snapshot_evidence_arrays_are_independent_copies() -> void:
+	# Arrange — node with 2 evidence entries
+	var root: HypothesisNodeData = _make_node("root-A", "", 0, ["ev-1", "ev-2"])
+	var data: WorkspaceData = _data_with_nodes([root])
+
+	# Act
+	data.submit()
+	var snapshot_evidence: Array = []
+	for nd: Dictionary in data.chain_data_snapshot["nodes"]:
+		if nd["node_id"] == "root-A":
+			snapshot_evidence = nd["evidence"]
+			break
+	var snapshot_evidence_size_before: int = snapshot_evidence.size()
+
+	# Directly mutate the live HypothesisNodeData evidence array
+	data.nodes[0].evidence.append("ev-injected-post-freeze")
+
+	# Assert — snapshot evidence array is unaffected (it is a .duplicate() per build_chain_data)
+	assert_int(snapshot_evidence.size()).is_equal(snapshot_evidence_size_before)
+	assert_bool(snapshot_evidence.has("ev-injected-post-freeze")).is_false()
+
+
+# ─── Validation-blocks-freeze contract ───────────────────────────────────────
+
+func test_submit_valid_tree_passes_validation_and_freezes() -> void:
+	# NOTE: build_chain_data() only ever produces allow-listed fields (it builds from
+	# ALLOWED_NODE_FIELDS explicitly). Therefore a schema violation cannot be injected
+	# through the normal submit() path — the validate_chain_data() call inside submit()
+	# will always pass for a valid tree. Schema violation coverage is in chain_data_test.gd
+	# (AC-10, AC-52) which tests validate_chain_data() directly with poisoned dicts.
+	# This test asserts the positive-path contract: a valid tree freezes successfully.
+
+	# Arrange — tree with root + child + evidence
+	var root: HypothesisNodeData = _make_node("root-A", "", 0, ["ev-1"])
+	var child: HypothesisNodeData = _make_node("child-A1", "root-A", 1, ["ev-2", "ev-3"])
+	var data: WorkspaceData = _data_with_nodes([root, child])
+
+	# Act
+	var result: bool = data.submit()
+
+	# Assert — submit succeeds; state is FROZEN; snapshot is populated
+	assert_bool(result).is_true()
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.FROZEN)
+	assert_bool(data.chain_data_snapshot.is_empty()).is_false()
+	assert_int(data.chain_data_snapshot.get("schema_version", -1)).is_equal(1)
+	assert_int((data.chain_data_snapshot["nodes"] as Array).size()).is_equal(2)
+
+
+# ─── State-guard branch coverage ──────────────────────────────────────────────
+
+func test_submit_from_read_only_state_does_not_emit() -> void:
+	# Arrange — drive ACTIVE → FROZEN → READ_ONLY (the fourth state guard branch)
+	var root: HypothesisNodeData = _make_node("root-A")
+	var data: WorkspaceData = _data_with_nodes([root])
+	assert_bool(data.submit()).is_true()
+	data._transition_to_read_only()
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.READ_ONLY)
+	var snapshot_json_before: String = JSON.stringify(data.chain_data_snapshot, "", true)
+
+	# Connect AFTER reaching READ_ONLY (only monitors the rejected submit)
+	var captured: Array = []
+	var cb: Callable = func(_old_s: int, _new_s: int) -> void:
+		captured.append(true)
+	data.workspace_state_changed.connect(cb)
+
+	# Act — submit() from READ_ONLY must be rejected (guard requires ACTIVE)
+	var result: bool = data.submit()
+
+	# Assert — no emit, no state change, snapshot unchanged
+	data.workspace_state_changed.disconnect(cb)
+	assert_bool(result).is_false()
+	assert_int(captured.size()).is_equal(0)
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.READ_ONLY)
+	assert_str(JSON.stringify(data.chain_data_snapshot, "", true)).is_equal(snapshot_json_before)
+
+
+# ─── Empty-tree submission (story-007 QA edge case) ───────────────────────────
+
+func test_submit_empty_tree_freezes_with_empty_nodes() -> void:
+	# Per story-007 QA "Edge cases: submit with empty tree (empty chain_data —
+	# schema_version=1 with nodes=[])". An ACTIVE workspace with zero nodes is a valid
+	# submission: build_chain_data() yields {schema_version:1, nodes:[], ...}, which
+	# passes the allow-list validator, so submit() freezes successfully.
+
+	# Arrange — ACTIVE with zero nodes
+	var data: WorkspaceData = _make_data()
+	data._transition_to_active()
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.ACTIVE)
+
+	# Act
+	var result: bool = data.submit()
+
+	# Assert — empty tree freezes; snapshot has schema_version=1 + empty nodes array
+	assert_bool(result).is_true()
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.FROZEN)
+	assert_int(data.chain_data_snapshot.get("schema_version", -1)).is_equal(1)
+	assert_int((data.chain_data_snapshot["nodes"] as Array).size()).is_equal(0)

--- a/tests/unit/workspace/freeze_recovery_test.gd
+++ b/tests/unit/workspace/freeze_recovery_test.gd
@@ -1,0 +1,100 @@
+## freeze_recovery_test.gd — WorkspaceData crash recovery snapshot round-trip tests.
+##
+## Covers story-007 Acceptance Criteria (data-layer scope):
+##   AC-27b  Crash recovery snapshot byte-equality:
+##           save WorkspaceData (with chain_data_snapshot populated) via ResourceSaver
+##           → load via ResourceLoader → JSON.stringify of loaded chain_data_snapshot
+##           (sort_keys=true, empty-string indent) == JSON.stringify of the original
+##           snapshot.
+##
+## ADR: docs/architecture/adr-0007-amend-1-chain-data-primitive-only.md
+##      docs/architecture/adr-0008-workspace-layout.md §1 (BFS canonical ordering)
+##
+## NOTE on submission_timestamp_unix determinism:
+##   build_chain_data() stamps submission_timestamp_unix = Time.get_unix_time_from_system().
+##   For AC-27b (save→load round-trip of the SAME snapshot), the timestamp is baked
+##   into chain_data_snapshot at submit() time. ResourceSaver/ResourceLoader preserves
+##   the baked value, so JSON.stringify equality holds. This is deterministic per run.
+##   Two separate calls to build_chain_data() may differ — but AC-27b never does that.
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/unit/workspace/freeze_recovery_test.gd
+extends GdUnitTestSuite
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+## Returns a fresh WorkspaceData in INACTIVE state.
+func _make_data() -> WorkspaceData:
+	return WorkspaceData.new()
+
+
+## Returns a HypothesisNodeData with the given fields pre-set.
+## depth must be set by the caller to match the intended tree level.
+func _make_node(
+	id: String,
+	parent: String = "",
+	depth: int = 0,
+	evidence: Array[String] = []
+) -> HypothesisNodeData:
+	var n := HypothesisNodeData.new()
+	n.node_id = id
+	n.label = "label-%s" % id
+	n.parent_id = parent
+	n.depth = depth
+	n.evidence = evidence
+	return n
+
+
+## Drives WorkspaceData to ACTIVE state with the given nodes already appended.
+## Mirrors the helper in chain_data_test.gd — independent copy, no shared state.
+func _data_with_nodes(node_list: Array) -> WorkspaceData:
+	var data: WorkspaceData = _make_data()
+	for n: HypothesisNodeData in node_list:
+		data.nodes.append(n)
+	data._transition_to_active()
+	return data
+
+
+# ─── AC-27b — snapshot byte-equality after save/load round-trip ───────────────
+
+func test_auto_resubmit_snapshot_byte_equality() -> void:
+	# Arrange — build a tree with nodes at multiple depths + evidence
+	var root_a: HypothesisNodeData = _make_node("root-A", "", 0, ["ev-1", "ev-2"])
+	var root_b: HypothesisNodeData = _make_node("root-B", "", 0, ["ev-3"])
+	var child_a1: HypothesisNodeData = _make_node("child-A1", "root-A", 1, ["ev-4"])
+	var child_b1: HypothesisNodeData = _make_node("child-B1", "root-B", 1, [])
+	var data: WorkspaceData = _data_with_nodes([root_a, root_b, child_a1, child_b1])
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.ACTIVE)
+
+	# Act — submit() populates chain_data_snapshot and freezes
+	var submit_result: bool = data.submit()
+	assert_bool(submit_result).is_true()
+	assert_int(data.state).is_equal(WorkspaceData.WorkspaceState.FROZEN)
+	assert_bool(data.chain_data_snapshot.is_empty()).is_false()
+
+	# Capture the original snapshot JSON (canonical: sort_keys=true, empty indent)
+	var original_snapshot: Dictionary = data.chain_data_snapshot
+	var original_json: String = JSON.stringify(original_snapshot, "", true)
+	assert_str(original_json).is_not_empty()
+
+	# Save to a temp user:// path
+	const SAVE_PATH: String = "user://test_freeze_recovery.tres"
+	var save_err: Error = ResourceSaver.save(data, SAVE_PATH)
+	assert_int(save_err).is_equal(OK)
+
+	# Load back — use CACHE_MODE_IGNORE to force a fresh deserialization
+	var loaded: WorkspaceData = ResourceLoader.load(
+		SAVE_PATH, "", ResourceLoader.CACHE_MODE_IGNORE
+	) as WorkspaceData
+	assert_object(loaded).is_not_null()
+
+	# Assert — JSON.stringify of loaded snapshot == JSON.stringify of original snapshot
+	# Both use sort_keys=true and empty-string indent for canonical byte comparison
+	# (ADR-0008 §1; matching the story-002 convention used in chain_data builds).
+	var loaded_json: String = JSON.stringify(loaded.chain_data_snapshot, "", true)
+	assert_str(loaded_json).is_equal(original_json)
+
+	# Cleanup
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(SAVE_PATH))

--- a/tests/unit/workspace/performance_test.gd
+++ b/tests/unit/workspace/performance_test.gd
@@ -1,0 +1,70 @@
+## performance_test.gd — WorkspaceData performance gate tests.
+##
+## Covers story-012 Performance Gates:
+##   AC-49   60fps worst-case tree render (SKIP-STUB — headless Control instantiation blocked)
+##   AC-49b  Memory regression: worst-case data-only tree stays under 2 GB working-set budget
+##           (SKIP-STUB — hollow guard at 45-node data-only scale; meaningful worst-case
+##           is the rendered Control tree, which shares AC-49's headless blocker)
+##
+## SKIP-STUB rationale for AC-49b:
+##   OS.get_static_memory_usage() IS project-sanctioned (ADR-0007 §Risk 6, AC-22,
+##   TR-submission-015 N=100 averaging) — the API is NOT deprecated and is NOT the blocker.
+##   The skip is deferred because: (a) a data-only tree of 45 HypothesisNodeData Resources
+##   trivially satisfies the 2 GB budget and the assertion cannot fail at this scale, making
+##   the test a hollow regression guard; (b) the meaningful worst-case is the rendered
+##   Control tree, which shares AC-49's headless Control instantiation blocker (OQ-W10).
+##   Unblock both AC-49 and AC-49b together once OQ-W10 is ratified.
+##
+## gdunit4 v5.x skip pattern (GDScript variant):
+##   func test_xxx(_do_skip := true, _skip_reason := "...") -> void:
+##   This is the ONLY supported skip mechanism in gdunit4 GDScript.
+##   Imperative skip("reason") is the C# variant (gdUnit4Net) and is NOT supported here.
+##   Ref: technical-preferences.md → gdunit4 GDScript skip API.
+##
+## ADR: docs/architecture/adr-0008-workspace-layout.md §1
+##
+## Run:
+##   addons/gdUnit4/runtest.sh --godot_binary /opt/homebrew/bin/godot \
+##     -a tests/unit/workspace/performance_test.gd
+extends GdUnitTestSuite
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+## Returns a HypothesisNodeData with node_id set; all other fields default.
+func _make_node(id: String) -> HypothesisNodeData:
+	var n := HypothesisNodeData.new()
+	n.node_id = id
+	n.label = "label-%s" % id
+	return n
+
+
+# ─── AC-49 — 60fps worst-case tree (skip-stub) ───────────────────────────────
+
+func test_ac_49_60fps_worst_case_tree(_do_skip := true, _skip_reason := "VR pending OQ-W10 ratify — headless Control instantiation") -> void:
+	# Blocking dependency: OQ-W10 ratification of headless Control instantiation
+	# for worst-case tree render under 16.6ms budget.
+	# This test will instantiate KrCard nodes (Control subclass) and measure frame
+	# time once that infrastructure is confirmed to work headlessly.
+	pass
+
+
+# ─── AC-49b — Memory regression: worst-case data-only tree (skip-stub) ────────
+
+func test_ac_49b_memory_worst_case_data_tree_under_2gb(_do_skip := true, _skip_reason := "deferred: data-only tree is a hollow guard at 45-node scale; meaningful worst-case is the rendered Control tree, which shares AC-49's headless blocker (OQ-W10)") -> void:
+	# Intent: build the worst-case DATA tree (same shape as EC-3: 3 roots × 2-branch
+	# × depth-3 × 5 evidence per node = 45 nodes / 225 evidence strings), then assert
+	# memory usage stays under the 2 GB working-set budget (technical-preferences.md).
+	#
+	# Intended assertion (pending API verification):
+	#   var mem_before := OS.get_static_memory_usage()
+	#   <build 45-node tree>
+	#   var mem_after := OS.get_static_memory_usage()
+	#   assert_int(mem_after).is_less(2 * 1024 * 1024 * 1024)
+	#
+	# This would trivially pass for 45 HypothesisNodeData Resources, but serves as
+	# a regression guard if node counts scale unexpectedly.
+	#
+	# Unblock by: confirm the exact memory query API in docs/engine-reference/godot/
+	# for Godot 4.6, then replace the skip pattern with the verified call.
+	pass


### PR DESCRIPTION
## Summary

Implements two full architectural modules and closes a batch of data-layer stories across four epics. **18 stories** implemented + closed, **2 epics created** (one fully complete), all verified — **434 gdunit4 cases, 0 failures**.

### Submission & Evaluation (#9) — epic COMPLETE (5/5) 🎉
`EvaluationService` autoload + `PlayerSubmission`/`EvaluationResult`/`CommentTemplates` Resources. Deterministic weighted-grading core (Pillar 1): 5 subscores + clamped `final_score` + verdict (파기/파기환송/기각/각하) + 5-state `submit(PlayerSubmission)` pipeline (Validating gate via `LibraryService.validate_citations` + `CaseService.get_case`) + comment-template decision tree. GDD §4.2/§4.3 worked examples verified in tests.

### Save/Load (#3) — 8/8 implementable cores
`SaveLoadService` autoload SIXTH: atomic write (`.tmp`→rename), 6 save-data Resource classes + schema versioning, signal-triggered 250ms-debounce autosave, boot load + corruption→`.backup` recovery + `active_case_recovered`, resolution/recovery cascades + revert guard, close-request forced flush, anti-Pillar serialization guards. (Cross-service end-to-end subscriptions wire up now that EvaluationService exists.)

### UI Foundation (#2) — 3/5
UIService autoload (Theme + viewport debounce + reduced_motion + `tween_property` gateway); KrCustomControl composition pattern (KrPane/Card/Button/Banner via `NOTIFICATION_ACCESSIBILITY_UPDATE` role assignment).

### Reasoning Workspace (#6) — data-layer
story-007 freeze+submit cascade (data-layer) + story-012 tree-structural edge-case suite.

## Design decision
**TD-001 reconciled**: `EvaluationService.submit(submission: PlayerSubmission)` is canonical (the grading algorithm scores disposition + citations, neither in `chain_data`); control-manifest corrected to match ADR-0007.

## Engine gotchas found + worked around (docs/tech-debt-register.md TD-002..005)
- `ResourceSaver.save()` picks format by extension → bare `.tmp` fails `ERR_FILE_UNRECOGNIZED` (use `name.tmp.tres`)
- Godot 4.6 `Control` has no `accessibility_role` property → `DisplayServer.accessibility_update_set_role` inside `NOTIFICATION_ACCESSIBILITY_UPDATE`
- new `class_name` scripts need `godot --headless --import` before headless gdunit4 runs (CI note)

## Test evidence
`addons/gdUnit4/runtest.sh -a tests/unit -a tests/integration` → **434 cases, 0 errors, 0 failures, 17 skipped (deferred), exit 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)