### PR TITLE
fix(architecture-decision): add a top H1 for the skill itself

### DIFF
--- a/.claude/skills/architecture-decision/SKILL.md
+++ b/.claude/skills/architecture-decision/SKILL.md
@@ -7,6 +7,8 @@ allowed-tools: Read, Glob, Grep, Write, Edit, Task, AskUserQuestion
 model: sonnet
 ---
 
+# architecture-decision: write an Architecture Decision Record (ADR)
+
 When this skill is invoked:
 
 ## 0. Parse Arguments — Detect Retrofit Mode


### PR DESCRIPTION
Fixes #83.

The skill had no top-level H1; the first H1 was the placeholder `# ADR-[NNNN]: [Title]` inside the ADR template the skill emits. Patch adds `# architecture-decision: write an Architecture Decision Record (ADR)` right after the frontmatter. Template placeholder unchanged.