### PR TITLE
team-narrative: add the missing Phase 2 -> Phase 3 AskUserQuestion gate

### DIFF
--- a/.claude/skills/team-narrative/SKILL.md
+++ b/.claude/skills/team-narrative/SKILL.md
@@ -65,6 +65,8 @@ Delegate in parallel — issue all three Task calls simultaneously before waitin
 - **writer**: Draft character dialogue using voice profiles. Ensure all lines are under 120 characters, use named placeholders for variables, and are localization-ready.
 - **art-director**: Define character visual design direction for key characters appearing in this content (silhouette, visual archetype, distinguishing features). Specify environmental visual storytelling elements for each key space (prop composition, lighting notes, spatial arrangement). Define tone palette and cinematic direction for any cutscenes or scripted sequences.
 
+After all three Phase 2 agents return, summarise their proposals and use `AskUserQuestion` to capture the user's approval before continuing to Phase 3 (per **Decision Points** above).
+
 ### Phase 3: Level Narrative Integration
 Delegate to **level-designer**:
 - Review the narrative brief and lore foundation


### PR DESCRIPTION
Fixes https://github.com/Donchitos/Claude-Code-Game-Studios/issues/86.

"Decision Points" promised an `AskUserQuestion` gate at every phase
transition, but Phase 2 -> Phase 3 had none. This PR adds an explicit
instruction after the parallel Phase 2 block to summarise its three
outputs and call `AskUserQuestion` before Phase 3 delegates to
level-designer.