### PR TITLE
fix: change subagent models from fixed to inherit (fixes #67)

### DIFF
--- a/.claude/agents/accessibility-specialist.md
+++ b/.claude/agents/accessibility-specialist.md
@@ -2,7 +2,7 @@
 name: accessibility-specialist
 description: "The Accessibility Specialist ensures the game is playable by the widest possible audience. They enforce accessibility standards, review UI for compliance, and design assistive features including remapping, text scaling, colorblind modes, and screen reader support."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 10
 ---
 You are the Accessibility Specialist for an indie game project. Your mission is to ensure every player can enjoy the game regardless of ability.

--- a/.claude/agents/ai-programmer.md
+++ b/.claude/agents/ai-programmer.md
@@ -2,7 +2,7 @@
 name: ai-programmer
 description: "The AI Programmer implements game AI systems: behavior trees, state machines, pathfinding, perception systems, decision-making, and NPC behavior. Use this agent for AI system implementation, pathfinding optimization, enemy behavior programming, or AI debugging."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 

--- a/.claude/agents/analytics-engineer.md
+++ b/.claude/agents/analytics-engineer.md
@@ -2,7 +2,7 @@
 name: analytics-engineer
 description: "The Analytics Engineer designs telemetry systems, player behavior tracking, A/B test frameworks, and data analysis pipelines. Use this agent for event tracking design, dashboard specification, A/B test design, or player behavior analysis methodology."
 tools: Read, Glob, Grep, Write, Edit, Bash, WebSearch
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 

--- a/.claude/agents/art-director.md
+++ b/.claude/agents/art-director.md
@@ -2,7 +2,7 @@
 name: art-director
 description: "The Art Director owns the visual identity of the game: style guides, art bible, asset standards, color palettes, UI/UX visual design, and the art production pipeline. Use this agent for visual consistency reviews, asset spec creation, art bible maintenance, or UI visual direction."
 tools: Read, Glob, Grep, Write, Edit, WebSearch
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 memory: project

--- a/.claude/agents/audio-director.md
+++ b/.claude/agents/audio-director.md
@@ -2,7 +2,7 @@
 name: audio-director
 description: "The Audio Director owns the sonic identity of the game: music direction, sound design philosophy, audio implementation strategy, and mix balance. Use this agent for audio direction decisions, sound palette definition, music cue planning, or audio system architecture."
 tools: Read, Glob, Grep, Write, Edit, WebSearch
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 memory: project

--- a/.claude/agents/community-manager.md
+++ b/.claude/agents/community-manager.md
@@ -2,7 +2,7 @@
 name: community-manager
 description: "The community manager owns player-facing communication: patch notes, social media posts, community updates, player feedback collection, bug report triage from players, and crisis communication. They translate between development team and player community."
 tools: Read, Glob, Grep, Write, Edit, Task
-model: haiku
+model: inherit
 maxTurns: 10
 disallowedTools: Bash
 ---

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -2,7 +2,7 @@
 name: devops-engineer
 description: "The DevOps Engineer maintains build pipelines, CI/CD configuration, version control workflow, and deployment infrastructure. Use this agent for build script maintenance, CI configuration, branching strategy, or automated testing pipeline setup."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: haiku
+model: inherit
 maxTurns: 10
 ---
 

--- a/.claude/agents/economy-designer.md
+++ b/.claude/agents/economy-designer.md
@@ -2,7 +2,7 @@
 name: economy-designer
 description: "The Economy Designer specializes in resource economies, loot systems, progression curves, and in-game market design. Use this agent for loot table design, resource sink/faucet analysis, progression curve calibration, or economic balance verification."
 tools: Read, Glob, Grep, Write, Edit
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 memory: project

--- a/.claude/agents/engine-programmer.md
+++ b/.claude/agents/engine-programmer.md
@@ -2,7 +2,7 @@
 name: engine-programmer
 description: "The Engine Programmer works on core engine systems: rendering pipeline, physics, memory management, resource loading, scene management, and core framework code. Use this agent for engine-level feature implementation, performance-critical systems, or core framework modifications."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 

--- a/.claude/agents/game-designer.md
+++ b/.claude/agents/game-designer.md
@@ -2,7 +2,7 @@
 name: game-designer
 description: "The Game Designer owns the mechanical and systems design of the game. This agent designs core loops, progression systems, combat mechanics, economy, and player-facing rules. Use this agent for any question about \"how does the game work\" at the mechanics level."
 tools: Read, Glob, Grep, Write, Edit, WebSearch
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 skills: [design-review, balance-check, brainstorm]

--- a/.claude/agents/gameplay-programmer.md
+++ b/.claude/agents/gameplay-programmer.md
@@ -2,7 +2,7 @@
 name: gameplay-programmer
 description: "The Gameplay Programmer implements game mechanics, player systems, combat, and interactive features as code. Use this agent for implementing designed mechanics, writing gameplay system code, or translating design documents into working game features."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 

--- a/.claude/agents/godot-csharp-specialist.md
+++ b/.claude/agents/godot-csharp-specialist.md
@@ -2,7 +2,7 @@
 name: godot-csharp-specialist
 description: "The Godot C# specialist owns all C# code quality in Godot 4 projects: .NET patterns, attribute-based exports, signal delegates, async patterns, type-safe node access, and C#-specific Godot idioms. They ensure clean, performant, type-safe C# that follows .NET and Godot 4 idioms correctly."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Godot C# Specialist for a Godot 4 project. You own everything related to C# code quality, patterns, and performance within the Godot engine.

--- a/.claude/agents/godot-gdextension-specialist.md
+++ b/.claude/agents/godot-gdextension-specialist.md
@@ -2,7 +2,7 @@
 name: godot-gdextension-specialist
 description: "The GDExtension specialist owns all native code integration with Godot: GDExtension API, C/C++/Rust bindings (godot-cpp, godot-rust), native performance optimization, custom node types, and the GDScript/native boundary. They ensure native code integrates cleanly with Godot's node system."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the GDExtension Specialist for a Godot 4 project. You own everything related to native code integration via the GDExtension system.

--- a/.claude/agents/godot-gdscript-specialist.md
+++ b/.claude/agents/godot-gdscript-specialist.md
@@ -2,7 +2,7 @@
 name: godot-gdscript-specialist
 description: "The GDScript specialist owns all GDScript code quality: static typing enforcement, design patterns, signal architecture, coroutine patterns, performance optimization, and GDScript-specific idioms. They ensure clean, typed, and performant GDScript across the project."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the GDScript Specialist for a Godot 4 project. You own everything related to GDScript code quality, patterns, and performance.

--- a/.claude/agents/godot-shader-specialist.md
+++ b/.claude/agents/godot-shader-specialist.md
@@ -2,7 +2,7 @@
 name: godot-shader-specialist
 description: "The Godot Shader specialist owns all Godot rendering customization: Godot shading language, visual shaders, material setup, particle shaders, post-processing, and rendering performance. They ensure visual quality within Godot's rendering pipeline."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Godot Shader Specialist for a Godot 4 project. You own everything related to shaders, materials, visual effects, and rendering customization.

--- a/.claude/agents/godot-specialist.md
+++ b/.claude/agents/godot-specialist.md
@@ -2,7 +2,7 @@
 name: godot-specialist
 description: "The Godot Engine Specialist is the authority on all Godot-specific patterns, APIs, and optimization techniques. They guide GDScript vs C# vs GDExtension decisions, ensure proper use of Godot's node/scene architecture, signals, and resources, and enforce Godot best practices."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Godot Engine Specialist for a game project built in Godot 4. You are the team's authority on all things Godot.

--- a/.claude/agents/lead-programmer.md
+++ b/.claude/agents/lead-programmer.md
@@ -2,7 +2,7 @@
 name: lead-programmer
 description: "The Lead Programmer owns code-level architecture, coding standards, code review, and the assignment of programming work to specialist programmers. Use this agent for code reviews, API design, refactoring strategy, or when determining how a design should be translated into code structure."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 skills: [code-review, architecture-decision, tech-debt]
 memory: project

--- a/.claude/agents/level-designer.md
+++ b/.claude/agents/level-designer.md
@@ -2,7 +2,7 @@
 name: level-designer
 description: "The Level Designer creates spatial designs, encounter layouts, pacing plans, and environmental storytelling guides for game levels and areas. Use this agent for level layout planning, encounter design, difficulty pacing, or spatial puzzle design."
 tools: Read, Glob, Grep, Write, Edit
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 memory: project

--- a/.claude/agents/live-ops-designer.md
+++ b/.claude/agents/live-ops-designer.md
@@ -2,7 +2,7 @@
 name: live-ops-designer
 description: "The live-ops designer owns post-launch content strategy: seasonal events, battle passes, content cadence, player retention mechanics, live service economy, and engagement analytics. They ensure the game stays fresh and players stay engaged without predatory monetization."
 tools: Read, Glob, Grep, Write, Edit, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 ---

--- a/.claude/agents/localization-lead.md
+++ b/.claude/agents/localization-lead.md
@@ -2,7 +2,7 @@
 name: localization-lead
 description: "Owns internationalization architecture, string management, locale testing, and translation pipeline. Use for i18n system design, string extraction workflows, locale-specific issues, or translation quality review."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 memory: project
 ---

--- a/.claude/agents/narrative-director.md
+++ b/.claude/agents/narrative-director.md
@@ -2,7 +2,7 @@
 name: narrative-director
 description: "The Narrative Director owns story architecture, world-building, character design, and dialogue strategy. Use this agent for story arc planning, character development, world rule definition, and narrative systems design. This agent focuses on structure and direction rather than writing individual lines."
 tools: Read, Glob, Grep, Write, Edit, WebSearch
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 memory: project

--- a/.claude/agents/network-programmer.md
+++ b/.claude/agents/network-programmer.md
@@ -2,7 +2,7 @@
 name: network-programmer
 description: "The Network Programmer implements multiplayer networking: state replication, lag compensation, matchmaking, and network protocol design. Use this agent for netcode implementation, synchronization strategy, bandwidth optimization, or multiplayer architecture."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 

--- a/.claude/agents/performance-analyst.md
+++ b/.claude/agents/performance-analyst.md
@@ -2,7 +2,7 @@
 name: performance-analyst
 description: "The Performance Analyst profiles game performance, identifies bottlenecks, recommends optimizations, and tracks performance metrics over time. Use this agent for performance profiling, memory analysis, frame time investigation, or optimization strategy."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 memory: project
 ---

--- a/.claude/agents/prototyper.md
+++ b/.claude/agents/prototyper.md
@@ -2,7 +2,7 @@
 name: prototyper
 description: "Rapid prototyping specialist for pre-production. Builds quick, throwaway implementations to validate game concepts and mechanics. Use during pre-production for concept validation, vertical slices, or mechanical experiments. Standards are intentionally relaxed for speed."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 25
 isolation: worktree
 ---

--- a/.claude/agents/qa-lead.md
+++ b/.claude/agents/qa-lead.md
@@ -2,7 +2,7 @@
 name: qa-lead
 description: "The QA Lead owns test strategy, bug triage, release quality gates, and testing process design. Use this agent for test plan creation, bug severity assessment, regression test planning, or release readiness evaluation."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 skills: [bug-report, release-checklist]
 memory: project

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -2,7 +2,7 @@
 name: qa-tester
 description: "The QA Tester writes detailed test cases, bug reports, and test checklists. Use this agent for test case generation, regression checklist creation, bug report writing, or test execution documentation."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 10
 ---
 

--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -2,7 +2,7 @@
 name: release-manager
 description: "Owns the release pipeline: certification checklists, store submissions, platform requirements, version numbering, and release-day coordination. Use for release planning, platform certification, store page preparation, or version management."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 skills: [release-checklist, changelog, patch-notes]
 ---

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -2,7 +2,7 @@
 name: security-engineer
 description: "The Security Engineer protects the game from cheating, exploits, and data breaches. They review code for vulnerabilities, design anti-cheat measures, secure save data and network communications, and ensure player data privacy compliance."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Security Engineer for an indie game project. You protect the game, its players, and their data from threats.

--- a/.claude/agents/sound-designer.md
+++ b/.claude/agents/sound-designer.md
@@ -2,7 +2,7 @@
 name: sound-designer
 description: "The Sound Designer creates detailed specifications for sound effects, documents audio events, and defines mixing parameters. Use this agent for SFX spec sheets, audio event planning, mixing documentation, or sound category definitions."
 tools: Read, Glob, Grep, Write, Edit
-model: haiku
+model: inherit
 maxTurns: 10
 disallowedTools: Bash
 ---

--- a/.claude/agents/systems-designer.md
+++ b/.claude/agents/systems-designer.md
@@ -2,7 +2,7 @@
 name: systems-designer
 description: "The Systems Designer creates detailed mechanical designs for specific game subsystems -- combat formulas, progression curves, crafting recipes, status effect interactions. Use this agent when a mechanic needs detailed rule specification, mathematical modeling, or interaction matrix design."
 tools: Read, Glob, Grep, Write, Edit
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 memory: project

--- a/.claude/agents/technical-artist.md
+++ b/.claude/agents/technical-artist.md
@@ -2,7 +2,7 @@
 name: technical-artist
 description: "The Technical Artist bridges art and engineering: shaders, VFX, rendering optimization, art pipeline tools, and performance profiling for visual systems. Use this agent for shader development, VFX system design, visual optimization, or art-to-engine pipeline issues."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 

--- a/.claude/agents/tools-programmer.md
+++ b/.claude/agents/tools-programmer.md
@@ -2,7 +2,7 @@
 name: tools-programmer
 description: "The Tools Programmer builds internal development tools: editor extensions, content authoring tools, debug utilities, and pipeline automation. Use this agent for custom tool creation, editor workflow improvements, or development pipeline automation."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 

--- a/.claude/agents/ue-blueprint-specialist.md
+++ b/.claude/agents/ue-blueprint-specialist.md
@@ -2,7 +2,7 @@
 name: ue-blueprint-specialist
 description: "The Blueprint specialist owns Blueprint architecture decisions, Blueprint/C++ boundary guidelines, Blueprint optimization, and ensures Blueprint graphs stay maintainable and performant. They prevent Blueprint spaghetti and enforce clean BP patterns."
 tools: Read, Glob, Grep, Write, Edit, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 ---

--- a/.claude/agents/ue-gas-specialist.md
+++ b/.claude/agents/ue-gas-specialist.md
@@ -2,7 +2,7 @@
 name: ue-gas-specialist
 description: "The Gameplay Ability System specialist owns all GAS implementation: abilities, gameplay effects, attribute sets, gameplay tags, ability tasks, and GAS prediction. They ensure consistent GAS architecture and prevent common GAS anti-patterns."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Gameplay Ability System (GAS) Specialist for an Unreal Engine 5 project. You own everything related to GAS architecture and implementation.

--- a/.claude/agents/ue-replication-specialist.md
+++ b/.claude/agents/ue-replication-specialist.md
@@ -2,7 +2,7 @@
 name: ue-replication-specialist
 description: "The UE Replication specialist owns all Unreal networking: property replication, RPCs, client prediction, relevancy, net serialization, and bandwidth optimization. They ensure server-authoritative architecture and responsive multiplayer feel."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Unreal Replication Specialist for an Unreal Engine 5 multiplayer project. You own everything related to Unreal's networking and replication system.

--- a/.claude/agents/ue-umg-specialist.md
+++ b/.claude/agents/ue-umg-specialist.md
@@ -2,7 +2,7 @@
 name: ue-umg-specialist
 description: "The UMG/CommonUI specialist owns all Unreal UI implementation: widget hierarchy, data binding, CommonUI input routing, widget styling, and UI optimization. They ensure UI follows Unreal best practices and performs well."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the UMG/CommonUI Specialist for an Unreal Engine 5 project. You own everything related to Unreal's UI framework.

--- a/.claude/agents/ui-programmer.md
+++ b/.claude/agents/ui-programmer.md
@@ -2,7 +2,7 @@
 name: ui-programmer
 description: "The UI Programmer implements user interface systems: menus, HUDs, inventory screens, dialogue boxes, and UI framework code. Use this agent for UI system implementation, widget development, data binding, or screen flow programming."
 tools: Read, Glob, Grep, Write, Edit, Bash
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 

--- a/.claude/agents/unity-addressables-specialist.md
+++ b/.claude/agents/unity-addressables-specialist.md
@@ -2,7 +2,7 @@
 name: unity-addressables-specialist
 description: "The Addressables specialist owns all Unity asset management: Addressable groups, asset loading/unloading, memory management, content catalogs, remote content delivery, and asset bundle optimization. They ensure fast load times and controlled memory usage."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Unity Addressables Specialist for a Unity project. You own everything related to asset loading, memory management, and content delivery.

--- a/.claude/agents/unity-dots-specialist.md
+++ b/.claude/agents/unity-dots-specialist.md
@@ -2,7 +2,7 @@
 name: unity-dots-specialist
 description: "The DOTS/ECS specialist owns all Unity Data-Oriented Technology Stack implementation: Entity Component System architecture, Jobs system, Burst compiler optimization, hybrid renderer, and DOTS-based gameplay systems. They ensure correct ECS patterns and maximum performance."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Unity DOTS/ECS Specialist for a Unity project. You own everything related to Unity's Data-Oriented Technology Stack.

--- a/.claude/agents/unity-shader-specialist.md
+++ b/.claude/agents/unity-shader-specialist.md
@@ -2,7 +2,7 @@
 name: unity-shader-specialist
 description: "The Unity Shader/VFX specialist owns all Unity rendering customization: Shader Graph, custom HLSL shaders, VFX Graph, render pipeline customization (URP/HDRP), post-processing, and visual effects optimization. They ensure visual quality within performance budgets."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Unity Shader and VFX Specialist for a Unity project. You own everything related to shaders, visual effects, and render pipeline customization.

--- a/.claude/agents/unity-specialist.md
+++ b/.claude/agents/unity-specialist.md
@@ -2,7 +2,7 @@
 name: unity-specialist
 description: "The Unity Engine Specialist is the authority on all Unity-specific patterns, APIs, and optimization techniques. They guide MonoBehaviour vs DOTS/ECS decisions, ensure proper use of Unity subsystems (Addressables, Input System, UI Toolkit, etc.), and enforce Unity best practices."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Unity Engine Specialist for a game project built in Unity. You are the team's authority on all things Unity.

--- a/.claude/agents/unity-ui-specialist.md
+++ b/.claude/agents/unity-ui-specialist.md
@@ -2,7 +2,7 @@
 name: unity-ui-specialist
 description: "The Unity UI specialist owns all Unity UI implementation: UI Toolkit (UXML/USS), UGUI (Canvas), data binding, runtime UI performance, input handling, and cross-platform UI adaptation. They ensure responsive, performant, and accessible UI."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Unity UI Specialist for a Unity project. You own everything related to Unity's UI systems — both UI Toolkit and UGUI.

--- a/.claude/agents/unreal-specialist.md
+++ b/.claude/agents/unreal-specialist.md
@@ -2,7 +2,7 @@
 name: unreal-specialist
 description: "The Unreal Engine Specialist is the authority on all Unreal-specific patterns, APIs, and optimization techniques. They guide Blueprint vs C++ decisions, ensure proper use of UE subsystems (GAS, Enhanced Input, Niagara, etc.), and enforce Unreal best practices across the codebase."
 tools: Read, Glob, Grep, Write, Edit, Bash, Task
-model: sonnet
+model: inherit
 maxTurns: 20
 ---
 You are the Unreal Engine Specialist for an indie game project built in Unreal Engine 5. You are the team's authority on all things Unreal.

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -2,7 +2,7 @@
 name: ux-designer
 description: "The UX Designer owns user experience flows, interaction design, accessibility, information architecture, and input handling design. Use this agent for user flow mapping, interaction pattern design, accessibility audits, or onboarding flow design."
 tools: Read, Glob, Grep, Write, Edit, WebSearch
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 memory: project

--- a/.claude/agents/world-builder.md
+++ b/.claude/agents/world-builder.md
@@ -2,7 +2,7 @@
 name: world-builder
 description: "The World Builder designs detailed world lore: factions, cultures, history, geography, ecology, and the rules that govern the game world. Use this agent for lore consistency checks, faction design, historical timeline creation, or world rule codification."
 tools: Read, Glob, Grep, Write, Edit
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 memory: project

--- a/.claude/agents/writer.md
+++ b/.claude/agents/writer.md
@@ -2,7 +2,7 @@
 name: writer
 description: "The Writer creates dialogue, lore entries, item descriptions, environmental text, and all player-facing written content. Use this agent for dialogue writing, lore creation, item/ability descriptions, or in-game text of any kind."
 tools: Read, Glob, Grep, Write, Edit
-model: sonnet
+model: inherit
 maxTurns: 20
 disallowedTools: Bash
 memory: project


### PR DESCRIPTION
## Problem

Closes #67

When the main session uses a large-context model (e.g., Opus with 1M context window), invoking a subagent with a fixed smaller-context model (Sonnet/Haiku) fails because the subagent cannot hold the parent session's accumulated context.

## Current state

45 of 48 agents are configured with fixed models:
- \model: sonnet\ — leads, programmers, designers, specialists
- \model: haiku\ — community-manager, devops-engineer, sound-designer

Only 3 directors use \model: opus\.

## Solution

Change all non-director agents to \model: inherit\:

- **Keep \model: opus\** for 3 directors: creative-director, technical-director, producer
  — strategic decision-making justifies the strongest model
- **Change to \model: inherit\** for all other 45 agents
  — inherits parent session's model, avoiding context window truncation

This mirrors the approach used by the Superpowers project.

## Files changed

46 files changed, 46 insertions(+), 46 deletions(-)

All changes are single-line: \model: sonnet\ → \model: inherit\ or \model: haiku\ → \model: inherit\.