### PR TITLE
Feat/sprint plan goal dependency audit

### DIFF
--- a/.claude/skills/sprint-plan/SKILL.md
+++ b/.claude/skills/sprint-plan/SKILL.md
@@ -47,9 +47,8 @@ See `.claude/docs/director-gates.md` for the full check pattern.
 
 ## Phase 1b: Sprint Goal Dependency Audit
 
-**Run this phase before generating any story list.** It prevents the Sprint 2
-failure pattern: a sprint goal that requires prerequisites that were never scoped,
-making the goal structurally unachievable from day one.
+**Run this phase before generating any story list.** It prevents the sprint goal that requires
+prerequisites that were never scoped, making the goal structurally unachievable from day one.
 
 **Step 1 — State the sprint goal explicitly.**
 If the sprint goal comes from the milestone doc, quote it. If not defined yet,
@@ -60,41 +59,45 @@ For each sprint goal category, check the corresponding prerequisites:
 
 | Goal type | Prerequisites to verify |
 |-----------|------------------------|
-| Playable game loop / vertical slice | All `.tscn` scene files in the loop path must exist |
-| Feature "works end-to-end" | Scene(s) hosting the feature must exist |
-| "Players can experience X" | UX flow for X must have a runnable scene entry point |
+| Playable game loop / vertical slice | All entry-point scene/level files in the loop path must exist |
+| Feature "works end-to-end" | Scene/level hosting the feature must exist |
+| "Players can experience X" | UX flow for X must have a runnable entry point |
 | Logic / systems only (no player-visible demo) | No scene prerequisite — skip this audit |
 
 **Step 3 — Check prerequisites exist.**
-For any "playable" or "end-to-end" goal, `Glob` for the required `.tscn` files:
+For any "playable" or "end-to-end" goal, `Glob` for the required scene/level files.
+Use the pattern matching the configured engine:
 
-```
-Glob: src/**/*.tscn
-```
+| Engine | Scene file pattern |
+|--------|--------------------|
+| Godot | `src/**/*.tscn` |
+| Unity | `Assets/**/*.unity` |
+| Unreal | `Content/**/*.umap` |
+| Unknown | Check `CLAUDE.md` → Technology Stack for engine, then use matching pattern |
 
 Compare the found files against what the sprint goal requires.
 
 **Step 4 — Surface missing prerequisites.**
 If any prerequisite is missing AND is not already in the current draft story list as a must-have:
 
-> ⚠️ **Goal prerequisite missing: `[path/to/scene.tscn]`**
-> The sprint goal "[goal]" requires this scene to exist. It is not in the codebase
+> ⚠️ **Goal prerequisite missing: `[path/to/scene-or-level-file]`**
+> The sprint goal "[goal]" requires this scene/level to exist. It is not in the codebase
 > and is not scoped as a must-have story. Without it, the sprint goal is
 > structurally unachievable.
 
 Use `AskUserQuestion`:
 - Prompt: "Missing prerequisite: [file]. How do you want to handle this?"
 - Options:
-  - `[A] Add it as a must-have story (Recommended) — scope the scene creation into this sprint`
+  - `[A] Add it as a must-have story (Recommended) — scope the scene/level creation into this sprint`
   - `[B] Downgrade the sprint goal — remove the runnable-loop requirement`
   - `[C] Accept the risk — I know the goal may not be fully demonstrable this sprint`
 
-If [A]: add a scene-creation story to the must-have list before Phase 2 begins.
+If [A]: add a scene/level-creation story to the must-have list before Phase 2 begins.
 If [B]: rephrase the sprint goal to not promise a runnable demo (e.g., "Implement logic layer for X" instead of "Playable X loop").
 If [C]: add a KNOWN RISK block to the sprint plan:
 ```markdown
 > ⚠️ **Known risk:** Sprint goal requires `[file]` which does not exist. Sprint may
-> not produce a runnable demo. Playtest sessions dependent on this scene are blocked.
+> not produce a runnable demo. Playtest sessions dependent on this scene/level are blocked.
 ```
 
 **Step 5 — Proceed to Phase 2 with prerequisites resolved.**

--- a/.claude/skills/sprint-plan/SKILL.md
+++ b/.claude/skills/sprint-plan/SKILL.md
@@ -45,6 +45,62 @@ See `.claude/docs/director-gates.md` for the full check pattern.
 
 ---
 
+## Phase 1b: Sprint Goal Dependency Audit
+
+**Run this phase before generating any story list.** It prevents the Sprint 2
+failure pattern: a sprint goal that requires prerequisites that were never scoped,
+making the goal structurally unachievable from day one.
+
+**Step 1 — State the sprint goal explicitly.**
+If the sprint goal comes from the milestone doc, quote it. If not defined yet,
+prompt the user with `AskUserQuestion` before continuing.
+
+**Step 2 — Identify what the sprint goal requires to be demonstrable.**
+For each sprint goal category, check the corresponding prerequisites:
+
+| Goal type | Prerequisites to verify |
+|-----------|------------------------|
+| Playable game loop / vertical slice | All `.tscn` scene files in the loop path must exist |
+| Feature "works end-to-end" | Scene(s) hosting the feature must exist |
+| "Players can experience X" | UX flow for X must have a runnable scene entry point |
+| Logic / systems only (no player-visible demo) | No scene prerequisite — skip this audit |
+
+**Step 3 — Check prerequisites exist.**
+For any "playable" or "end-to-end" goal, `Glob` for the required `.tscn` files:
+
+```
+Glob: src/**/*.tscn
+```
+
+Compare the found files against what the sprint goal requires.
+
+**Step 4 — Surface missing prerequisites.**
+If any prerequisite is missing AND is not already in the current draft story list as a must-have:
+
+> ⚠️ **Goal prerequisite missing: `[path/to/scene.tscn]`**
+> The sprint goal "[goal]" requires this scene to exist. It is not in the codebase
+> and is not scoped as a must-have story. Without it, the sprint goal is
+> structurally unachievable.
+
+Use `AskUserQuestion`:
+- Prompt: "Missing prerequisite: [file]. How do you want to handle this?"
+- Options:
+  - `[A] Add it as a must-have story (Recommended) — scope the scene creation into this sprint`
+  - `[B] Downgrade the sprint goal — remove the runnable-loop requirement`
+  - `[C] Accept the risk — I know the goal may not be fully demonstrable this sprint`
+
+If [A]: add a scene-creation story to the must-have list before Phase 2 begins.
+If [B]: rephrase the sprint goal to not promise a runnable demo (e.g., "Implement logic layer for X" instead of "Playable X loop").
+If [C]: add a KNOWN RISK block to the sprint plan:
+```markdown
+> ⚠️ **Known risk:** Sprint goal requires `[file]` which does not exist. Sprint may
+> not produce a runnable demo. Playtest sessions dependent on this scene are blocked.
+```
+
+**Step 5 — Proceed to Phase 2 with prerequisites resolved.**
+
+---
+
 ## Phase 2: Generate Output
 
 For `new`:


### PR DESCRIPTION
## Summary

Add Phase 1b: Sprint Goal Dependency Audit step to check prerequisites before making the sprint plan to prevent unrealistic goals.

## Type of Change

- [ ] New agent
- [ ] New skill
- [ ] New hook or rule
- [ ] Bug fix
- [ ] Documentation improvement
- [X] Other: Skill Improvement (/sprint-plan)

## Changes
Problem / Motivation
I've face this problem during the development of my game. The sprint plan were include a playtest from author, but the sprint itself contains only logic code. The scene required to run the test were not exist yet. This resulting in some stories can't be fulfilled and need to defer to the following sprint instead. No big deal - but this kind of surprise is annoying for me.

Proposed Solution
The improvement is already made, to summarize what Phase 1b do:
Step 1 — State the sprint goal explicitly.
Step 2 — Identify what the sprint goal requires to be demonstrable.
Step 3 — Check prerequisites exist. (scene files)
Step 4 — Surface missing prerequisites.
Step 5 — Proceed to Phase 2 with prerequisites resolved.

## Checklist

- [X] I've tested this in a Claude Code session
- [ ] New agents include the Collaboration Protocol section
- [ ] New skills use the subdirectory format (`.claude/skills/<name>/SKILL.md`)
- [ ] Reference docs are updated (agent-roster, skills-reference, hooks-reference, rules-reference)
- [ ] Hooks use `grep -E` (POSIX) and fail gracefully without jq/python
- [X] No hardcoded paths or platform-specific assumptions
