### PR TITLE
Trae/solo agent t7 d gl q

### DIFF
--- a/study-docs/01-项目概览.md
+++ b/study-docs/01-项目概览.md
@@ -1,0 +1,147 @@
+# 01 · 项目概览
+
+## 一句话定位
+
+**Claude Code Game Studios** 把一个 Claude Code 会话，编排成了一座虚拟的独立游戏工作室。
+
+原文来自 [README.md](file:///workspace/README.md)：
+
+> Turn a single Claude Code session into a full game development studio.
+> 49 agents. 73 skills. One coordinated AI team.
+
+翻译过来就是：**用 49 个智能体、73 个技能，把一个 AI 会话变成一支协同作战的团队**。
+
+---
+
+## 它解决什么问题
+
+一个人用 AI 做游戏，最大的问题不是"AI 不会写代码"，而是**没有结构**。README 里说得很直白：
+
+> Building a game solo with AI is powerful — but a single chat session has no structure. No one stops you from hardcoding magic numbers, skipping design docs, or writing spaghetti code. There's no QA pass, no design review, no one asking "does this actually fit the game's vision?"
+
+翻译：单聊会话里没人拦你硬编码魔法数字、跳过设计文档、写意大利面代码。没有 QA、没有设计评审、没人问"这真的符合游戏愿景吗？"
+
+这个项目的解法是**给 AI 会话套上真实工作室的结构**：
+
+- 用 **总监（directors）** 守愿景
+- 用 **部门主管（leads）** 管各自领域
+- 用 **专家（specialists）** 干活
+- 每个智能体都有明确职责、升级路径、质量门禁
+
+**关键定位：这不是自动驾驶系统，而是协作系统。** 你做每一个决定，AI 团队负责提问、早发现错误、保持项目有序。
+
+---
+
+## 核心数字速查
+
+| 类别 | 数量 | 在哪 | 干什么 |
+|------|------|------|--------|
+| **Agents 智能体** | 49 | [.claude/agents/](file:///workspace/.claude/agents/) | 角色定义，每个一个 `.md` 文件 |
+| **Skills 技能** | 73 | [.claude/skills/](file:///workspace/.claude/skills/) | `/slash` 命令，每个一个子目录 |
+| **Hooks 钩子** | 12 | [.claude/hooks/](file:///workspace/.claude/hooks/) | 自动校验脚本（bash） |
+| **Rules 规则** | 11 | [.claude/rules/](file:///workspace/.claude/rules/) | 按路径生效的编码规范 |
+| **Templates 模板** | 41 | [.claude/docs/templates/](file:///workspace/.claude/docs/templates/) | GDD/ADR/Sprint 等文档模板 |
+
+记住这组数字，后面每一篇都在拆解它们怎么协作。
+
+---
+
+## 工作室隐喻：把 AI 会话想象成一家公司
+
+这是理解整个项目的**核心心智模型**。读不懂没关系，先有个画面感：
+
+```
+你（人类开发者）= 老板 / 最终决策者
+        │
+        ├── creative-director    创意总监（守愿景）
+        ├── technical-director   技术总监（守架构）
+        └── producer             制作人（守进度，协调全员）
+                │
+        ┌───────┼────────┬────────┬────────┐
+        ▼       ▼        ▼        ▼        ▼
+   游戏设计   程序主管   美术   音频   叙事 ...
+        │       │
+        ▼       ▼
+     系统设计  玩法程序
+     关卡设计  引擎程序
+     经济设计  AI 程序 ...
+```
+
+**类比**：你开了一家游戏公司。你不是亲自写每一行代码，而是雇佣了一批专家。每个专家只管自己那一摊（`gameplay-programmer` 只写玩法代码，`qa-tester` 只写测试），跨部门的事由主管协调，主管谈不拢就找总监，总监谈不拢就找你。
+
+Claude Code 在这里扮演的角色是：**这家公司的"操作系统"**。它提供：
+
+- **`agents/`**：员工档案（每个智能体的职责、能用什么工具、归谁管）
+- **`skills/`**：标准作业流程（SOP），用 `/命令` 触发
+- **`hooks/`**：自动质检流水线（提交前自动检查）
+- **`rules/`**：岗位操作规范（写玩法代码必须数据驱动）
+- **`CLAUDE.md`**：公司章程（项目级总配置）
+
+---
+
+## 项目目录骨架
+
+来自 [README.md 的 Project Structure](file:///workspace/README.md)：
+
+```
+CLAUDE.md                           # 公司章程（项目级总配置）
+.claude/
+  settings.json                     # 钩子、权限、安全规则
+  agents/                           # 49 个智能体定义
+  skills/                           # 73 个 slash 命令
+  hooks/                            # 12 个钩子脚本
+  rules/                            # 11 条路径规则
+  docs/                             # 内部文档（workflow-catalog 等）
+src/                                # 游戏源码
+assets/                             # 美术/音频/数据
+design/                             # 设计文档（GDD）
+docs/                               # 技术文档、ADR
+production/                         # 冲刺计划、里程碑
+```
+
+**关键观察**：`.claude/` 目录是 Claude Code 的"配置心脏"。所有编排能力都集中在这里。`src/`、`design/`、`production/` 是被编排的"业务产物"。
+
+---
+
+## 它怎么工作（30 秒版）
+
+1. 你在终端敲 `claude` 开一个会话
+2. 会话一启动，`session-start.sh` 钩子自动告诉你当前在哪个分支、最近提交了啥
+3. 你敲 `/start`，系统问你"你现在到哪一步了"（没想法/有模糊概念/有清晰设计/已有代码），然后引导你走对应流程
+4. 你敲 `/dev-story production/epics/combat/melee-hitbox.md`，这个 skill 会：
+   - 读故事文件、读 GDD、读 ADR、读控制清单
+   - 路由到正确的程序员智能体（`gameplay-programmer`）
+   - 智能体写代码前先问你"我可以写到这个路径吗？"
+   - 写完汇总，告诉你下一步该跑 `/code-review` 然后 `/story-done`
+5. 你敲 `git commit`，`validate-commit.sh` 钩子自动检查：有没有硬编码数值、JSON 是否合法、设计文档章节是否齐全
+
+整个过程里，**你始终是决策者，AI 是提议者和执行者**。
+
+---
+
+## 为什么这是学习编排的"好教材"
+
+1. **规模够大**：49 个智能体不是玩具，是真实工程量。你能看到大规模编排怎么不乱套。
+2. **分层清晰**：三层架构（总监/主管/专家）是经典组织设计，能直接迁移到任何领域。
+3. **机制完整**：agents + skills + hooks + rules 四件套齐全，缺一不可的编排要素都覆盖。
+4. **人在环中**：不是"全自动 AI"，而是"协作 AI"。这恰恰是当前最实用的编排范式。
+5. **可读性高**：所有配置都是 markdown + YAML frontmatter，不是黑盒代码，读得懂、改得动。
+6. **有真实流程**：7 阶段流水线（概念→系统设计→技术设置→预制作→制作→打磨→发布）是真实游戏开发流程，能学到"流程编排"而非"单点自动化"。
+
+---
+
+## 小测验
+
+**Q1**：这个项目里，"谁"是最终决策者？
+> **A**：你（人类开发者）。AI 团队提议、分析、执行，但所有写文件、提交、战略决策都由你拍板。详见 [07 协作协议](file:///workspace/study-docs/07-协作协议与人在环.md)。
+
+**Q2**：`.claude/` 目录里，哪个子目录放的是"员工档案"？
+> **A**：`agents/`。每个 `.md` 文件是一个智能体的定义（职责、工具、模型、归谁管）。`skills/` 是作业流程，`hooks/` 是自动质检，`rules/` 是岗位规范。
+
+---
+
+## 动手
+
+打开 [.claude/agents/](file:///workspace/.claude/agents/) 数一数有多少个 `.md` 文件。再随便点开一个，比如 [creative-director.md](file:///workspace/.claude/agents/creative-director.md)，看看一个"创意总监"的档案长什么样。不用全看懂，先有个印象。
+
+下一篇 → [02 Claude Code 基础概念](file:///workspace/study-docs/02-Claude-Code基础概念.md)

--- a/study-docs/02-Claude-Code基础概念.md
+++ b/study-docs/02-Claude-Code基础概念.md
@@ -1,0 +1,248 @@
+# 02 · Claude Code 基础概念
+
+在拆解 49 个智能体怎么协作之前，我们先认识 Claude Code 的"配置零件"。这一篇是后续所有章节的地基。
+
+---
+
+## Claude Code 是什么
+
+Claude Code 是 Anthropic 出的**命令行 AI 编程助手**。你在终端敲 `claude`，它就开一个会话，能读写文件、跑命令、上网搜、调用各种工具。
+
+但裸的 Claude Code 只是一个"全能但无结构的助手"。要把它变成"一支有分工的团队"，需要靠**配置文件**告诉它：你是谁、能用什么、该怎么做、不能做什么。
+
+这些配置文件几乎都集中在一个地方：**`.claude/` 目录**，外加一个项目根目录的 `CLAUDE.md`。
+
+---
+
+## 两大配置入口
+
+### 1. `CLAUDE.md` —— 项目章程
+
+位置：[CLAUDE.md](file:///workspace/CLAUDE.md)
+
+这是 Claude Code 启动时**第一个读**的项目级文件。你可以理解为"公司章程"——它告诉 AI 这个项目是什么、技术栈是什么、要遵守哪些总原则。
+
+看这个项目的 `CLAUDE.md` 节选：
+
+```markdown
+# Claude Code Game Studios -- Game Studio Agent Architecture
+
+Indie game development managed through 49 coordinated Claude Code subagents.
+
+## Technology Stack
+- **Engine**: [CHOOSE: Godot 4 / Unity / Unreal Engine 5]
+- **Language**: [CHOOSE: GDScript / C# / C++ / Blueprint]
+- **Version Control**: Git with trunk-based development
+
+## Coordination Rules
+@.claude/docs/coordination-rules.md
+
+## Collaboration Protocol
+**User-driven collaboration, not autonomous execution.**
+Every task follows: Question -> Options -> Decision -> Draft -> Approval
+```
+
+**两个关键语法**：
+
+- `@路径` —— **引用语法**。`@.claude/docs/coordination-rules.md` 表示"把那个文件的内容也加载进来"。这样 `CLAUDE.md` 可以保持精简，把细节拆到子文件。
+- 普通文本 —— 直接是给 AI 的指令。
+
+**类比**：`CLAUDE.md` 就像公司章程，开篇定调子（"我们是 49 个智能体的工作室"），然后用 `@` 引用各部门的规章制度。
+
+### 2. `.claude/settings.json` —— 机器配置
+
+位置：[.claude/settings.json](file:///workspace/.claude/settings.json)
+
+这是 JSON 格式的"机器可读配置"，管三件事：**状态栏、权限、钩子**。
+
+```json
+{
+  "statusLine": { "command": "bash .claude/statusline.sh" },
+  "permissions": {
+    "allow": ["Bash(git status*)", "Bash(git diff*)", ...],
+    "deny":  ["Bash(rm -rf *)", "Bash(git push --force*)", "Read(**/.env*)"]
+  },
+  "hooks": { ... }
+}
+```
+
+- **`statusLine`**：底部状态栏显示什么（上下文用量、模型、当前阶段）。
+- **`permissions.allow`**：自动放行的安全操作（`git status`、跑测试）。
+- **`permissions.deny`**：永远禁止的危险操作（`rm -rf`、强推、读 `.env`）。
+- **`hooks`**：在哪些事件触发哪些脚本。详见 [05 Hook 自动化守卫](file:///workspace/study-docs/05-Hook自动化守卫.md)。
+
+**类比**：`settings.json` 是公司的"门禁系统 + 安检规则"。白名单的进，黑名单的拦，特定时刻自动巡检。
+
+---
+
+## `.claude/` 目录的六大部件
+
+这是整个编排的核心。逐一认识：
+
+### 部件 1：`agents/` —— 员工档案
+
+每个 `.md` 文件 = 一个智能体。文件名就是智能体名。比如 [creative-director.md](file:///workspace/.claude/agents/creative-director.md) 定义了"创意总监"。
+
+每个档案由两部分组成：
+
+```markdown
+---
+name: creative-director
+description: "The Creative Director is the highest-level creative authority..."
+tools: Read, Glob, Grep, Write, Edit, WebSearch
+model: opus
+maxTurns: 30
+disallowedTools: Bash
+skills: [brainstorm, design-review]
+---
+
+You are the Creative Director for an indie game project...
+（下面是给这个智能体的详细人设和职责说明）
+```
+
+- **YAML frontmatter**（`---` 之间的部分）：机器配置。名字、能用哪些工具、用哪个模型、最多几轮、禁用什么、关联哪些技能。
+- **正文**：人设和职责。这是给 AI 读的"岗位说明书"。
+
+**关键设计**：每个智能体的 `tools` 字段是**最小权限原则**的体现。`creative-director` 禁用了 `Bash`——创意总监不该跑终端命令，那是程序员和运维的活。
+
+### 部件 2：`skills/` —— 标准作业流程（SOP）
+
+每个子目录 = 一个 `/slash` 命令。比如 [skills/dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md) 定义了 `/dev-story` 命令。
+
+```markdown
+---
+name: dev-story
+description: "Read a story file and implement it..."
+argument-hint: "[story-path]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Bash, Task, AskUserQuestion
+model: sonnet
+---
+
+# Dev Story
+This skill bridges planning and code...
+## Phase 1: Find the Story
+## Phase 2: Load Full Context
+## Phase 3: Route to the Right Programmer
+...
+```
+
+- **`user-invocable: true`**：用户能直接敲 `/dev-story` 触发。
+- **`allowed-tools`**：这个技能能用哪些工具（含 `Task` = 能派生子智能体）。
+- **正文**：分阶段的执行流程。这是"作业指导书"。
+
+**类比**：`agents/` 是"员工档案"，`skills/` 是"SOP 手册"。员工按 SOP 干活，SOP 调度员工。
+
+### 部件 3：`hooks/` —— 自动质检脚本
+
+每个 `.sh` 文件 = 一个钩子脚本。在特定事件自动触发。比如 [validate-commit.sh](file:///workspace/.claude/hooks/validate-commit.sh) 在每次 `git commit` 前自动检查。
+
+钩子靠**退出码**说话：
+
+- `exit 0` = 放行
+- `exit 2` = 阻止（stderr 内容会反馈给 AI）
+- 其他 = 非阻塞警告
+
+详见 [05 Hook 自动化守卫](file:///workspace/study-docs/05-Hook自动化守卫.md)。
+
+### 部件 4：`rules/` —— 路径作用域规范
+
+每个 `.md` 文件 = 一条规则，靠 frontmatter 的 `paths` 字段决定**只在哪些路径生效**。比如 [gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md)：
+
+```markdown
+---
+paths:
+  - "src/gameplay/**"
+---
+
+# Gameplay Code Rules
+- ALL gameplay values MUST come from external config/data files, NEVER hardcoded
+- Use delta time for ALL time-dependent calculations
+- NO direct references to UI code — use events/signals
+...
+```
+
+**关键设计**：规则**只在该管的地方管**。写 `src/gameplay/` 下的代码时强制数据驱动；写 `prototypes/` 下的代码时规则放松（原型就该快糙猛）。详见 [06 Rules 路径规则](file:///workspace/study-docs/06-Rules路径规则.md)。
+
+### 部件 5：`docs/` —— 内部参考文档
+
+不是给用户读的，是给 AI 和 skill 读的"参考资料"。重要的几个：
+
+- [workflow-catalog.yaml](file:///workspace/.claude/docs/workflow-catalog.yaml)：7 阶段流水线定义，`/help` 命令读它来判断"你在哪一步"。
+- [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md)：智能体协作地图，谁能委派谁、冲突找谁。
+- [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md)：协作规则（垂直委派、横向咨询、冲突升级）。
+- [context-management.md](file:///workspace/.claude/docs/context-management.md)：上下文管理策略。
+- `templates/`：41 个文档模板（GDD、ADR、Sprint 计划等）。
+
+### 部件 6：`statusline.sh` —— 状态栏脚本
+
+底部状态栏显示什么。会显示上下文用量百分比、当前模型、项目阶段、当前在做的 Epic/Feature/Task 面包屑。
+
+---
+
+## 四件套怎么协同（核心图）
+
+```
+用户敲 /dev-story [path]
+        │
+        ▼
+   skills/dev-story/SKILL.md          ← SOP：分 7 个 Phase 执行
+        │
+        │ Phase 3: 路由到 gameplay-programmer
+        ▼
+   Task(subagent_type=gameplay-programmer)
+        │
+        ▼
+   agents/gameplay-programmer.md      ← 员工档案：人设 + 工具权限
+        │
+        │ 写代码到 src/gameplay/xxx
+        ▼
+   rules/gameplay-code.md 自动生效    ← 路径规则：必须数据驱动
+        │
+        │ 用户敲 git commit
+        ▼
+   hooks/validate-commit.sh 自动跑    ← 质检：检查硬编码、JSON、章节
+        │
+        ▼
+   exit 0 放行 / exit 2 阻止
+```
+
+**这就是编排的本质**：skill 调度 agent，agent 受 rules 约束，hooks 在关键节点守门，全部由 `CLAUDE.md` 和 `settings.json` 统一配置。
+
+---
+
+## 模型分层（一个常被忽略的细节）
+
+这个项目还示范了**按任务难度选模型**，来自 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md)：
+
+| 层 | 模型 | 用途 | 成本 |
+|----|------|------|------|
+| **Haiku** | `claude-haiku-4-5` | 只读状态检查、格式化、简单查询 | 低 |
+| **Sonnet** | `claude-sonnet-4-6` | 实现、设计撰写、单系统分析（默认） | 中 |
+| **Opus** | `claude-opus-4-6` | 多文档综合、高风险门禁、跨系统评审 | 高 |
+
+比如 `/help`、`/sprint-status` 这种只读命令用 Haiku（省钱），`/review-all-gdds`、`/gate-check` 这种高风险综合判断用 Opus（保质量），其余默认 Sonnet。
+
+**这是编排的进阶智慧**：不是所有任务都需要最贵的模型。把简单任务下放给便宜模型，是规模化编排必备的成本意识。
+
+---
+
+## 小测验
+
+**Q1**：`CLAUDE.md` 里的 `@.claude/docs/coordination-rules.md` 是什么意思？
+> **A**：引用语法。表示把那个文件的内容也加载进上下文。这样 `CLAUDE.md` 保持精简，细节拆到子文件。
+
+**Q2**：一个智能体的 `tools: Read, Glob, Grep, Write, Edit, WebSearch` 和 `disallowedTools: Bash` 是什么关系？
+> **A**：`tools` 是白名单（能用这些），`disallowedTools` 是显式黑名单（额外禁掉 Bash）。两者叠加 = 这个智能体能读能写能搜网，但不能跑终端命令。这是最小权限原则。
+
+**Q3**：`skills/` 和 `agents/` 的关系是什么？
+> **A**：`skills/` 是 SOP（标准作业流程），`agents/` 是员工档案。skill 调度 agent，agent 按 skill 的流程干活。一个 skill 可以调度多个 agent，一个 agent 可以被多个 skill 调用。
+
+---
+
+## 动手
+
+1. 打开 [.claude/settings.json](file:///workspace/.claude/settings.json)，找到 `permissions.deny`，看看哪些操作被永远禁止。
+2. 打开 [.claude/agents/qa-tester.md](file:///workspace/.claude/agents/qa-tester.md)，对比 [creative-director.md](file:///workspace/.claude/agents/creative-director.md)，看看"测试员"和"创意总监"的 `tools` 和 `model` 有什么不同，想想为什么。
+
+下一篇 → [03 Agent 编排体系](file:///workspace/study-docs/03-Agent编排体系.md)

--- a/study-docs/03-Agent编排体系.md
+++ b/study-docs/03-Agent编排体系.md
@@ -1,0 +1,280 @@
+# 03 · Agent 编排体系
+
+这一篇拆解 49 个智能体怎么组织、怎么分工、怎么合作、怎么处理冲突。这是整个项目最核心的编排智慧。
+
+---
+
+## 三层层级：模仿真实工作室
+
+来自 [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md) 和 [README.md](file:///workspace/README.md)：
+
+```
+Tier 1 — 总监层（Directors，Opus 模型）
+  creative-director    technical-director    producer
+
+Tier 2 — 主管层（Department Leads，Sonnet 模型）
+  game-designer        lead-programmer       art-director
+  audio-director       narrative-director    qa-lead
+  release-manager      localization-lead
+
+Tier 3 — 专家层（Specialists，Sonnet/Haiku 模型）
+  gameplay-programmer  engine-programmer     ai-programmer
+  network-programmer   tools-programmer      ui-programmer
+  systems-designer     level-designer        economy-designer
+  ...（共 30+ 个专家）
+```
+
+**为什么分三层？** 这是经典的组织设计。总监管"方向和愿景"，主管管"领域和标准"，专家管"具体执行"。每一层只关心自己那一层的事，复杂决策不跳层。
+
+**类比**：医院。院长（总监）定方向，科室主任（主管）管本专业标准，主治医生（专家）看病开方。你不会让院长去开处方，也不会让实习生定科室战略。
+
+---
+
+## 每一层的职责定位
+
+### Tier 1：总监 —— 守愿景、守架构、守进度
+
+| 总监 | 守什么 | 关键职责 |
+|------|--------|----------|
+| `creative-director` | **愿景** | 游戏核心幻想、支柱、调性、跨部门创意冲突仲裁 |
+| `technical-director` | **架构** | 技术栈、架构决策、性能策略、技术冲突仲裁 |
+| `producer` | **进度** | 冲刺计划、里程碑、风险、跨部门协调 |
+
+看 [creative-director.md](file:///workspace/.claude/agents/creative-director.md) 的人设开头：
+
+> You are the Creative Director for an indie game project. You are the final authority on all creative decisions. Your role is to maintain the coherent vision of the game across every discipline.
+
+注意"final authority on all creative decisions"——但这个 authority 是**提议权**，不是**最终决定权**。最终决定权在你（人类）。详见 [07 协作协议](file:///workspace/study-docs/07-协作协议与人在环.md)。
+
+### Tier 2：主管 —— 管领域、定标准、带专家
+
+| 主管 | 领域 | 能委派给哪些专家 |
+|------|------|-------------------|
+| `game-designer` | 游戏设计 | systems-designer, level-designer, economy-designer |
+| `lead-programmer` | 代码架构 | gameplay/engine/ai/network/tools/ui-programmer |
+| `art-director` | 视觉方向 | technical-artist, ux-designer |
+| `audio-director` | 音频方向 | sound-designer |
+| `narrative-director` | 叙事 | writer, world-builder |
+| `qa-lead` | 质量 | qa-tester |
+
+主管是"承上启下"的枢纽：总监委派任务给主管，主管拆解后委派给专家；专家干完汇报给主管，主管汇总后汇报给总监。
+
+### Tier 3：专家 —— 干具体活
+
+每个专家只管一摊。比如：
+- `gameplay-programmer` 只写玩法代码
+- `qa-tester` 只写测试和报 bug
+- `writer` 只写对话和背景设定
+- `economy-designer` 只管经济平衡
+
+**关键设计**：专家的 `tools` 字段是最小权限的。比如 `qa-tester` 用 Haiku 模型（只读+格式化任务），`creative-director` 禁用 `Bash`（总监不跑命令）。
+
+---
+
+## 委派规则：谁能指挥谁
+
+来自 [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md) 的"Delegation Rules"表。核心是**垂直委派，不能跳层**：
+
+```
+creative-director  →  game-designer  →  systems-designer
+       ↑                  ↑                    │
+       │                  │                    │
+       └── 跳过 game-designer 直接找 systems-designer？❌ 不行
+```
+
+完整委派关系（节选）：
+
+| 谁委派 | 能委派给 |
+|--------|----------|
+| `creative-director` | game-designer, art-director, audio-director, narrative-director |
+| `technical-director` | lead-programmer, devops-engineer, performance-analyst |
+| `producer` | 任何智能体（但只能在对方领域内派活） |
+| `game-designer` | systems-designer, level-designer, economy-designer |
+| `lead-programmer` | gameplay/engine/ai/network/tools/ui-programmer |
+| `qa-lead` | qa-tester |
+
+**为什么不能跳层？** 因为跳层会绕过领域把关。如果创意总监直接找 `systems-designer` 改公式，就绕过了 `game-designer` 的设计审查，容易出设计冲突。
+
+---
+
+## 横向咨询：同级可以问，但不能下命令
+
+来自 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) 第 2 条：
+
+> **Horizontal Consultation**: Agents at the same tier may consult each other but must not make binding decisions outside their domain.
+
+**类比**：你和隔壁部门的同事可以聊天请教，但你不能命令他改他部门的代码。要跨部门协作，得走正式流程（找共同上级）。
+
+**实例**：`gameplay-programmer` 写战斗代码时，可以问 `ai-programmer`"敌人 AI 那边怎么接收伤害事件"，但不能直接改 `ai-programmer` 的文件。要改，得让 `lead-programmer` 协调。
+
+---
+
+## 冲突升级：谈不拢找共同上级
+
+来自 [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md) 的"Escalation Paths"表：
+
+| 冲突场景 | 升级给谁 |
+|----------|----------|
+| 两个设计师对机制有分歧 | `game-designer`（他们的共同上级） |
+| 游戏设计 vs 叙事冲突 | `creative-director`（设计和叙事的共同上级） |
+| 游戏设计 vs 技术可行性 | `producer` 协调，再升级到 `creative-director` + `technical-director` |
+| 代码架构分歧 | `technical-director` |
+| 跨系统代码冲突 | `lead-programmer`，再升级 `technical-director` |
+| 进度冲突 | `producer` |
+| 范围超容量 | `producer`，再升级 `creative-director` 决定砍什么 |
+| 质量门禁分歧 | `qa-lead`，再升级 `technical-director` |
+
+**核心原则**：**找共同上级**。两个下属吵架，找管他们俩的那个人。
+
+**类比**：前端和后端吵架，找技术总监；产品和工程吵架，找 CEO。
+
+---
+
+## 变更传播：跨部门改动由 producer 协调
+
+来自 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) 第 4 条：
+
+> **Change Propagation**: When a design change affects multiple domains, the `producer` agent coordinates the propagation.
+
+**为什么是 producer？** 因为 producer 是唯一"不归任何单一领域"的总协调者。设计改了影响代码、测试、进度，只有 producer 能全盘协调。
+
+**实例**（来自 [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md) 的"Design Change Notification"）：
+
+> 当设计文档变更时，game-designer 必须通知：
+> - lead-programmer（实现影响）
+> - qa-lead（测试计划要更新）
+> - producer（进度影响评估）
+> - 相关专家智能体
+
+---
+
+## 域边界：不许改别人家的文件
+
+来自 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) 第 5 条：
+
+> **No Unilateral Cross-Domain Changes**: An agent must never modify files outside its designated directories without explicit delegation.
+
+**这是编排的铁律**。`gameplay-programmer` 不能改 `src/ui/` 下的文件，要改得让 `ui-programmer` 来，或者由 `lead-programmer` 显式委派。
+
+**为什么这么严？** 因为 AI 最容易犯的错就是"顺手改了不该改的地方"。明确域边界能防止连锁错误和职责混乱。
+
+---
+
+## 五大反模式（必须避免）
+
+来自 [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md) 末尾。这是给 AI 看的"不许做的事"：
+
+1. **绕过层级**：专家不该做主管该做的决定，不请示就拍板。
+2. **跨域实现**：智能体不该改自己领域外的文件，除非被显式委派。
+3. **影子决策**：所有决定必须留文档。口头协议不留痕会导致矛盾。
+4. **巨型任务**：每个任务必须 1-3 天能做完。做不完就先拆分。
+5. **基于假设的实现**：规格模糊时必须问，不能猜。猜错的代价比问一句高得多。
+
+**这五条是编排的"防呆设计"**。每一条都对应 AI 最容易犯的错。
+
+---
+
+## 引擎专家：可插拔的子团队
+
+这是个很巧妙的设计。项目支持三大引擎（Godot/Unity/Unreal），每个引擎有自己的"子团队"：
+
+| 引擎 | 主管 | 子专家 |
+|------|------|--------|
+| Godot 4 | `godot-specialist` | GDScript / C# / Shader / GDExtension 专家 |
+| Unity | `unity-specialist` | DOTS / Shader / Addressables / UI 专家 |
+| Unreal 5 | `unreal-specialist` | GAS / Blueprint / Replication / UMG 专家 |
+
+**关键设计**：你只用其中一组，删掉另外两组。这是"可插拔架构"——核心编排不变，引擎专家按需替换。
+
+**编排启示**：设计编排时，把"可变部分"（引擎、技术栈）和"不变部分"（流程、角色）分开。不变的部分做成骨架，可变的部分做成可替换模块。
+
+---
+
+## 一个完整的委派链示例
+
+来自 [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md) 的"Pattern 1: New Feature (Full Pipeline)"。这是一个新功能从概念到完成的完整链路：
+
+```
+1. creative-director   批准功能概念符合愿景
+2. game-designer       写设计文档
+3. producer            排期，识别依赖
+4. lead-programmer     设计代码架构，画接口草图
+5. [专家程序员]         实现功能
+6. technical-artist    做视觉特效（如需）
+7. writer              写文本内容（如需）
+8. sound-designer      列音频事件清单（如需）
+9. qa-tester           写测试用例
+10. qa-lead            审查测试覆盖
+11. lead-programmer    代码审查
+12. qa-tester          执行测试
+13. producer           标记任务完成
+```
+
+**注意几个编排细节**：
+- 步骤 6-8 可以**并行**（互不依赖）。
+- 步骤 9-10 是**串行**（测试员写完，主管才审查）。
+- 步骤 11 和 12 看似可以并行，但实际是**串行**（代码审查可能要求改，改完才测）。
+- 每一步都有"把关人"：创意总监管愿景、主管管标准、QA 管质量、制作人管进度。
+
+---
+
+## Subagent vs Agent Team：两种多智能体模式
+
+来自 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) 的"Subagents vs Agent Teams"。这是进阶概念，但很重要：
+
+### Subagents（当前在用）
+
+通过 `Task` 工具在**单个 Claude Code 会话内**派生子智能体。子智能体共享会话权限，串行或并行运行，结果返回给父会话。
+
+**适用**：绝大多数场景。所有 `team-*` 技能和编排技能都用这个。
+
+### Agent Teams（实验性，需 opt-in）
+
+多个**独立的 Claude Code 会话**同时运行，通过共享任务列表协调。每个会话有独立上下文窗口和 token 预算。需要环境变量 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`。
+
+**适用**：
+- 工作跨多个子系统且不碰同一批文件
+- 每个工作流要 30 分钟以上，受益于真并行
+- 一个高级智能体要协调 3+ 专家会话同时干不同 epic
+
+**不适用**：
+- 一个会话的输出是另一个的输入（用串行 subagent）
+- 任务塞得进单会话上下文（用 subagent）
+- 成本敏感（每个团队成员独立烧 token）
+
+**编排启示**：默认用 subagent（简单、共享上下文、便宜）。只有真并行且任务够大才上 agent team。
+
+---
+
+## 并行任务协议
+
+来自 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) 末尾。当编排技能派生多个独立智能体时：
+
+1. **先发后等**：所有独立的 Task 调用一起发出，再等结果。
+2. **收齐再走**：所有结果收齐再进依赖阶段。
+3. **阻塞立即上报**：任何智能体 BLOCKED 立刻告诉用户，不静默跳过。
+4. **必出部分报告**：哪怕部分阻塞，也要把已完成的部分汇报出来。
+
+**这是并行的纪律**。AI 最容易犯的错是"一个一个串行等"，浪费时间和 token。
+
+---
+
+## 小测验
+
+**Q1**：`gameplay-programmer` 想改 `src/ui/` 下的文件，应该怎么做？
+> **A**：不能直接改（域边界铁律）。要么让 `ui-programmer` 来改，要么由 `lead-programmer` 显式委派给 `gameplay-programmer` 临时跨域。
+
+**Q2**：`game-designer` 和 `narrative-director` 对某个机制有分歧，找谁仲裁？
+> **A**：`creative-director`。因为设计和叙事的共同上级是创意总监。看升级路径表。
+
+**Q3**：为什么 `creative-director` 的 `disallowedTools` 里有 `Bash`？
+> **A**：最小权限原则。创意总监的职责是守愿景和仲裁创意冲突，不该跑终端命令。跑命令是程序员和运维的活。禁用 Bash 防止总监"越权动手"。
+
+---
+
+## 动手
+
+1. 打开 [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md)，找到"Pattern 2: Bug Fix"和"Pattern 3: Balance Adjustment"，对比三条链路的异同。
+2. 打开 [.claude/agents/](file:///workspace/.claude/agents/) 目录，挑三个不同层级的智能体（比如一个总监、一个主管、一个专家），对比它们的 `tools`、`model`、`maxTurns` 字段，想想为什么这么设。
+
+下一篇 → [04 Skill 技能系统](file:///workspace/study-docs/04-Skill技能系统.md)

--- a/study-docs/04-Skill技能系统.md
+++ b/study-docs/04-Skill技能系统.md
@@ -1,0 +1,317 @@
+# 04 · Skill 技能系统
+
+上一篇讲了"谁"（agent）。这一篇讲"怎么干"（skill）。73 个 `/slash` 命令是怎么定义、怎么触发、怎么串成流水线的。
+
+---
+
+## Skill 是什么
+
+Skill = **可复用的标准作业流程（SOP）**，用 `/命令` 触发。
+
+每个 skill 是 [.claude/skills/](file:///workspace/.claude/skills/) 下的一个子目录，里面有一个 `SKILL.md`。比如 `/dev-story` 对应 [skills/dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md)。
+
+**Skill 和 Agent 的关系**：
+
+- **Agent** 是"员工"——有人设、有工具权限、归某个主管管。
+- **Skill** 是"作业流程"——分阶段、有路由、调度员工去干活。
+
+一个 skill 可以调度多个 agent，一个 agent 可以被多个 skill 调用。比如 `gameplay-programmer` 会被 `/dev-story`、`/team-combat`、`/hotfix` 等多个 skill 调用。
+
+---
+
+## SKILL.md 的结构
+
+看 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md) 的开头：
+
+```markdown
+---
+name: dev-story
+description: "Read a story file and implement it. Loads the full context..."
+argument-hint: "[story-path]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Bash, Task, AskUserQuestion
+model: sonnet
+---
+
+# Dev Story
+## Phase 1: Find the Story
+## Phase 2: Load Full Context
+## Phase 3: Route to the Right Programmer
+## Phase 4: Implement
+## Phase 5: Test Evidence Requirements
+## Phase 6: Collect and Summarise
+## Phase 7: Update Session State
+```
+
+**关键字段**：
+
+| 字段 | 作用 |
+|------|------|
+| `name` | 命令名（`/dev-story`） |
+| `description` | 一句话说明，给 `/help` 和 AI 识别用 |
+| `argument-hint` | 参数提示（`[story-path]`） |
+| `user-invocable: true` | 用户能直接敲命令触发 |
+| `allowed-tools` | 这个 skill 能用哪些工具。注意 `Task` = 能派生子智能体 |
+| `model` | 用哪个模型跑这个 skill |
+
+**正文**：分 Phase 的执行流程。这是给 AI 读的"作业指导书"，告诉它每一步做什么、读什么文件、什么时候问用户、什么时候派子智能体。
+
+---
+
+## 73 个 Skill 的分类
+
+来自 [README.md](file:///workspace/README.md) 的 Slash Commands 章节。按用途分 11 类：
+
+| 类别 | 代表命令 | 干什么 |
+|------|----------|--------|
+| **入门导航** | `/start` `/help` `/project-stage-detect` | 引导你从零开始，判断你在哪一步 |
+| **游戏设计** | `/brainstorm` `/design-system` `/map-systems` | 头脑风暴、系统地图、写 GDD |
+| **美术资产** | `/art-bible` `/asset-spec` `/asset-audit` | 美术圣经、资产规格、审计 |
+| **UX 界面** | `/ux-design` `/ux-review` | UX 规格和评审 |
+| **架构** | `/create-architecture` `/architecture-decision` `/architecture-review` | 架构文档、ADR、评审 |
+| **故事与冲刺** | `/create-epics` `/create-stories` `/dev-story` `/sprint-plan` | 史诗、故事、实现、冲刺 |
+| **评审分析** | `/code-review` `/balance-check` `/scope-check` `/gate-check` | 代码/平衡/范围/门禁评审 |
+| **QA 测试** | `/qa-plan` `/smoke-check` `/regression-suite` `/test-setup` | 测试计划、冒烟、回归、框架 |
+| **生产管理** | `/milestone-review` `/retrospective` `/bug-report` | 里程碑、复盘、bug |
+| **发布** | `/release-checklist` `/launch-checklist` `/changelog` `/hotfix` | 发布清单、变更日志、热修 |
+| **团队编排** | `/team-combat` `/team-narrative` `/team-ui` `/team-qa` ... | 多智能体协同做某个功能 |
+
+**编排启示**：skill 不是随便堆的，是按**软件开发生命周期**分类的。从概念到发布，每个阶段都有对应技能。这就是"流程编排"。
+
+---
+
+## 7 阶段流水线：workflow-catalog
+
+这是整个项目的"主流程骨架"。来自 [workflow-catalog.yaml](file:///workspace/.claude/docs/workflow-catalog.yaml)。
+
+```
+1. concept          概念      → 把想法变成文档化的概念
+2. systems-design   系统设计  → 为每个系统写 GDD
+3. technical-setup  技术设置  → 架构决策、ADR、控制清单
+4. pre-production   预制作    → UX 规格、资产规格、原型、史诗、故事
+5. production       制作      → 冲刺循环：实现故事、代码审查、关闭
+6. polish           打磨      → 性能、平衡、playtest
+7. release          发布      → 发布清单、上线清单
+```
+
+**每个阶段有这些属性**：
+
+```yaml
+phases:
+  concept:
+    label: "Concept"
+    description: "Develop your game idea into a documented concept"
+    next_phase: systems-design      # 下一阶段
+    steps:
+      - id: brainstorm
+        name: "Brainstorm"
+        command: /brainstorm
+        required: false              # 是否必需
+        description: "..."
+      - id: engine-setup
+        command: /setup-engine
+        required: true
+        artifact:                    # 怎么判断这一步完成了
+          glob: ".claude/docs/technical-preferences.md"
+          pattern: "Engine: [^[]"
+```
+
+**关键设计**：
+
+1. **`required: true/false`**：必需步骤阻塞进入下一阶段，可选步骤只是建议。
+2. **`artifact`**：用文件 glob 模式自动检测"这一步做完了没"。比如 `engine-setup` 完成的标志是 `technical-preferences.md` 里有 `Engine: xxx` 字样。
+3. **`repeatable: true`**：可重复步骤（比如每个系统都要写一个 GDD）。
+4. **门禁是建议性的**：`/gate-check` 的判定是 ADVISORY，不硬阻塞。**用户永远有权决定是否前进**。
+
+---
+
+## `/help` 怎么用这个 catalog
+
+`/help` 命令读 `workflow-catalog.yaml`，然后：
+
+1. 检查每个阶段的 `artifact`（文件存不存在、模式匹不匹配）。
+2. 判断"你大概在哪个阶段"。
+3. 列出"当前阶段的下一步是什么"。
+
+**这是编排的精妙之处**：AI 不靠猜，靠**文件存在性**判断进度。文件就是状态机。
+
+---
+
+## Skill 的内部结构：以 `/dev-story` 为例
+
+`/dev-story` 是最核心的实现技能。我们拆它的 7 个 Phase（来自 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md)）：
+
+### Phase 1: 找故事
+- 有参数 → 直接读那个文件
+- 没参数 → 查 `production/session-state/active.md` 找当前故事，或列出所有 `Status: Ready` 的故事让用户选
+
+### Phase 2: 加载完整上下文
+**关键设计**：实现前必须把所有上下文加载齐。要读：
+- 故事文件（标题、ID、层、类型、TR-ID、验收标准、依赖）
+- TR registry（`docs/architecture/tr-registry.yaml`，需求真源）
+- 治理 ADR（决策和实现指南）
+- 控制清单（`docs/architecture/control-manifest.md`，层级规则）
+- 引擎偏好（命名规范、性能预算）
+
+**还做依赖校验**：故事的依赖如果没完成，会停下来问用户"要继续吗、停下来、还是标记依赖完成"。
+
+**还做清单版本校验**：故事的清单版本和当前清单版本不一致，会问用户"用新规则还是旧规则"。
+
+### Phase 3: 路由到正确的程序员
+**核心是路由表**：
+
+| 故事上下文 | 派给谁 |
+|------------|--------|
+| Foundation 层 | `engine-programmer` |
+| 任何层 - UI 类型 | `ui-programmer` |
+| 任何层 - Visual/Feel 类型 | `gameplay-programmer` |
+| Core/Feature - 玩法机制 | `gameplay-programmer` |
+| Core/Feature - AI 行为 | `ai-programmer` |
+| Core/Feature - 网络 | `network-programmer` |
+| Config/Data - 无代码 | 不派 agent，直接改数据文件 |
+
+**还会派引擎专家做副手**：当 ADR 标记引擎风险为 HIGH 时，强制派引擎专家验证。
+
+### Phase 4: 实现
+通过 `Task` 工具派生子智能体，把上下文包打包给它。子智能体写代码、写测试。
+
+**关键指令**：实现必须遵循 ADR 的实现指南，尊重控制清单规则，不越界（不碰 Out of Scope 的文件）。
+
+### Phase 5: 测试证据要求
+不同故事类型要求不同证据：
+
+| 类型 | 必需证据 |
+|------|----------|
+| Logic | 自动化单元测试（阻塞） |
+| Integration | 集成测试或 playtest 记录（阻塞） |
+| Visual/Feel | 证据文档（建议） |
+| UI | 手动走查文档或交互测试（建议） |
+| Config/Data | 无（冒烟检查即证据） |
+
+### Phase 6: 汇总
+收集：改了哪些文件、测试文件、是否越界、引擎风险、阻塞。输出结构化摘要。
+
+### Phase 7: 更新会话状态
+悄悄往 `production/session-state/active.md` 追加一条记录。这是"文件即记忆"的体现（详见 [08 上下文管理](file:///workspace/study-docs/08-上下文管理艺术.md)）。
+
+---
+
+## Skill 的协作协议
+
+每个 skill 都遵守 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md) 的五步：
+
+```
+Question → Options → Decision → Draft → Approval
+```
+
+`/dev-story` 在 Phase 2 的清单版本校验就是典型：
+
+1. **Question**：检测到版本不一致
+2. **Options**：用 `AskUserQuestion` 给三个选项（用新规则/用旧规则/停下来看 diff）
+3. **Decision**：用户选
+4. **Draft**：按选择更新故事文件的清单版本字段
+5. **Approval**：进入下一阶段前隐含确认
+
+详见 [07 协作协议](file:///workspace/study-docs/07-协作协议与人在环.md)。
+
+---
+
+## Team Skill：多智能体协同
+
+`/team-*` 系列是编排的高阶形态。以 [team-combat/SKILL.md](file:///workspace/.claude/skills/team-combat/SKILL.md) 为例，它编排 7 个智能体做一个战斗功能：
+
+```
+game-designer        设计机制
+gameplay-programmer  实现核心代码
+ai-programmer        实现 NPC AI
+technical-artist     做 VFX
+sound-designer       定义音频事件
+engine specialist    验证引擎惯用法
+qa-tester            写测试、验证
+```
+
+**6 阶段流水线**：
+
+```
+Phase 1: 设计      → game-designer 写设计文档
+Phase 2: 架构      → gameplay-programmer 画架构草图 + 引擎专家验证
+                     [用户批准才进下一阶段]
+Phase 3: 并行实现  → 4 个智能体同时干（gameplay + ai + tech-artist + sound）
+Phase 4: 集成      → 把各子系统接起来
+Phase 5: 验证      → qa-tester 写测试、跑测试
+Phase 6: 签字      → 汇总状态：COMPLETE / NEEDS WORK / BLOCKED
+```
+
+**关键编排细节**：
+
+1. **Phase 间有用户批准门**：每个 Phase 转换都要 `AskUserQuestion` 让用户确认。
+2. **Phase 3 是并行**：4 个独立子智能体同时派生，符合"并行任务协议"（先发后等）。
+3. **错误恢复协议**：任何子智能体 BLOCKED 立即上报，给用户三个选项（跳过/重试/停下）。
+4. **文件写入委托**：编排器自己不写文件，所有写操作委托给子智能体，每个子智能体单独执行"我可以写到这个路径吗"协议。
+
+---
+
+## Review Mode：可调节的严格度
+
+来自 [team-combat/SKILL.md](file:///workspace/.claude/skills/team-combat/SKILL.md) 的 Phase 0。这是个很实用的设计：
+
+| 模式 | 行为 |
+|------|------|
+| `full` | 派所有总监和主管门禁 |
+| `lean` | 只派阶段门禁（跳过中间总监门禁） |
+| `solo` | 跳过所有门禁，技能自己跑 |
+
+**怎么选**：
+- 命令行加 `--review solo` 单次覆盖
+- 否则读 `production/review-mode.txt`
+- 否则默认 `lean`
+
+**编排启示**：编排不是"一刀切"。给用户一个"严格度旋钮"，让用户按场景调。重要功能用 full，快速原型用 solo。
+
+---
+
+## Skill 的错误恢复协议
+
+几乎所有 skill 末尾都有"Error Recovery Protocol"。来自 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md)：
+
+```
+如果任何派生的 agent 返回 BLOCKED、出错、或无法完成：
+
+1. 立即上报：在继续依赖阶段前，先告诉用户"[AgentName]: BLOCKED — [原因]"
+2. 评估依赖：检查被阻塞 agent 的输出是否被后续阶段需要。如果是，不要越过那个依赖点
+3. 用 AskUserQuestion 给选项：
+   - 跳过这个 agent，在最终报告里标注缺口
+   - 用更窄的范围重试
+   - 停下来先解决阻塞
+4. 总是产出部分报告：哪怕部分阻塞，也要把已完成的部分汇报出来
+```
+
+**核心原则**：
+- **不静默吞错**：BLOCKED 必须告诉用户。
+- **不因部分失败丢弃已完成**：总要出部分报告。
+- **依赖链断了就停**：不要在缺依赖的情况下硬走。
+
+**这是编排的"韧性设计"**。AI 编排最容易出的错就是"某个子任务失败，整个流程崩了或静默继续"。这个协议两头堵死。
+
+---
+
+## 小测验
+
+**Q1**：`/dev-story` 在实现前为什么要读那么多文件（故事、TR registry、ADR、控制清单、引擎偏好）？
+> **A**：因为"上下文不全 = 代码漂离设计"。故事的验收标准可能过时（要查 TR registry 的最新需求），实现方式必须遵循 ADR，编码必须符合控制清单的层级规则。少读一个，就可能写出不符合设计的代码。
+
+**Q2**：`/team-combat` 的 Phase 3 为什么能并行派 4 个智能体？
+> **A**：因为这 4 个智能体（gameplay-programmer / ai-programmer / technical-artist / sound-designer）的输入互不依赖——玩法代码、AI、VFX、音频可以同时开工。符合"并行任务协议"：独立就并行，依赖就串行。
+
+**Q3**：`workflow-catalog.yaml` 里的 `artifact` 字段是干什么的？
+> **A**：自动检测"这一步做完了没"。用文件 glob 模式（必要时加文本 pattern）判断。比如 `engine-setup` 完成的标志是 `technical-preferences.md` 里有 `Engine: xxx`。这让 `/help` 能靠文件存在性判断进度，不靠 AI 猜。
+
+---
+
+## 动手
+
+1. 打开 [workflow-catalog.yaml](file:///workspace/.claude/docs/workflow-catalog.yaml)，找到 `production` 阶段，数数它有几个 step，哪些 `required: true`，哪些 `repeatable: true`。
+2. 打开 [skills/start/SKILL.md](file:///workspace/.claude/skills/start/SKILL.md)，看看 `/start` 这个入门命令是怎么"问你在哪一步"的。
+3. 对比 [skills/dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md) 和 [skills/team-combat/SKILL.md](file:///workspace/.claude/skills/team-combat/SKILL.md)，看单个智能体调度和多智能体协同的 skill 写法有什么不同。
+
+下一篇 → [05 Hook 自动化守卫](file:///workspace/study-docs/05-Hook自动化守卫.md)

--- a/study-docs/05-Hook自动化守卫.md
+++ b/study-docs/05-Hook自动化守卫.md
@@ -1,0 +1,300 @@
+# 05 · Hook 自动化守卫
+
+前面讲的 agent 和 skill 都是"AI 主动遵守"的软约束。Hook 不一样——它是**硬约束**，是机器自动执行的脚本，AI 绕不过去。这一篇拆解 12 个钩子怎么守住底线。
+
+---
+
+## Hook 是什么
+
+Hook = **在特定事件自动触发的脚本**。Claude Code 在关键节点（会话开始、工具调用前、工具调用后、会话结束等）会自动跑你配置的脚本。
+
+**和 skill 的区别**：
+- Skill 是 AI 主动读、主动执行的"作业流程"。
+- Hook 是**事件驱动**的，AI 不调用它，它在事件发生时自动跑。
+
+**和 rule 的区别**：
+- Rule 是"写代码时遵守的规范"，靠 AI 自觉。
+- Hook 是"提交时强制检查"，AI 想绕也绕不过。
+
+**类比**：rule 是"公司规章制度"（靠自觉），hook 是"门口的金属探测门"（强制）。
+
+---
+
+## 退出码：钩子的"语言"
+
+钩子靠**退出码**和 Claude Code 通信。这是最重要的概念：
+
+| 退出码 | 含义 | 行为 |
+|--------|------|------|
+| `exit 0` | 放行 | 工具调用继续 |
+| `exit 2` | 阻止 | 工具调用被阻止，stderr 内容反馈给 AI |
+| 其他（如 `exit 1`） | 非阻塞警告 | 警告显示但工具调用继续 |
+
+**关键设计**：只有 `exit 2` 能硬阻止。其他都是建议性的。
+
+看 [validate-commit.sh](file:///workspace/.claude/hooks/validate-commit.sh) 的两类用法：
+
+```bash
+# 硬阻止（JSON 不合法就拦下）：
+if ! "$PYTHON_CMD" -m json.tool "$file" > /dev/null 2>&1; then
+    echo "BLOCKED: $file is not valid JSON" >&2
+    exit 2
+fi
+
+# 软警告（设计文档缺章节、硬编码数值，只警告不拦）：
+WARNINGS="$WARNINGS\nDESIGN: $file missing required section: $section"
+...
+exit 0   # 最后还是放行
+```
+
+**编排启示**：硬阻止用于"绝对不能发生的"（无效 JSON 会崩游戏），软警告用于"应该但不致命的"（缺章节、硬编码）。区分对待，避免钩子太烦人被关掉。
+
+---
+
+## 8 类钩子事件
+
+来自 [settings.json](file:///workspace/.claude/settings.json) 的 `hooks` 配置。Claude Code 支持这些事件：
+
+| 事件 | 何时触发 | 这个项目挂了什么 |
+|------|----------|-------------------|
+| `SessionStart` | 会话开始 | `session-start.sh`（显示分支和最近提交）、`detect-gaps.sh`（检测新项目/缺设计文档） |
+| `PreToolUse` | 工具调用前 | `validate-commit.sh`（提交前校验）、`validate-push.sh`（推送前校验） |
+| `PostToolUse` | 工具调用后 | `validate-assets.sh`（写资产后校验）、`validate-skill-change.sh`（改 skill 后提醒测试） |
+| `Notification` | 通知事件 | `notify.sh`（Windows 弹 toast） |
+| `PreCompact` | 压缩前 | `pre-compact.sh`（保存会话进度笔记） |
+| `PostCompact` | 压缩后 | `post-compact.sh`（提醒从 active.md 恢复状态） |
+| `Stop` | 会话结束 | `session-stop.sh`（归档 active.md 到日志） |
+| `SubagentStart` | 子智能体启动 | `log-agent.sh`（审计日志开始） |
+| `SubagentStop` | 子智能体停止 | `log-agent-stop.sh`（审计日志结束） |
+
+---
+
+## settings.json 怎么挂钩子
+
+看 [settings.json](file:///workspace/.claude/settings.json) 的结构：
+
+```json
+"hooks": {
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash .claude/hooks/validate-commit.sh",
+          "timeout": 15
+        },
+        {
+          "type": "command",
+          "command": "bash .claude/hooks/validate-push.sh",
+          "timeout": 10
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [ ... ]
+    }
+  ]
+}
+```
+
+**关键字段**：
+
+- **`matcher`**：匹配哪些工具。`"Bash"` = 只在 Bash 工具调用时触发；`"Write|Edit"` = 写或编辑时触发；`""` = 所有工具都触发。
+- **`timeout`**：超时秒数。超时按放行处理（避免钩子卡死整个会话）。
+- **`command`**：跑什么命令。钩子通过 stdin 收到 JSON，通过退出码和 stderr 反馈。
+
+---
+
+## 12 个钩子逐一拆解
+
+### 1. `session-start.sh`（SessionStart）
+
+会话一开始就跑。显示当前分支和最近提交，帮你"找回状态"。
+
+**编排作用**：长项目里，你打开会话第一眼就知道"我在哪、最近干了啥"。这是"上下文恢复"的第一步。
+
+### 2. `detect-gaps.sh`（SessionStart）
+
+检测项目缺口：
+- 全新项目（没有引擎配置、没有游戏概念）→ 建议 `/start`
+- 有代码或原型但没有设计文档 → 提醒补设计文档
+
+**编排作用**：自动诊断"项目健康度"。防止"埋头写代码忘了写设计"。
+
+### 3. `validate-commit.sh`（PreToolUse, matcher: Bash）
+
+每次 Bash 工具调用都触发，但**只在命令是 `git commit` 时真正执行**，其他情况立即 `exit 0`。这是性能优化——钩子挂得广但跑得轻。
+
+检查内容：
+- **设计文档章节**：`design/gdd/` 下的 `.md` 必须有 8 个必需章节（Overview / Player Fantasy / Detailed / Formulas / Edge Cases / Dependencies / Tuning Knobs / Acceptance Criteria）。缺章节 → 警告。
+- **JSON 合法性**：`assets/data/*.json` 必须是合法 JSON。不合法 → **硬阻止**（exit 2）。
+- **硬编码数值**：`src/gameplay/` 下出现 `damage = 25.0` 这种 → 警告（应该用数据文件）。
+- **TODO 格式**：`src/` 下的 TODO 必须带 owner，如 `TODO(name)`。裸 TODO → 警告。
+
+**编排作用**：在"提交"这个天然检查点，自动跑多维度质检。AI 想偷偷提交硬编码代码？警告会显示出来。
+
+### 4. `validate-push.sh`（PreToolUse, matcher: Bash）
+
+类似上面，但只在 `git push` 时执行。警告推送到受保护分支（如 main）。
+
+### 5. `validate-assets.sh`（PostToolUse, matcher: Write|Edit）
+
+每次写/编辑文件后触发，但**只在文件路径在 `assets/` 下时真正执行**。校验命名规范和 JSON 结构。
+
+### 6. `validate-skill-change.sh`（PostToolUse, matcher: Write|Edit）
+
+每次写/编辑后触发，但**只在文件路径在 `.claude/skills/` 下时真正执行**。提醒"改了 skill，建议跑 `/skill-test` 验证"。
+
+**编排作用**：防止"改了 skill 引入 bug 但忘了测"。这是元编排——编排系统自己也受钩子守护。
+
+### 7. `pre-compact.sh`（PreCompact）
+
+Claude Code 上下文快满时会自动"压缩"（compact）。压缩前先跑这个钩子，保存会话进度笔记到 `active.md`。
+
+### 8. `post-compact.sh`（PostCompact）
+
+压缩后跑。提醒 AI"从 `active.md` 恢复状态"。
+
+**这两个钩子合起来**：让会话压缩不丢上下文。详见 [08 上下文管理](file:///workspace/study-docs/08-上下文管理艺术.md)。
+
+### 9. `notify.sh`（Notification）
+
+通知事件时跑。Windows 上弹 toast 通知（PowerShell），其他平台无操作。
+
+**编排作用**：长任务跑完通知你。你不用盯着屏幕。
+
+### 10. `session-stop.sh`（Stop）
+
+会话结束时跑。把 `active.md` 归档到会话日志，记录 git 活动。
+
+### 11. `log-agent.sh`（SubagentStart）
+
+每次派生子智能体时跑。记录审计日志开始。
+
+### 12. `log-agent-stop.sh`（SubagentStop）
+
+子智能体结束时跑。完成审计日志记录。
+
+**这两个钩子合起来**：形成完整的子智能体调用审计链。你能事后查"哪个会话派生了哪些子智能体、各跑了多久"。
+
+---
+
+## 钩子的"早退"设计
+
+看 [validate-commit.sh](file:///workspace/.claude/hooks/validate-commit.sh) 的开头：
+
+```bash
+# Only process git commit commands
+if ! echo "$COMMAND" | grep -qE '^git[[:space:]]+commit'; then
+    exit 0
+fi
+```
+
+**这是关键性能优化**。钩子挂在所有 Bash 调用上（matcher: Bash），但 99% 的 Bash 调用不是 `git commit`。脚本第一件事就是判断"是不是 commit"，不是就立即放行。
+
+README 里专门提醒：
+
+> `validate-commit.sh`、`validate-assets.sh`、`validate-skill-change.sh` 在每次 Bash/Write 工具调用时都触发，但路径/命令不相关时立即 exit 0。这是正常的钩子行为，不是性能问题。
+
+**编排启示**：钩子要"挂得广、跑得轻"。匹配条件不满足时必须立即返回，不能做重活。
+
+---
+
+## 跨平台兼容性
+
+看 [validate-commit.sh](file:///workspace/.claude/hooks/validate-commit.sh) 的细节：
+
+```bash
+# 用 jq 如果有，否则降级到 grep
+if command -v jq >/dev/null 2>&1; then
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+else
+    COMMAND=$(echo "$INPUT" | grep -oE '...')
+fi
+
+# 找一个能用的 Python
+for cmd in python python3 py; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+        PYTHON_CMD="$cmd"
+        break
+    fi
+done
+```
+
+**编排启示**：钩子要"优雅降级"。工具缺失时不崩，只是失去部分校验。README 说：
+
+> All hooks fail gracefully if optional tools are missing — nothing breaks, you just lose validation.
+
+---
+
+## 权限规则：钩子的"兄弟"
+
+[settings.json](file:///workspace/.claude/settings.json) 的 `permissions` 是钩子的补充。它不靠脚本，靠模式匹配：
+
+```json
+"permissions": {
+  "allow": [
+    "Bash(git status*)",
+    "Bash(git diff*)",
+    "Bash(python -m pytest*)"
+  ],
+  "deny": [
+    "Bash(rm -rf *)",
+    "Bash(git push --force*)",
+    "Bash(git reset --hard*)",
+    "Bash(sudo *)",
+    "Bash(*>.env*)",
+    "Read(**/.env*)"
+  ]
+}
+```
+
+- **`allow`**：自动放行，不弹确认框（`git status`、跑测试）。
+- **`deny`**：永远禁止，连确认框都不弹（`rm -rf`、强推、读 `.env`）。
+
+**和钩子的分工**：
+- 权限规则管"能不能做"（白名单/黑名单）。
+- 钩子管"做了之后/之前怎么检查"（内容校验）。
+
+**编排启示**：硬危险用权限 deny（一刀切），软风险用钩子警告（给 AI 改正机会）。
+
+---
+
+## 钩子的设计哲学
+
+总结这个项目钩子设计的几条原则：
+
+1. **事件驱动，不侵入**：钩子在天然节点（提交、推送、会话开始/结束）跑，不打断 AI 工作流。
+2. **早退优化**：匹配不满足立即返回，挂得广跑得轻。
+3. **软硬分级**：致命错误 `exit 2` 硬阻止，建议性警告 `exit 0` + stderr。
+4. **优雅降级**：工具缺失不崩，只是失去校验。
+5. **跨平台**：用 POSIX 兼容的 `grep -E`，不用 `grep -P`。
+6. **元守护**：改 skill 的钩子提醒测 skill——编排系统自己也受守护。
+7. **审计可追溯**：SubagentStart/Stop 钩子形成完整审计链。
+
+---
+
+## 小测验
+
+**Q1**：钩子的 `exit 2` 和 `exit 0` 有什么区别？
+> **A**：`exit 2` 硬阻止工具调用，stderr 反馈给 AI；`exit 0` 放行（即使有 stderr 警告也只是显示，不阻止）。只有 `exit 2` 能拦下 AI 的操作。
+
+**Q2**：为什么 `validate-commit.sh` 挂在所有 Bash 调用上（matcher: Bash），但不会拖慢会话？
+> **A**：因为脚本第一件事就是判断"命令是不是 `git commit`"，不是就立即 `exit 0`。99% 的 Bash 调用不是 commit，瞬间返回。这叫"挂得广、跑得轻"。
+
+**Q3**：`pre-compact.sh` 和 `post-compact.sh` 解决什么问题？
+> **A**：会话压缩会丢失上下文。`pre-compact` 在压缩前把进度笔记存到 `active.md`，`post-compact` 在压缩后提醒 AI 从 `active.md` 恢复状态。两个钩子让压缩不丢记忆。
+
+---
+
+## 动手
+
+1. 打开 [validate-commit.sh](file:///workspace/.claude/hooks/validate-commit.sh)，找出哪段是"硬阻止"（exit 2），哪段是"软警告"（exit 0 + stderr）。
+2. 打开 [session-start.sh](file:///workspace/.claude/hooks/session-start.sh)，看它会话开始时显示什么。
+3. 想一想：如果你想加一个"提交前必须跑测试"的钩子，应该挂在哪个事件？matcher 设什么？怎么"早退"？
+
+下一篇 → [06 Rules 路径规则](file:///workspace/study-docs/06-Rules路径规则.md)

--- a/study-docs/06-Rules路径规则.md
+++ b/study-docs/06-Rules路径规则.md
@@ -1,0 +1,187 @@
+# 06 · Rules 路径规则
+
+这一篇讲 11 条规则怎么"按目录"生效。规则是编排里最"细"的一层——它管的是具体代码怎么写。
+
+---
+
+## Rule 是什么
+
+Rule = **按路径生效的编码规范**。每个 `.md` 文件 = 一条规则，靠 frontmatter 的 `paths` 字段决定只在哪些路径下生效。
+
+位置：[.claude/rules/](file:///workspace/.claude/rules/)
+
+**和 hook 的区别**：
+- Hook 是"事件触发"的脚本，在提交/推送时跑。
+- Rule 是"路径触发"的规范，在 AI 写那个路径下的代码时自动加载进上下文。
+
+**类比**：hook 是"门口安检"（进出时检查），rule 是"区域法规"（在那个区域活动时适用）。
+
+---
+
+## Rule 的结构
+
+看 [gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md)：
+
+```markdown
+---
+paths:
+  - "src/gameplay/**"
+---
+
+# Gameplay Code Rules
+
+- ALL gameplay values MUST come from external config/data files, NEVER hardcoded
+- Use delta time for ALL time-dependent calculations (frame-rate independence)
+- NO direct references to UI code — use events/signals for cross-system communication
+- Every gameplay system must implement a clear interface
+- State machines must have explicit transition tables with documented states
+- Write unit tests for all gameplay logic — separate logic from presentation
+- Document which design doc each feature implements in code comments
+- No static singletons for game state — use dependency injection
+
+## Examples
+
+**Correct** (data-driven):
+\`\`\`gdscript
+var damage: float = config.get_value("combat", "base_damage", 10.0)
+\`\`\`
+
+**Incorrect** (hardcoded):
+\`\`\`gdscript
+var damage: float = 25.0   # VIOLATION: hardcoded gameplay value
+\`\`\`
+```
+
+**两部分**：
+
+1. **YAML frontmatter**：`paths` 字段决定生效范围。`src/gameplay/**` = `src/gameplay/` 下所有文件。
+2. **正文**：规则条文 + 正反例。
+
+**关键设计**：规则带**正反例**。AI 看了就知道"这样对、那样错"。比纯条文强得多。
+
+---
+
+## 11 条规则的路径分工
+
+来自 [README.md](file:///workspace/README.md) 的 Path-Scoped Rules 表：
+
+| 路径 | 规则文件 | 强制什么 |
+|------|----------|----------|
+| `src/gameplay/**` | [gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md) | 数据驱动、delta time、不引用 UI、依赖注入 |
+| `src/core/**` | [engine-code.md](file:///workspace/.claude/rules/engine-code.md) | 热路径零分配、线程安全、API 稳定性 |
+| `src/ai/**` | [ai-code.md](file:///workspace/.claude/rules/ai-code.md) | 性能预算、可调试性、数据驱动参数 |
+| `src/networking/**` | [network-code.md](file:///workspace/.claude/rules/network-code.md) | 服务器权威、版本化消息、安全 |
+| `src/ui/**` | [ui-code.md](file:///workspace/.claude/rules/ui-code.md) | 不持有游戏状态、本地化就绪、无障碍 |
+| `design/gdd/**` | [design-docs.md](file:///workspace/.claude/rules/design-docs.md) | 必需 8 章节、公式格式、边界情况 |
+| `tests/**` | [test-standards.md](file:///workspace/.claude/rules/test-standards.md) | 测试命名、覆盖率、fixture 模式 |
+| `prototypes/**` | [prototype-code.md](file:///workspace/.claude/rules/prototype-code.md) | 放松标准、要 README、记录假设 |
+| `assets/**` | [data-files.md](file:///workspace/.claude/rules/data-files.md) | 数据文件规范 |
+| `shaders/**` | [shader-code.md](file:///workspace/.claude/rules/shader-code.md) | 着色器规范 |
+| 叙事相关 | [narrative.md](file:///workspace/.claude/rules/narrative.md) | 叙事文档规范 |
+
+---
+
+## 路径作用域的精妙之处
+
+**核心思想**：不同路径有不同的"严格度"。生产代码严，原型代码松。
+
+对比 [gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md)（生产玩法代码）和 [prototype-code.md](file:///workspace/.claude/rules/prototype-code.md)（原型代码）：
+
+| 维度 | gameplay-code（严） | prototype-code（松） |
+|------|---------------------|----------------------|
+| 数值 | 必须数据驱动，禁止硬编码 | 允许硬编码（快速验证） |
+| 测试 | 必须写单元测试 | 不强制测试 |
+| 文档 | 必须注释对应设计文档 | 只要 README 和假设记录 |
+| 架构 | 必须接口、依赖注入 | 随便写，能跑就行 |
+
+**为什么这么设？** 因为原型是"用完即扔"的，要求它遵守生产标准反而拖慢验证。生产代码是要长期维护的，必须严。
+
+**编排启示**：规则要"因地制宜"。一刀切的规则要么太严（拖慢原型）要么太松（生产代码失控）。按路径分级是正解。
+
+---
+
+## Rule 怎么被加载
+
+Claude Code 在写文件时，会检查：
+
+1. 这个文件路径匹配哪些规则的 `paths`？
+2. 把匹配的规则正文加载进当前上下文。
+3. AI 写代码时遵守这些规则。
+
+**这是隐式的**。AI 不需要"调用"规则，规则自动生效。你只要在 `.claude/rules/` 放对文件，写对应路径时规则就来了。
+
+---
+
+## Rule 和 Hook 的配合
+
+规则和钩子经常配合守护同一件事。以"硬编码数值"为例：
+
+| 层 | 谁 | 干什么 |
+|----|-----|--------|
+| **Rule** | [gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md) | 写 `src/gameplay/` 时告诉 AI"必须数据驱动"，带正反例 |
+| **Hook** | [validate-commit.sh](file:///workspace/.claude/hooks/validate-commit.sh) | 提交时 grep 检测 `damage = 25.0` 这种模式，警告 |
+
+**双重守护**：规则是"写之前的教育"，钩子是"提交时的抽查"。AI 即使没遵守规则，钩子也会在提交时抓住。
+
+**编排启示**：重要规范要"双保险"。软约束（rule）+ 硬约束（hook）组合，比单一约束可靠得多。
+
+---
+
+## Rule 和 Agent 的配合
+
+不同智能体写不同路径，自然受不同规则约束：
+
+| 智能体 | 主要写哪 | 受哪些规则约束 |
+|--------|----------|----------------|
+| `gameplay-programmer` | `src/gameplay/` | gameplay-code |
+| `engine-programmer` | `src/core/` | engine-code |
+| `ai-programmer` | `src/ai/` | ai-code |
+| `network-programmer` | `src/networking/` | network-code |
+| `ui-programmer` | `src/ui/` | ui-code |
+| `game-designer` | `design/gdd/` | design-docs |
+| `qa-tester` | `tests/` | test-standards |
+| `prototyper` | `prototypes/` | prototype-code |
+
+**这是域边界的另一层保障**。不仅 agent 的人设限定它能写哪，规则还限定它在那儿必须怎么写。
+
+---
+
+## 设计文档规则：8 章节强制
+
+看 [design-docs.md](file:///workspace/.claude/rules/design-docs.md) 和 [validate-commit.sh](file:///workspace/.claude/hooks/validate-commit.sh) 的配合。GDD 必须有 8 个章节：
+
+1. Overview
+2. Player Fantasy
+3. Detailed（规则）
+4. Formulas（公式）
+5. Edge Cases（边界情况）
+6. Dependencies（依赖）
+7. Tuning Knobs（调参旋钮）
+8. Acceptance Criteria（验收标准）
+
+**规则**告诉 AI 写 GDD 时要包含这 8 章。**钩子**在提交时检查这 8 章是否存在，缺了警告。
+
+**为什么这么严？** 因为 GDD 是后续所有工作的源头。缺章节意味着设计不完整，会导致实现时猜测、测试时无据。强制 8 章保证设计文档"够用"。
+
+---
+
+## 小测验
+
+**Q1**：为什么 `prototypes/` 下的规则比 `src/gameplay/` 松？
+> **A**：因为原型是"用完即扔"的快速验证，要求生产级标准会拖慢验证节奏。生产代码要长期维护，必须严。规则按路径分级，因地制宜。
+
+**Q2**：规则和钩子怎么配合守护"数据驱动"？
+> **A**：规则（gameplay-code.md）在 AI 写 `src/gameplay/` 代码时教育它"必须数据驱动，带正反例"；钩子（validate-commit.sh）在提交时 grep 检测硬编码模式并警告。软约束 + 硬约束双保险。
+
+**Q3**：`paths: ["src/gameplay/**"]` 里的 `**` 是什么意思？
+> **A**：glob 通配符，匹配任意层级子目录。`src/gameplay/**` = `src/gameplay/` 下所有文件（含子目录）。如果写 `src/gameplay/*` 则只匹配直接子文件，不含子目录。
+
+---
+
+## 动手
+
+1. 打开 [.claude/rules/](file:///workspace/.claude/rules/)，对比 [gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md) 和 [prototype-code.md](file:///workspace/.claude/rules/prototype-code.md) 的规则条文，感受"严"和"松"的差异。
+2. 打开 [design-docs.md](file:///workspace/.claude/rules/design-docs.md)，看 8 章节的具体要求。
+3. 想一想：如果你做一个 Web 项目，你会怎么按路径分规则？比如 `src/components/`、`src/api/`、`src/utils/` 各该有什么规则？
+
+下一篇 → [07 协作协议与人在环](file:///workspace/study-docs/07-协作协议与人在环.md)

--- a/study-docs/07-协作协议与人在环.md
+++ b/study-docs/07-协作协议与人在环.md
@@ -1,0 +1,472 @@
+# 07 · 协作协议与人在环
+
+这是整个项目**最反直觉、也最重要**的一篇。这个系统不是"让 AI 自动干活"，而是"让 AI 提议、人决策"。这一篇拆解协作协议怎么落地。
+
+---
+
+## 核心哲学：协作，不是自治
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md) 开篇：
+
+> This agent architecture is designed for **USER-DRIVEN COLLABORATION**, not autonomous AI generation.
+
+翻译：这套架构是为"**用户驱动的协作**"设计的，不是"AI 自主生成"。
+
+**两种模型的对比**：
+
+```
+✅ 对的模型：协作顾问
+Agent = 专家顾问
+User = 创意总监（最终决策者）
+
+Agent：
+- 问澄清问题
+- 研究并呈现选项
+- 解释权衡和理由
+- 起草提案供审查
+- 等用户批准后才写
+
+User：
+- 做所有创意和战略决策
+- 批准或拒绝 agent 建议
+- 指挥设计愿景
+- 任何东西写入文件前签字
+
+❌ 错的模型：自主生成器
+- Agent 设计完直接写
+- Agent 不问用户就决策
+- Agent 不经批准就写代码
+- 用户只说"做个游戏"然后等
+```
+
+**为什么这么设计？** 因为 AI 自主生成的最大问题是"它猜错了你不知道"。协作模式让 AI 在每个关键点暴露推理，你能及时纠偏。
+
+---
+
+## 五步协作模式
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md)：
+
+```
+Question → Options → Decision → Draft → Approval
+提问      选项       决策       草稿     批准
+```
+
+每一步做什么：
+
+| 步骤 | AI 做 | 用户做 |
+|------|-------|--------|
+| **Question** | 问澄清问题（"核心幻想是什么？实时还是回合制？"） | 回答，给上下文 |
+| **Options** | 给 2-4 个选项，每个带利弊、参考游戏、支柱对齐 | 听完分析 |
+| **Decision** | 给推荐（"我推荐 B 因为..."），但明确"你决定" | 拍板 |
+| **Draft** | 按决策起草（代码/文档/方案） | 审查草稿 |
+| **Approval** | 问"我可以写到 [路径] 吗？" | "可以" / "改 X 再写" |
+
+**关键**：每一步都不能跳。尤其 **Approval 永远不能省**——AI 不能未经批准写文件。
+
+---
+
+## 一个完整的协作范例
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md) 的"crafting system"例子。这是学习协作模式最好的教材。我精简转述：
+
+```
+1. AGENT 问问题
+   "设计制造系统，我需要了解：
+    - 配方是发现还是 NPC 教？
+    - 失败多惩罚？
+    - 实验有资源成本吗？"
+
+2. USER 给上下文
+   "通过实验发现。失败消耗材料但给部分 XP。主要面向探索型玩家。"
+
+3. AGENT 给选项
+   "基于你的目标，三种方案：
+    A. 完全随机发现 — 最大探索奖励，但可能感觉任意
+    B. 食材提示系统 — 奖励观察和推理
+    C. 混合（发现+提示）— 兼顾多种玩家类型
+    哪个最符合你的愿景？"
+
+4. USER 决策
+   "C 感觉对。设 X=5 次失败解锁提示。"
+
+5. AGENT 起草
+   "核心循环：
+    1. 玩家选 2-4 个食材
+    2. 系统查配方库
+    3. 匹配：成功，学配方，给物品，满 XP
+    4. 不匹配：失败，消耗材料，25% XP
+    5. 任意组合失败 5 次后解锁提示
+    公式：success_xp = base_xp * recipe_tier^1.5
+    符合你的意图吗？"
+
+6. USER 细化
+   "循环不错，但 25% XP 太慷慨，改 15%。
+    提示阈值分级：Tier 1 = 5 次，Tier 2+ = 3 次。"
+
+7. AGENT 更新
+   "更新：failure_xp = success_xp * 0.15
+        hint_unlock = 5 if tier==1 else 3
+    继续起草 Edge Cases 还是先细化公式？"
+
+8. USER 批准下一步
+   "公式好了，继续 Edge Cases。"
+
+9. [每个章节重复循环]
+
+10. 最终批准
+    AGENT："GDD 草稿完成。覆盖：概述/幻想/规则/公式/边界/依赖/旋钮/验收。
+           可以写到 design/gdd/crafting-system.md 吗？"
+    USER："可以，写。"
+
+11. AGENT 写文件
+    [用 Write 工具]
+    "已创建 design/gdd/crafting-system.md。要我跑 /design-review 验证吗？"
+```
+
+**注意几个细节**：
+
+- AI **不一次性写完整个文档**，而是逐章节起草、逐章节批准。
+- 每个章节内部也是"起草→审查→修改→批准"的小循环。
+- 写文件前**最后一次明确征求批准**："可以写到 [路径] 吗？"
+- 写完后**主动建议下一步**（"要我跑 /design-review 吗？"）。
+
+---
+
+## 文件写入协议（铁律）
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md) 的"File Writing Protocol"：
+
+```
+NEVER Write Files Without Explicit Approval
+永远不要未经明确批准写文件
+```
+
+每次写文件必须：
+
+```
+1. AGENT："我完成了 [设计/代码/文档]。摘要：
+          [要点]
+          可以写到 [路径] 吗？"
+
+2. USER："可以" / "不，先改 X" / "给我看完整草稿"
+
+3. 如果"可以"：
+   AGENT：[用 Write/Edit 工具]
+          "已写到 [路径]。下一步？"
+
+   如果"不"：
+   AGENT：[按请求改]
+          [回到第 1 步]
+```
+
+**多文件改动**还要额外步骤：
+
+```
+AGENT："这次实现要改 3 个文件：
+       1. src/gameplay/inventory.gd（核心逻辑）
+       2. src/ui/inventory_ui.gd（显示）
+       3. assets/data/inventory_config.json（常量）
+       要我：
+       A) 先看代码再全写
+       B) 一个一个写，每个之间批准
+       C) 现在全写（最快但审查少）
+       复杂功能我推荐 B。"
+```
+
+**编排启示**：复杂改动给用户"审查粒度"选择权。不是一刀切"全批准"或"全拒绝"。
+
+---
+
+## 增量写入：长文档不失忆
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md) 的"Incremental Section Writing"。
+
+写多章节文档（GDD、架构文档、设定集）时：
+
+```
+1. AGENT 先建骨架（所有章节标题，空内容）
+   "可以建 design/gdd/crafting-system.md 骨架吗？"
+   USER："可以"
+
+2. 每个章节：
+   AGENT：[在对话里起草章节]
+   USER：[审查、要求改]
+   AGENT：[改到批准]
+   AGENT："可以把这章写到文件吗？"
+   USER："可以"
+   AGENT：[Edit 写入]
+   AGENT：[更新 production/session-state/active.md 进度]
+   ─── 这章的对话可以安全压缩了 ───
+   ─── 决策已经在文件里 ───
+
+3. 如果会话崩溃或压缩：
+   AGENT：[读文件 — 完成的章节都在]
+   AGENT：[读 active.md — 知道下一步]
+   AGENT："1-4 章完成。开始第 5 章吗？"
+```
+
+**为什么这么做？** 一个 8 章文档带 2-3 轮修改，对话能累积 30-50k tokens。增量写入让活跃上下文只 hold 当前章节的讨论（~3-5k tokens），完成的章节已经落盘。
+
+**这是协作和上下文管理的交汇点**。详见 [08 上下文管理](file:///workspace/study-docs/08-上下文管理艺术.md)。
+
+---
+
+## AskUserQuestion：结构化决策 UI
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md) 的"Structured Decision UI"。
+
+`AskUserQuestion` 是个工具，把决策变成**可选 UI**而不是纯文本。核心模式叫 **Explain → Capture**：
+
+```
+1. Explain（在对话里写完整分析）
+   详细的利弊、理论引用、参考游戏、支柱对齐。
+   推理在这里。
+
+2. Capture（调用 AskUserQuestion）
+   简短的选项标签 + 一句话描述。
+   用户从 UI 选或打字自定义。
+```
+
+**为什么两步？** 因为工具的描述字段太短，装不下完整分析。所以先在对话里展开，再用工具捕获决定。
+
+**什么时候用 AskUserQuestion**：
+
+✅ 用于：
+- 每个有 2-4 选项的决策点
+- 初始澄清问题（受限答案）
+- 一次最多批量 4 个独立问题
+- 下一步选择（"先起草公式还是细化规则？"）
+- 架构决策（"静态工具类还是单例？"）
+- 战略选择（"简化范围、延期、还是砍功能？"）
+
+❌ 不用于：
+- 开放式探索问题（"你对 roguelike 什么感兴趣？"）
+- 单一是/否确认（"可以写文件吗？"）
+- 作为 Task 子智能体运行时（工具可能不可用）
+
+**格式规范**：
+- 标签：1-5 个词（如"混合发现"）
+- 描述：1 句话总结方法和关键权衡
+- 推荐：在推荐选项标签后加"(Recommended)"
+- 多选：选项不互斥时用 `multiSelect: true`
+
+---
+
+## 提问的好模式 vs 坏模式
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md)。
+
+### 好问题
+
+✅ **带理由的多选**：
+```
+"敌人要预警攻击吗？
+ A) 是，提前 0.5s（易上手，节奏感）
+ B) 是，提前 0.2s（紧凑时机，技术向）
+ C) 不预警（纯模式学习，高难度）
+ 哪个符合你的愿景？"
+```
+
+✅ **带权衡的受限选项**：
+```
+"背包系统：
+ 1. 网格（生化危机、暗黑）：空间管理深，慢
+ 2. 列表（天际、辐射）：快，策略性弱
+ 3. 混合（重量+槽位）：中等复杂度
+ 鉴于你的'有意义选择'支柱，我倾向 1 或 3。想法？"
+```
+
+✅ **带上下文的开放问题**：
+```
+"设计文档没说玩家制造时死亡会怎样。
+ 选项：
+ - 材料损失（严，风险/回报）
+ - 材料返还（宽容）
+ - 半成品保存（实现复杂）
+ 哪个符合你的目标难度？"
+```
+
+### 坏问题
+
+❌ **太开放**：
+```
+"战斗系统应该是什么样的？"
+← 太宽，用户不知道从哪开始
+```
+
+❌ **引导/假设**：
+```
+"我用实时战斗，因为这是该 genre 标准。"
+← 没问就假设了
+```
+
+❌ **无上下文的二元**：
+```
+"要技能树吗？是/否？"
+← 没有利弊，没参考支柱
+```
+
+**编排启示**：好问题 = 受限选项 + 权衡 + 参考。坏问题 = 太开放 / 假设 / 无上下文。
+
+---
+
+## Agent 人格指南
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md)。
+
+### 应该是
+
+✅ **协作顾问**：
+- "我建议三种方法，你选"
+- "基于 [理由] 我推荐 X，但你定"
+- "我需要你对 [具体决策] 的输入"
+
+✅ **会解释的专家**：
+- "我推荐 A 因为 [设计理论理由]"
+- "这个方案符合你的'有意义选择'支柱，因为..."
+- "这是 [参考游戏] 怎么处理的，以及为什么有效"
+
+✅ **耐心的迭代者**：
+- "没问题，我改公式。这样如何？"
+- "要我深入那个边界情况，还是这个分辨率够了？"
+
+### 不应该是
+
+❌ **自主执行者**：
+- "我设计好你的战斗系统了 [完成]"
+- "实现并提交了"
+- "我决定用方案 X"
+
+❌ **被动接单员**：
+- "好的" [不问就做]
+- [不问歧义]
+- [不标潜在问题]
+
+---
+
+## Team Skill 里的协作
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md) 末尾。多智能体协同也保持人在环：
+
+```
+USER: "/team-combat '抓钩能力'"
+
+SKILL（协调器）:
+"我来协调战斗团队设计实现抓钩。开始前几个问题：
+ 1. 这是移动工具、战斗工具、还是两者？
+ 2. 拉敌人到玩家、玩家到点、还是两者？
+ 3. 有参考游戏吗？（正当防卫、生化突击队、进击的巨人？）
+
+ [用户答]
+
+ 基于你的回答，我让团队提方案。
+
+ Phase 1: 设计（game-designer）
+ [game-designer 问问题、给选项]
+ [用户决策]
+ game-designer: '设计完成。进架构阶段。'
+
+ Phase 2: 架构（gameplay-programmer）
+ [game-designer 提代码结构]
+ [用户批准或要求改]
+
+ Phase 3: 并行实现
+ 我现在协调 4 个 agent 并行实现：
+ - gameplay-programmer: 核心抓钩物理
+ - technical-artist: 缆绳 VFX
+ - sound-designer: 嗖+撞击 SFX
+ - ai-programmer: 敌人对被抓的反应
+
+ 每个会先给你看再写。继续吗？"
+
+USER: "可以"
+
+[每个 agent 展示工作、获批准、再写]
+
+SKILL:
+"4 个子系统实现完。要我：
+ A) 让 gameplay-programmer 现在集成
+ B) 你先独立测每个
+ C) 集成前跑 /code-review？"
+```
+
+**关键**：编排自动化了，但**决策点始终在用户**。
+
+---
+
+## 协作自检清单
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md) 末尾。每次 agent 交互后检查：
+
+- [ ] agent 问了澄清问题吗？
+- [ ] agent 给了多个带权衡的选项吗？
+- [ ] 你做了最终决定吗？
+- [ ] agent 写文件前获得你批准了吗？
+- [ ] agent 解释了为什么推荐吗？
+
+**任何一个答"否"，说明 agent 不够协作**。
+
+---
+
+## 用户怎么"逼"AI 协作
+
+来自 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md) 末尾。
+
+### 好的用户提示
+
+```
+"我想设计技能树。问我它该怎么工作，然后基于我的回答给选项。"
+
+"提三种背包方案，每个带利弊。"
+
+"实现前给我看提议的架构，解释你的理由。"
+```
+
+### 坏的用户提示（诱发自治）
+
+```
+"做个战斗系统"  ← 没引导，agent 被迫猜
+
+"直接做"  ← 没协作机会
+
+"实现设计文档里的所有东西"  ← 没批准点
+```
+
+**编排启示**：协作是双向的。系统设计得再协作，用户一句"直接做"也会退化成自治。好用户会主动"逼"AI 提问和给选项。
+
+---
+
+## 为什么这个设计反直觉但正确
+
+直觉上，"AI 自治"听起来更高效——你说一句"做个游戏"，AI 全做了。但实践上：
+
+1. **AI 猜错的代价比问一句高得多**。一个猜错的设计可能要 3 天返工。
+2. **小错累积成大错**。每个决策点偏一点，10 个决策后完全跑偏。
+3. **人不参与会失去掌控**。你不知道 AI 为什么这么做，出问题不知道怎么修。
+4. **协作暴露 AI 推理**。每个决策点 AI 都要解释理由，你能及时发现"它的思路不对"。
+
+**类比**：自治像"自动驾驶"，协作像"导航"。自动驾驶你睡着了不知道它开哪去；导航它告诉你下一步怎么走，你随时能改路线。
+
+---
+
+## 小测验
+
+**Q1**：五步协作模式是哪五步？哪一步绝对不能省？
+> **A**：Question → Options → Decision → Draft → Approval。**Approval 绝对不能省**——AI 不能未经批准写文件。
+
+**Q2**：`AskUserQuestion` 的 Explain → Capture 模式为什么是两步？
+> **A**：因为工具的描述字段太短，装不下完整分析。所以先在对话里展开完整利弊分析（Explain），再用工具捕获决定（Capture 简短选项）。
+
+**Q3**：增量写入（逐章节写文档）解决什么问题？
+> **A**：长文档对话会累积 30-50k tokens 撑爆上下文。增量写入让活跃上下文只 hold 当前章节（~3-5k），完成章节已落盘。同时每章单独批准，保持人在环。
+
+---
+
+## 动手
+
+1. 打开 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md)，通读"Pattern: Question → Options → Decision → Draft → Approval"那一节的完整对话范例。
+2. 打开 [creative-director.md](file:///workspace/.claude/agents/creative-director.md)，找"Strategic Decision Workflow"和"Example Interaction Pattern"，看创意总监怎么按五步协作的。
+3. 想一想：如果你让 AI 帮你设计一个 Web 应用的登录系统，你会怎么用"好用户提示"逼它协作？
+
+下一篇 → [08 上下文管理艺术](file:///workspace/study-docs/08-上下文管理艺术.md)

--- a/study-docs/08-上下文管理艺术.md
+++ b/study-docs/08-上下文管理艺术.md
@@ -1,0 +1,286 @@
+# 08 · 上下文管理艺术
+
+这是编排里**最被低估**的一篇。再好的 agent、skill、hook，如果会话上下文爆了或失忆了，全白搭。这个项目示范了非常成熟的上下文管理策略。
+
+---
+
+## 核心问题：上下文是稀缺资源
+
+来自 [context-management.md](file:///workspace/.claude/docs/context-management.md) 开篇：
+
+> Context is the most critical resource in a Claude Code session. Manage it actively.
+
+翻译：上下文是 Claude Code 会话里**最关键的资源**，必须主动管理。
+
+**为什么是核心资源？** 因为 Claude Code 的上下文窗口有限（虽然有压缩机制，但压缩会丢信息）。所有对话、读过的文件、AI 的推理都在上下文里。上下文满了，要么压缩（可能丢关键信息），要么会话崩。
+
+**类比**：上下文像"工作台"。工作台就那么大，堆满了就干不了活。你要主动收拾——把不用的收进抽屉（文件），把要用的摆出来。
+
+---
+
+## 第一策略：文件即记忆
+
+来自 [context-management.md](file:///workspace/.claude/docs/context-management.md)：
+
+> **The file is the memory, not the conversation.** Conversations are ephemeral and will be compacted or lost. Files on disk persist across compactions and session crashes.
+
+翻译：**文件是记忆，不是对话**。对话是短暂的，会被压缩或丢失。磁盘上的文件能跨压缩和崩溃存活。
+
+**这是整个项目上下文管理的根本原则**。所有"重要决策"都必须落盘，不能只存在对话里。
+
+### 会话状态文件：active.md
+
+位置：`production/session-state/active.md`
+
+这是"活的检查点"。每完成一个里程碑就更新：
+
+- 设计章节批准并写入文件
+- 架构决策做出
+- 实现里程碑达成
+- 测试结果获得
+
+状态文件应包含：当前任务、进度清单、关键决策、正在改的文件、未解决的问题。
+
+### 状态栏块（Production+ 阶段）
+
+项目进入 Production/Polish/Release 阶段时，`active.md` 里放一个结构化状态块：
+
+```markdown
+<!-- STATUS -->
+Epic: Combat System
+Feature: Melee Combat
+Task: Implement hitbox detection
+<!-- /STATUS -->
+```
+
+[statusline.sh](file:///workspace/.claude/statusline.sh) 会解析它，在底部状态栏显示面包屑：`Combat System > Melee Combat > Hitboxes`。
+
+**编排启示**：状态栏让"当前在做什么"始终可见。你打开会话第一眼就知道焦点，不用翻对话历史。
+
+### 崩溃恢复
+
+来自 [context-management.md](file:///workspace/.claude/docs/context-management.md) 末尾。会话死了或开新会话继续：
+
+1. `session-start.sh` 钩子自动检测并预览 `active.md`
+2. 读完整状态文件拿上下文
+3. 读状态里列的未完成文件
+4. 从下一个未完成章节/任务继续
+
+**这是"文件即记忆"的终极体现**。会话可以死，只要文件在，就能恢复。
+
+---
+
+## 第二策略：增量写入
+
+来自 [context-management.md](file:///workspace/.claude/docs/context-management.md) 和 [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md)。
+
+写多章节文档时：
+
+```
+1. 立即建骨架（所有章节标题，空内容）
+2. 对话里讨论并起草一个章节
+3. 一批准就写到文件
+4. 更新会话状态文件
+5. 写完一章后，之前关于那章的讨论可以安全压缩——决策在文件里了
+```
+
+**为什么这么做？** 这让上下文只 hold **当前章节**的讨论（~3-5k tokens），而不是整个文档的对话历史（~30-50k tokens）。
+
+**实例**：写一个 8 章的 GDD，每章 2-3 轮修改：
+- 不增量：8 章 × 3 轮 × 平均 2k tokens = 48k tokens 全程在上下文里
+- 增量：每章写完落盘，上下文只 hold 当前章 ~5k tokens
+
+**5 倍以上的上下文节省**。这是长会话能撑住的关键。
+
+---
+
+## 第三策略：主动压缩
+
+来自 [context-management.md](file:///workspace/.claude/docs/context-management.md)：
+
+> Compact proactively at ~60-70% context usage, not reactively at the limit.
+
+**在 60-70% 上下文用量时主动压缩，不要等到极限才被动压缩**。
+
+### 压缩的时机
+
+- **自然压缩点**：写完一节到文件后、提交后、完成任务后、开始新话题前
+- **聚焦压缩**：`/compact Focus on [当前任务] — 1-3 节已写入文件，正在写第 4 节`
+- **任务间清理**：不相关任务之间用 `/clear`
+
+### 压缩时保留什么
+
+来自 [context-management.md](file:///workspace/.claude/docs/context-management.md) 的"Compaction Instructions"。压缩时要在摘要里保留：
+
+- `production/session-state/active.md` 的引用（读它恢复状态）
+- 本次会话改的文件清单及用途
+- 做出的架构决策及理由
+- 活跃冲刺任务及当前状态
+- agent 调用及结果（成功/失败/阻塞）
+- 测试结果（通过/失败数、具体失败）
+- 未解决的阻塞或等用户输入的问题
+- 当前任务和进行到第几步
+- 当前文档哪些章节已写、哪些还在进行
+
+**压缩后**：读 `active.md` 和正在改的文件恢复完整上下文。**文件里有决策，对话历史是次要的**。
+
+---
+
+## 第四策略：钩子辅助压缩
+
+来自 [settings.json](file:///workspace/.claude/settings.json) 和 [05 Hook](file:///workspace/study-docs/05-Hook自动化守卫.md)。
+
+`PreCompact` 和 `PostCompact` 两个钩子让压缩不丢记忆：
+
+```
+上下文快满 → 触发压缩
+              │
+              ▼
+       pre-compact.sh 跑
+       （保存进度笔记到 active.md）
+              │
+              ▼
+       压缩发生（丢部分对话）
+              │
+              ▼
+       post-compact.sh 跑
+       （提醒 AI 从 active.md 恢复状态）
+              │
+              ▼
+       AI 读 active.md，继续工作
+```
+
+**这是钩子和上下文管理的交汇**。钩子把"压缩"这个本来会丢信息的事件，变成"先存档再压缩再读档"的安全操作。
+
+---
+
+## 第五策略：子智能体委派
+
+来自 [context-management.md](file:///workspace/.claude/docs/context-management.md) 的"Subagent Delegation"：
+
+> Use subagents for research and exploration to keep the main session clean.
+
+**用子智能体做研究和探索，保持主会话干净**。子智能体跑在独立上下文窗口里，只返回摘要：
+
+- **用子智能体**：跨多文件调查、探索陌生代码、研究要消耗 >5k tokens 文件读取时
+- **直接读**：你确切知道要查哪 1-2 个文件时
+- **子智能体不继承对话历史**——必须在 prompt 里给完整上下文
+
+**编排启示**：主会话是"指挥官"，子智能体是"侦察兵"。侦察兵出去探路，回来只报告结论。探路过程的细节不污染指挥官的上下文。
+
+**实例**：`/dev-story` 派 `gameplay-programmer` 子智能体写代码。子智能体读 ADR、读控制清单、写代码、写测试——这些都在它自己的上下文里。它只返回"改了哪些文件、测试结果、有没有阻塞"的摘要给主会话。
+
+---
+
+## 上下文预算
+
+来自 [context-management.md](file:///workspace/.claude/docs/context-management.md)：
+
+| 任务类型 | 启动预算 |
+|----------|----------|
+| 轻（读/评审） | ~3k tokens |
+| 中（实现功能） | ~8k tokens |
+| 重（多系统重构） | ~15k tokens |
+
+**编排启示**：不同任务消耗不同。重型任务要预留更多上下文空间，更早压缩。
+
+---
+
+## 状态文件实战：dev-story 的 Phase 7
+
+看 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md) 的 Phase 7：
+
+```
+## Phase 7: Update Session State
+
+Silently append to production/session-state/active.md:
+
+## Session Extract — /dev-story [date]
+- Story: [story-path] — [story title]
+- Files changed: [comma-separated list]
+- Test written: [path, or "None — Visual/Feel/Config story"]
+- Blockers: [None, or description]
+- Next: /code-review [files] then /story-done [story-path]
+
+Create active.md if it does not exist. Confirm: "Session state updated."
+```
+
+**关键设计**：
+
+1. **悄悄追加**（Silently append）——不打断用户，不要求批准。状态记录是元操作，不需要人在环。
+2. **结构化格式**——固定字段，方便后续解析。
+3. **包含"下一步"**——`Next: /code-review [files] then /story-done [story-path]`。会话崩溃后，AI 读 active.md 就知道下一步该干啥。
+4. **不存在就建**——`Create active.md if it does not exist`。
+
+**这是"文件即记忆"的落地范例**。每个 skill 都在关键节点更新 active.md，形成连续的状态链。
+
+---
+
+## 状态栏：上下文用量的实时可见
+
+来自 [settings.json](file:///workspace/.claude/settings.json)：
+
+```json
+"statusLine": {
+  "type": "command",
+  "command": "bash .claude/statusline.sh"
+}
+```
+
+[statusline.sh](file:///workspace/.claude/statusline.sh) 在底部状态栏显示：
+
+- 上下文用量百分比（让你知道何时该压缩）
+- 当前模型
+- 项目阶段
+- Epic > Feature > Task 面包屑
+
+**编排启示**：上下文用量必须**实时可见**。看不见就会用爆。状态栏是"上下文仪表盘"。
+
+---
+
+## 上下文管理的五条铁律
+
+总结这个项目的上下文管理智慧：
+
+1. **文件是记忆，对话是临时**——所有重要决策必须落盘。
+2. **增量写入**——长文档逐章节写，每章写完落盘，上下文只 hold 当前章。
+3. **主动压缩**——60-70% 就压，不要等极限。自然点（写完章节、提交后）最佳。
+4. **子智能体隔离**——重读取的研究委派给子智能体，主会话只收摘要。
+5. **钩子辅助压缩**——PreCompact 存档，PostCompact 提醒读档。
+
+---
+
+## 为什么这对编排至关重要
+
+编排的本质是"让多个智能体协同完成大任务"。大任务意味着长会话。长会话意味着上下文管理是生死攸关的：
+
+- **没有文件即记忆**：会话一压缩，AI 忘了之前决策，重复或矛盾。
+- **没有增量写入**：长文档一次性写，上下文爆，写不完。
+- **没有主动压缩**：等到极限被动压缩，关键信息可能丢。
+- **没有子智能体隔离**：主会话被研究细节撑爆。
+- **没有钩子辅助**：压缩时没存档，恢复时丢状态。
+
+**这个项目能撑起 49 个智能体、7 阶段流水线、长文档协作，靠的就是这套上下文管理**。它不性感，但是编排的"地基"。
+
+---
+
+## 小测验
+
+**Q1**：为什么"文件即记忆"比"对话即记忆"可靠？
+> **A**：对话是短暂的，会被压缩或丢失；文件能跨压缩和崩溃存活。重要决策只存在对话里，压缩后就可能忘。落盘才能恢复。
+
+**Q2**：增量写入怎么节省上下文？
+> **A**：长文档逐章节写，每章写完落盘。完成后那章的讨论可以安全压缩（决策在文件里）。上下文只 hold 当前章节讨论（~3-5k），而不是整个文档历史（~30-50k）。5 倍以上节省。
+
+**Q3**：`PreCompact` 和 `PostCompact` 钩子各干什么？
+> **A**：`PreCompact` 在压缩前把进度笔记存到 active.md（存档）；`PostCompact` 在压缩后提醒 AI 从 active.md 恢复状态（读档）。两个钩子让压缩不丢记忆。
+
+---
+
+## 动手
+
+1. 打开 [context-management.md](file:///workspace/.claude/docs/context-management.md)，通读"File-Backed State"和"Incremental File Writing"两节。
+2. 打开 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md)，找 Phase 7，看它怎么"悄悄追加"active.md。
+3. 想一想：如果你做一个长会话项目（比如写一本书），你会怎么用 active.md + 增量写入 + 主动压缩管理上下文？
+
+下一篇 → [09 实战案例剖析](file:///workspace/study-docs/09-实战案例剖析.md)

--- a/study-docs/09-实战案例剖析.md
+++ b/study-docs/09-实战案例剖析.md
@@ -1,0 +1,419 @@
+# 09 · 实战案例剖析
+
+前八篇讲了"零件"。这一篇把零件组装起来，看两个核心 skill 的完整运行流程。这是检验你理解程度的"综合题"。
+
+---
+
+## 案例 A：`/dev-story` —— 单智能体实现一个故事
+
+这是项目里**最高频**的 skill：读一个故事文件，实现它。来自 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md)。
+
+### 场景设定
+
+假设你正在做一款动作游戏，有一个故事文件：
+
+```
+production/epics/combat/melee-hitbox.md
+```
+
+故事标题："实现近战命中检测"，类型 Logic，层 Core，TR-ID 是 `TR-COMBAT-003`，治理 ADR 是 `adr-002-melee-combat.md`。
+
+你敲：`/dev-story production/epics/combat/melee-hitbox.md`
+
+### Phase 1：找故事
+
+skill 有参数，直接读那个文件。
+
+**如果没参数**：查 `production/session-state/active.md` 找当前故事；没有就 glob `production/epics/**/*.md`，列出所有 `Status: Ready` 的故事让你选。
+
+### Phase 2：加载完整上下文
+
+**这是最关键的一步**。实现前必须把上下文加载齐。skill 先校验必需文件存在：
+
+| 文件 | 路径 | 缺了怎么办 |
+|------|------|------------|
+| TR registry | `docs/architecture/tr-registry.yaml` | **停**——"跑 /architecture-review 引导生成" |
+| 治理 ADR | `docs/architecture/adr-002-melee-combat.md` | **停**——"跑 /architecture-decision 创建" |
+| 控制清单 | `docs/architecture/control-manifest.md` | **警告但继续** |
+
+如果 TR registry 或 ADR 缺失，把故事状态设为 BLOCKED，**不派任何程序员**。
+
+**然后并行读**（独立读取，一起发）：
+- 故事文件（标题、ID、层、类型、TR-ID、验收标准、依赖、Out of Scope）
+- TR registry（查 TR-COMBAT-003 的最新需求——这是真源，不信故事文件内联文本，可能过时）
+- 治理 ADR（决策 + 实现指南 + 引擎兼容性）
+- 控制清单（Core 层的必需/禁止模式）
+- 引擎偏好（命名规范、性能预算）
+
+**依赖校验**：故事的依赖如果没完成，用 `AskUserQuestion` 问你：
+- A) 继续 anyway（接受依赖风险）
+- B) 停下，先完成依赖
+- C) 依赖其实做完了只是状态没更新
+
+**清单版本校验**：故事的清单版本和当前清单不一致，问你：
+- A) 更新故事版本，用新规则实现（推荐）
+- B) 用旧规则实现（接受不合规风险）
+- C) 停下，先看 diff
+
+**悄悄更新两处**：
+- `production/sprint-status.yaml`（如果存在）：故事状态改 `in_progress`
+- 故事文件本身：`Last Updated:` 改今天日期
+
+### Phase 3：路由到正确的程序员
+
+**用路由表**：
+
+| 故事上下文 | 派给 |
+|------------|------|
+| Foundation 层 | `engine-programmer` |
+| 任何层 - UI 类型 | `ui-programmer` |
+| 任何层 - Visual/Feel | `gameplay-programmer` |
+| Core/Feature - 玩法机制 | `gameplay-programmer` |
+| Core/Feature - AI 行为 | `ai-programmer` |
+| Core/Feature - 网络 | `network-programmer` |
+| Config/Data | 不派 agent，直接改数据文件 |
+
+我们的故事是 Core 层、Logic 类型、玩法机制 → 派 `gameplay-programmer`。
+
+**引擎专家副手**：读 ADR，如果引擎风险 HIGH，强制派引擎专家验证。比如 ADR 假设了 Godot 4.6 的某个 API，但 4.6 改了，需要 `godot-specialist` 确认。
+
+### Phase 4：实现
+
+通过 `Task` 工具派生子智能体。**关键：给路径，不给内容**——让子智能体自己读：
+
+```
+Task(subagent_type=gameplay-programmer, prompt="""
+1. 故事文件：production/epics/combat/melee-hitbox.md — 完整读
+2. GDD 需求：查 TR-COMBAT-003 在 docs/architecture/tr-registry.yaml — 用 requirement 字段
+3. ADR：docs/architecture/adr-002-melee-combat.md — 只读 Decision 和 Implementation Guidelines
+4. 控制清单：docs/architecture/control-manifest.md — 只读 Core 层规则
+5. 引擎偏好：.claude/docs/technical-preferences.md — 命名规范和性能预算
+6. 测试文件路径：tests/combat/melee_hitbox_test.gd — 必须创建
+7. 测试要求：每个验收标准至少一个测试函数。命名 test_[scenario]_[expected]。无随机种子、无时间依赖、无外部 IO
+8. 明确指令：按 ADR 指南实现，尊重清单规则，不越 Out of Scope 边界
+""")
+```
+
+子智能体（`gameplay-programmer`）在它自己的上下文里：
+- 读这些文件
+- 按 ADR 实现指南写代码到 `src/gameplay/combat/melee_hitbox.gd`
+- 写测试到 `tests/combat/melee_hitbox_test.gd`
+- **写之前问你**："我可以写到 src/gameplay/combat/melee_hitbox.gd 吗？"（协作协议）
+- 写完返回摘要
+
+**注意**：子智能体写 `src/gameplay/` 下的代码时，[gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md) 规则自动生效——必须数据驱动、用 delta time、不引用 UI。
+
+### Phase 5：测试证据
+
+不同故事类型要求不同证据。我们的 Logic 类型 → **阻塞**，必须有自动化单元测试。
+
+### Phase 6：汇总
+
+子智能体返回后，主会话收集：
+- 改了哪些文件（`src/gameplay/combat/melee_hitbox.gd` 创建，`tests/combat/melee_hitbox_test.gd` 创建）
+- 测试文件（路径 + 测试函数数）
+- 是否越界（应该没有）
+- 引擎风险（应该没有）
+- 阻塞（应该没有）
+
+输出结构化摘要：
+
+```
+## Implementation Complete: 实现近战命中检测
+
+**Files changed**:
+- src/gameplay/combat/melee_hitbox.gd — 创建（命中检测核心逻辑）
+- tests/combat/melee_hitbox_test.gd — 测试文件（5 个测试函数）
+
+**Acceptance criteria covered**:
+- [x] 命中框在攻击启动后 3 帧激活 — implemented in melee_hitbox.gd:_activate_hitbox
+- [x] 命中框持续 5 帧 — covered by test_hitbox_duration
+- [x] 同一攻击内每个目标只受一次伤害 — covered by test_single_hit_per_target
+- ...
+
+**Deviations from scope**: None
+**Engine risks flagged**: None
+**Blockers**: None
+
+**Before running /story-done:** 本地跑测试确认通过。
+
+Ready for: /code-review src/gameplay/combat/melee_hitbox.gd then /story-done production/epics/combat/melee-hitbox.md
+```
+
+### Phase 7：更新会话状态
+
+悄悄追加到 `production/session-state/active.md`：
+
+```
+## Session Extract — /dev-story 2026-06-22
+- Story: production/epics/combat/melee-hitbox.md — 实现近战命中检测
+- Files changed: src/gameplay/combat/melee_hitbox.gd, tests/combat/melee_hitbox_test.gd
+- Test written: tests/combat/melee_hitbox_test.gd
+- Blockers: None
+- Next: /code-review src/gameplay/combat/melee_hitbox.gd then /story-done production/epics/combat/melee-hitbox.md
+```
+
+### 完整编排链路图
+
+```
+用户敲 /dev-story [path]
+        │
+        ▼
+   Phase 1: 读故事文件
+        │
+        ▼
+   Phase 2: 校验 + 并行读 5 个上下文文件
+        │  (TR registry / ADR / 控制清单 / 引擎偏好 / 故事)
+        │
+        ├─ 依赖校验 → AskUserQuestion
+        ├─ 清单版本校验 → AskUserQuestion
+        │
+        ▼
+   Phase 3: 路由表 → gameplay-programmer
+        │  (引擎风险 HIGH 时加派 godot-specialist)
+        │
+        ▼
+   Phase 4: Task 派生子智能体
+        │
+        │  子智能体在自己上下文里：
+        │  ├─ 读 5 个文件
+        │  ├─ 问"可以写吗"（协作协议）
+        │  ├─ 写代码（gameplay-code 规则自动生效）
+        │  ├─ 写测试
+        │  └─ 返回摘要
+        │
+        ▼
+   Phase 5: 校验测试证据（Logic 类型阻塞）
+        │
+        ▼
+   Phase 6: 汇总结构化报告
+        │
+        ▼
+   Phase 7: 悄悄追加 active.md
+        │
+        ▼
+   提示用户下一步：/code-review → /story-done
+```
+
+**这个流程体现了编排的所有要素**：
+- **路由**：按故事层/类型派对的 agent
+- **上下文管理**：并行读、子智能体隔离、状态落盘
+- **协作**：版本不一致、依赖未完成都问你
+- **规则**：gameplay-code 自动生效
+- **韧性**：缺文件 BLOCKED、错误恢复协议
+
+---
+
+## 案例 B：`/team-combat` —— 多智能体协同做一个功能
+
+这是编排的高阶形态：7 个智能体协同做一个战斗功能。来自 [team-combat/SKILL.md](file:///workspace/.claude/skills/team-combat/SKILL.md)。
+
+### 场景设定
+
+你敲：`/team-combat 抓钩能力`
+
+### Phase 0：解析 review 模式
+
+1. 命令行有 `--review solo`？用 solo
+2. 否则读 `production/review-mode.txt`
+3. 否则默认 `lean`
+
+模式决定派不派总监门禁。
+
+### 团队组成
+
+```
+game-designer        设计机制
+gameplay-programmer  实现核心代码
+ai-programmer        实现 NPC AI
+technical-artist     做 VFX
+sound-designer       定义音频事件
+engine specialist    验证引擎惯用法（从 technical-preferences.md 读）
+qa-tester            写测试、验证
+```
+
+### Phase 1：设计
+
+派 `game-designer` 子智能体：
+- 创建/更新 `design/gdd/grapple-system.md`
+- 覆盖：机制概述、玩家幻想、详细规则、公式、边界情况、依赖、调参旋钮、验收标准
+
+子智能体按协作协议工作：问你问题、给选项、起草、获批准、写文件。
+
+### Phase 2：架构
+
+派 `gameplay-programmer`（涉及 AI 时加 `ai-programmer`）：
+- 评审设计文档
+- 设计代码架构：类结构、接口、数据流
+- 识别与现有系统的集成点
+- 输出：架构草图 + 文件清单 + 接口定义
+
+**然后派引擎专家验证架构**：
+- 类/节点/组件结构对引擎惯用吗？（Godot 节点层级 / Unity MonoBehaviour vs DOTS / Unreal Actor/Component）
+- 有引擎原生系统该用而不是自定义实现吗？
+- 提议的 API 在锁定引擎版本里废弃或改了吗？
+- 输出：引擎架构笔记，并入架构
+
+**用 `AskUserQuestion` 问你**：
+- A) 继续——派实现 agent（gameplay + ai + tech-artist + sound）
+- B) 先改架构
+- C) 停下，稍后继续
+
+**只有你选 A 才进 Phase 3**。
+
+### Phase 3：并行实现
+
+**这是编排的精华**。4 个独立子智能体**同时**派生：
+
+```
+Task(gameplay-programmer)  ← 实现核心抓钩物理
+Task(ai-programmer)        ← 实现敌人对被抓的反应
+Task(technical-artist)     ← 做缆绳 VFX
+Task(sound-designer)       ← 定义嗖+撞击 SFX
+```
+
+**为什么能并行？** 因为这 4 个的输入互不依赖——玩法代码、AI、VFX、音频可以同时开工。符合"并行任务协议"：独立就并行，先发后等。
+
+每个子智能体在各自上下文里：
+- 读设计文档和架构草图
+- 按协作协议问你"可以写吗"
+- 写代码/资产
+- 返回摘要
+
+### Phase 4：集成
+
+把 4 个子系统接起来：
+- 玩法代码 + AI + VFX + 音频
+- 确保所有调参旋钮暴露且数据驱动
+- 验证与现有战斗系统兼容
+
+### Phase 5：验证
+
+派 `qa-tester`：
+- 从验收标准写测试用例
+- 测设计文档里的所有边界情况
+- 验证性能影响在预算内
+- 发现问题报 bug
+
+### Phase 6：签字
+
+收集所有团队成员结果：
+- 报告功能状态：COMPLETE / NEEDS WORK / BLOCKED
+- 列出未决问题和负责人
+
+### 错误恢复
+
+任何子智能体 BLOCKED：
+1. 立即上报"[AgentName]: BLOCKED — [原因]"
+2. 评估依赖：被阻塞输出是否被后续需要
+3. `AskUserQuestion` 给三选项：跳过标注缺口 / 更窄范围重试 / 停下解决
+4. **总出部分报告**——哪怕部分阻塞
+
+### 完整编排链路图
+
+```
+用户敲 /team-combat 抓钩能力
+        │
+        ▼
+   Phase 0: 解析 review 模式
+        │
+        ▼
+   Phase 1: 设计
+   Task(game-designer) → 写 GDD
+        │  (协作协议：问、选项、批准、写)
+        ▼
+   Phase 2: 架构
+   Task(gameplay-programmer + ai-programmer) → 架构草图
+   Task(engine specialist) → 验证引擎惯用法
+        │
+        ├─ AskUserQuestion: 批准架构？
+        │  (用户选 A 才继续)
+        ▼
+   Phase 3: 并行实现（4 个 Task 同时发）
+   ┌─ Task(gameplay-programmer) → 核心物理
+   ├─ Task(ai-programmer)        → 敌人反应
+   ├─ Task(technical-artist)     → 缆绳 VFX
+   └─ Task(sound-designer)       → 音频事件
+        │  (各自协作协议、各自上下文)
+        ▼
+   Phase 4: 集成
+        │
+        ▼
+   Phase 5: 验证
+   Task(qa-tester) → 写测试、跑测试、报 bug
+        │
+        ▼
+   Phase 6: 签字
+   汇总：COMPLETE / NEEDS WORK / BLOCKED
+```
+
+### 两个案例的对比
+
+| 维度 | `/dev-story` | `/team-combat` |
+|------|--------------|----------------|
+| 智能体数 | 1（+可选引擎专家） | 7 |
+| 并行性 | 串行 | Phase 3 并行 4 个 |
+| 输入 | 已有故事文件 | 一句功能描述 |
+| 起点 | 实现阶段 | 设计阶段 |
+| Phase 间批准 | 隐式 | 显式 AskUserQuestion |
+| 适用 | 实现明确的故事 | 做一个跨领域功能 |
+| 复杂度 | 中 | 高 |
+
+---
+
+## 编排模式总结
+
+从这两个案例能提炼出**编排的核心模式**：
+
+### 模式 1：上下文打包
+实现前把所有相关文件**并行读**齐。少读一个 = 代码漂离设计。
+
+### 模式 2：路由表
+按任务的层/类型/系统，用明确路由表派对的 agent。不靠 AI 猜。
+
+### 模式 3：子智能体隔离
+重活委派给子智能体，主会话只收摘要。上下文不污染。
+
+### 模式 4：并行独立任务
+输入互不依赖的子智能体**同时**派生。先发后等。
+
+### 模式 5：Phase 间批准门
+每个 Phase 转换用 `AskUserQuestion` 让用户确认。人在环。
+
+### 模式 6：错误恢复协议
+任何子智能体 BLOCKED 立即上报，给三选项，总出部分报告。不静默吞错。
+
+### 模式 7：状态落盘
+关键节点悄悄追加 `active.md`。文件即记忆。
+
+### 模式 8：规则自动生效
+子智能体写 `src/gameplay/` 时，gameplay-code 规则自动加载。不靠自觉。
+
+### 模式 9：双保险
+重要规范 rule（教育）+ hook（抽查）双守护。
+
+### 模式 10：可调严格度
+review mode（full/lean/solo）给用户"严格度旋钮"。
+
+---
+
+## 小测验
+
+**Q1**：`/dev-story` 的 Phase 2 为什么要在实现前读那么多文件？
+> **A**：因为"上下文不全 = 代码漂离设计"。故事的验收标准可能过时（查 TR registry 最新需求），实现方式必须遵循 ADR，编码必须符合控制清单的层级规则。少读一个就可能写出不符合设计的代码。
+
+**Q2**：`/team-combat` 的 Phase 3 为什么能并行派 4 个智能体？
+> **A**：因为这 4 个（gameplay-programmer / ai-programmer / technical-artist / sound-designer）输入互不依赖——玩法代码、AI、VFX、音频可同时开工。符合"并行任务协议"：独立就并行，先发后等。
+
+**Q3**：如果 `/team-combat` 的 `technical-artist` 返回 BLOCKED，编排器怎么做？
+> **A**：1) 立即上报"technical-artist: BLOCKED — 原因"；2) 评估 VFX 是否被后续集成阶段需要（是）；3) AskUserQuestion 给三选项：跳过标注缺口 / 更窄范围重试 / 停下解决；4) 总出部分报告，不丢弃已完成的部分。
+
+---
+
+## 动手
+
+1. 打开 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md)，通读 7 个 Phase，对照本篇看是否对得上。
+2. 打开 [team-combat/SKILL.md](file:///workspace/.claude/skills/team-combat/SKILL.md)，找 Phase 3 的并行派生描述，看它怎么写"parallel where possible"。
+3. 打开 [docs/examples/](file:///workspace/docs/examples/) 目录，看 [session-implement-combat-damage.md](file:///workspace/docs/examples/session-implement-combat-damage.md) 这种"会话范例"，对照本篇理解真实会话怎么走。
+
+下一篇 → [10 学习路径与练习](file:///workspace/study-docs/10-学习路径与练习.md)

--- a/study-docs/10-学习路径与练习.md
+++ b/study-docs/10-学习路径与练习.md
@@ -1,0 +1,167 @@
+# 10 · 学习路径与练习
+
+这是最后一篇。给你一条从"小白"到"能自己搭编排"的阶梯路径，配自检清单和练习任务。
+
+---
+
+## 学习路径：四个阶段
+
+### 阶段 1：读懂（理解概念）
+
+**目标**：能用自己的话解释 Claude Code 编排的六大部件。
+
+**怎么学**：
+1. 按顺序读 [01](file:///workspace/study-docs/01-项目概览.md) 到 [09](file:///workspace/study-docs/09-实战案例剖析.md)。
+2. 每篇读完做"小测验"，不看答案先答。
+3. 每篇的"动手"任务都做一遍。
+
+**自检清单**（都能答"是"就过关）：
+- [ ] 我能说出 `.claude/` 下六个子目录各放什么
+- [ ] 我能解释 `CLAUDE.md` 里 `@路径` 引用语法的作用
+- [ ] 我能说出 agent 三层层级各管什么
+- [ ] 我能解释"垂直委派"和"横向咨询"的区别
+- [ ] 我能说出 hook 的 `exit 0` 和 `exit 2` 区别
+- [ ] 我能解释 rule 的 `paths` 字段怎么决定生效范围
+- [ ] 我能背出五步协作模式（Question→Options→Decision→Draft→Approval）
+- [ ] 我能说出"文件即记忆"为什么比"对话即记忆"可靠
+- [ ] 我能说出 `/dev-story` 的 7 个 Phase 各干什么
+- [ ] 我能解释 `/team-combat` 的 Phase 3 为什么能并行
+
+### 阶段 2：拆解（看懂实现）
+
+**目标**：能对着源文件讲清楚某个 agent/skill/hook 的设计意图。
+
+**怎么学**：
+1. 选 3 个不同层级的 agent（如 [creative-director.md](file:///workspace/.claude/agents/creative-director.md)、[game-designer.md](file:///workspace/.claude/agents/game-designer.md)、[qa-tester.md](file:///workspace/.claude/agents/qa-tester.md)），对比它们的 frontmatter（tools/model/maxTurns/disallowedTools）和正文结构，解释为什么这么设。
+2. 选 2 个 skill（如 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md) 和 [team-combat/SKILL.md](file:///workspace/.claude/skills/team-combat/SKILL.md)），对比单智能体调度和多智能体协同的写法差异。
+3. 选 2 个 hook（如 [validate-commit.sh](file:///workspace/.claude/hooks/validate-commit.sh) 和 [session-start.sh](file:///workspace/.claude/hooks/session-start.sh)），找出它们的"早退点"和"硬阻止点"。
+4. 读 [docs/examples/](file:///workspace/docs/examples/) 下的会话范例，对照真实会话理解流程。
+
+**自检清单**：
+- [ ] 我能解释为什么 `creative-director` 禁用 Bash
+- [ ] 我能解释为什么 `qa-tester` 用 Haiku 模型
+- [ ] 我能指出 `/dev-story` Phase 2 的两个"校验点"（依赖、清单版本）
+- [ ] 我能解释 `/team-combat` Phase 0 的 review 模式怎么解析
+- [ ] 我能找出 `validate-commit.sh` 哪段是 `exit 2`、哪段是 `exit 0` + stderr
+- [ ] 我能解释 [gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md) 和 [prototype-code.md](file:///workspace/.claude/rules/prototype-code.md) 为什么严格度不同
+
+### 阶段 3：改造（动手修改）
+
+**目标**：能在这个项目基础上做小修改，验证理解。
+
+**练习任务**（由易到难）：
+
+#### 任务 1：加一条规则
+在 [.claude/rules/](file:///workspace/.claude/rules/) 加一个 `docs-code.md`，paths 设 `docs/**`，规则是"所有代码示例必须带语言标签"。参考 [gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md) 的结构，带正反例。
+
+**验证**：让 AI 写 `docs/` 下的 markdown，看它是否自动遵守"带语言标签"。
+
+#### 任务 2：加一个 hook
+在 [.claude/hooks/](file:///workspace/.claude/hooks/) 加一个 `check-todo.sh`，挂在 `PreToolUse` matcher `Bash`，只在命令是 `git commit` 时执行，检查 `src/` 下是否有裸 TODO（不带 owner），有就 `exit 2` 阻止。参考 [validate-commit.sh](file:///workspace/.claude/hooks/validate-commit.sh) 的"早退"模式。
+
+**验证**：故意留一个 `TODO` 在 src/ 下提交，看是否被拦。
+
+#### 任务 3：加一个 agent
+在 [.claude/agents/](file:///workspace/.claude/agents/) 加一个 `data-engineer.md`，负责数据管道和 ETL。参考 [analytics-engineer.md](file:///workspace/.claude/agents/analytics-engineer.md) 的结构。frontmatter 设：model sonnet，tools Read/Glob/Grep/Write/Edit，disallowedTools Bash。
+
+**验证**：在某个 skill 里 `Task(subagent_type=data-engineer)`，看能否派生。
+
+#### 任务 4：改一个 skill
+选 [skills/help/SKILL.md](file:///workspace/.claude/skills/help/SKILL.md)，加一个"显示当前 review 模式"的功能（读 `production/review-mode.txt`）。
+
+**验证**：敲 `/help`，看是否显示当前 review 模式。
+
+### 阶段 4：迁移（自己设计）
+
+**目标**：能把这套编排思想迁移到非游戏项目。
+
+**练习**：选一个你熟悉的领域（Web 开发、数据分析、写作、研究），设计一个简化版编排：
+
+1. **定义 3-5 个 agent**：比如 Web 项目可以有 `frontend-engineer`、`backend-engineer`、`designer`、`qa`。每个写 frontmatter（tools/model）+ 人设。
+2. **定义 2-3 个 skill**：比如 `/implement-feature`、`/review-pr`。每个写分 Phase 的流程。
+3. **定义 1-2 个 hook**：比如提交前检查 lint。
+4. **定义 1-2 个 rule**：比如 `src/components/**` 下必须用函数组件。
+5. **写一个 CLAUDE.md**：定项目调子，用 `@` 引用子文档。
+
+**验证**：在一个空项目里部署你的编排，跑一遍 `/implement-feature`，看是否按预期工作。
+
+---
+
+## 关键概念速查表
+
+| 概念 | 一句话 | 详见 |
+|------|--------|------|
+| `CLAUDE.md` | 项目章程，第一个被读 | [02](file:///workspace/study-docs/02-Claude-Code基础概念.md) |
+| `@路径` | 引用语法，把子文件加载进上下文 | [02](file:///workspace/study-docs/02-Claude-Code基础概念.md) |
+| `settings.json` | 机器配置（权限/钩子/状态栏） | [02](file:///workspace/study-docs/02-Claude-Code基础概念.md) |
+| Agent 三层 | 总监/主管/专家 | [03](file:///workspace/study-docs/03-Agent编排体系.md) |
+| 垂直委派 | 不跳层，主管派专家 | [03](file:///workspace/study-docs/03-Agent编排体系.md) |
+| 横向咨询 | 同级可问不可命令 | [03](file:///workspace/study-docs/03-Agent编排体系.md) |
+| 冲突升级 | 找共同上级 | [03](file:///workspace/study-docs/03-Agent编排体系.md) |
+| 域边界 | 不改别人家文件 | [03](file:///workspace/study-docs/03-Agent编排体系.md) |
+| Skill | `/命令` 触发的 SOP | [04](file:///workspace/study-docs/04-Skill技能系统.md) |
+| workflow-catalog | 7 阶段流水线定义 | [04](file:///workspace/study-docs/04-Skill技能系统.md) |
+| artifact | 用文件 glob 判断步骤完成 | [04](file:///workspace/study-docs/04-Skill技能系统.md) |
+| 路由表 | 按层/类型派 agent | [04](file:///workspace/study-docs/04-Skill技能系统.md) / [09](file:///workspace/study-docs/09-实战案例剖析.md) |
+| review mode | full/lean/solo 严格度旋钮 | [04](file:///workspace/study-docs/04-Skill技能系统.md) |
+| Hook | 事件驱动的自动脚本 | [05](file:///workspace/study-docs/05-Hook自动化守卫.md) |
+| `exit 2` | 硬阻止 | [05](file:///workspace/study-docs/05-Hook自动化守卫.md) |
+| `exit 0` + stderr | 软警告 | [05](file:///workspace/study-docs/05-Hook自动化守卫.md) |
+| 早退优化 | 挂得广跑得轻 | [05](file:///workspace/study-docs/05-Hook自动化守卫.md) |
+| Rule `paths` | 按路径生效的规范 | [06](file:///workspace/study-docs/06-Rules路径规则.md) |
+| 五步协作 | Question→Options→Decision→Draft→Approval | [07](file:///workspace/study-docs/07-协作协议与人在环.md) |
+| AskUserQuestion | Explain→Capture 结构化决策 | [07](file:///workspace/study-docs/07-协作协议与人在环.md) |
+| 文件即记忆 | 文件是记忆，对话是临时 | [08](file:///workspace/study-docs/08-上下文管理艺术.md) |
+| active.md | 会话状态检查点 | [08](file:///workspace/study-docs/08-上下文管理艺术.md) |
+| 增量写入 | 逐章节写，上下文只 hold 当前章 | [08](file:///workspace/study-docs/08-上下文管理艺术.md) |
+| 主动压缩 | 60-70% 就压 | [08](file:///workspace/study-docs/08-上下文管理艺术.md) |
+| 子智能体隔离 | 重活委派，主会话只收摘要 | [08](file:///workspace/study-docs/08-上下文管理艺术.md) |
+| 并行任务协议 | 独立就并行，先发后等 | [03](file:///workspace/study-docs/03-Agent编排体系.md) / [09](file:///workspace/study-docs/09-实战案例剖析.md) |
+| 错误恢复 | BLOCKED 立即上报，总出部分报告 | [04](file:///workspace/study-docs/04-Skill技能系统.md) / [09](file:///workspace/study-docs/09-实战案例剖析.md) |
+
+---
+
+## 编排十诫
+
+这是整套学习文档的精华。掌握这十条，你就掌握了 Claude Code 智能体编排的核心：
+
+1. **`CLAUDE.md` 定方向，`@` 引用拆细节**——主配置精简，细节进子文件。
+2. **Agent 按层分工，最小权限**——总监/主管/专家，tools 字段最小化。
+3. **Skill 是 SOP，分 Phase 执行**——`/命令` 触发，路由表派 agent。
+4. **Hook 守底线，退出码说话**——`exit 2` 硬阻止，`exit 0` 软警告。
+5. **Rule 按路径生效，因地制宜**——生产严，原型松，带正反例。
+6. **人在环中，五步协作**——Question→Options→Decision→Draft→Approval，Approval 不省。
+7. **文件即记忆，对话是临时**——重要决策落盘，active.md 是检查点。
+8. **增量写入，主动压缩**——长文档逐章写，60-70% 就压。
+9. **子智能体隔离，并行独立任务**——重活委派，独立就并行。
+10. **错误恢复，总出部分报告**——BLOCKED 立即上报，不静默吞错。
+
+---
+
+## 推荐延伸阅读
+
+项目内：
+- [README.md](file:///workspace/README.md)——项目总览
+- [CLAUDE.md](file:///workspace/CLAUDE.md)——项目章程
+- [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md)——协作地图
+- [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md)——协作规则
+- [context-management.md](file:///workspace/.claude/docs/context-management.md)——上下文管理
+- [COLLABORATIVE-DESIGN-PRINCIPLE.md](file:///workspace/docs/COLLABORATIVE-DESIGN-PRINCIPLE.md)——协作原则
+- [docs/examples/](file:///workspace/docs/examples/)——会话范例
+- [workflow-catalog.yaml](file:///workspace/.claude/docs/workflow-catalog.yaml)——流水线定义
+
+---
+
+## 最后的话
+
+这个项目能教你的是**编排的思想**，不是教条的配置。三大思想最重要：
+
+1. **分工产生质量**：49 个智能体各管一摊，比一个全能 AI 干得好。因为专注 = 专业。
+2. **约束产生可靠**：rule 教育 + hook 强制 + 协作协议，三层约束让 AI 不跑偏。
+3. **人在环中产生掌控**：AI 提议、人决策，比 AI 自治更安全。因为 AI 猜错的代价比问一句高得多。
+
+这三条不只适用于 Claude Code，适用于所有 AI 编排。掌握了，你就能把这套思想迁移到任何领域。
+
+祝你编排愉快。
+
+← 返回 [README 索引](file:///workspace/study-docs/README.md)

--- a/study-docs/11-CLAUDE.md编写指导.md
+++ b/study-docs/11-CLAUDE.md编写指导.md
@@ -15,10 +15,13 @@
 
 - 一开始要设定"专家角色"吗？
 - 为什么这个项目先写项目名称和介绍？
-- `@路径` 引用语法背后是什么原理？
+- `@路径` 引用语法背后是什么原理？**会在启动时加载吗？**
+- `@` 引用和"路径特定规则"（path-specific rules）是什么关系？
 - 哪些内容该放 CLAUDE.md，哪些该拆出去？
 - 子目录的 CLAUDE.md 有什么用？
 - 怎么避免 CLAUDE.md 撑爆上下文？
+
+> **重要澄清**：根据 [Claude Code 官方文档](https://code.claude.com/docs/zh-CN/memory)，`@路径` 引用的文件**会在会话启动时全量加载**（不是按需加载）。真正实现"按需加载"的是子目录 CLAUDE.md（懒加载）。`@` 引用和路径特定规则（`.claude/rules/` 的 `paths` frontmatter）是**两个完全不同的机制**。详见下文"核心问题 4.5"。
 
 ---
 
@@ -186,7 +189,7 @@ Each agent owns a specific domain, enforcing separation of concerns and quality.
 
 ### `@` 引用的技术原理
 
-`@路径` 是 Claude Code 的**文件引用语法**。它的作用是：
+`@路径` 是 Claude Code 的**文件引用语法**（官方文档称"导入其他文件 / Import additional files"）。它的作用是：
 
 > 在读取 CLAUDE.md 时，把 `@` 后面那个文件的内容**内联展开**到当前位置。
 
@@ -194,19 +197,28 @@ Each agent owns a specific domain, enforcing separation of concerns and quality.
 
 1. **可维护性**：子文件独立修改，主文件不动。
 2. **可复用性**：一个子文件可以被多个地方引用（虽然 CLAUDE.md 里通常只引一次）。
-3. **按需加载**：某些实现支持延迟加载，不一定全部塞进初始上下文。
+3. **关注点分离**：主文件是"目录页"，细节进子文件，阅读和维护更清晰。
+
+#### ⚠️ 关键澄清：`@` 引用是"启动时全量加载"，不是"按需加载"
+
+根据 [Claude Code 官方文档](https://code.claude.com/docs/zh-CN/memory)，CLAUDE.md 在会话启动时**全部内容都会被加载**（不会只挑相关部分），`@` 引用的文件内容会被内联展开后一起加载。
+
+**这意味着**：
+- `@` 引用**不能减少上下文 token 成本**——该加载的还是加载了。
+- `@` 引用的真正价值是**可维护性和可读性**，不是省 token。
+- 如果引用的文件太大，照样会撑爆上下文。
+
+**所以 `@` 引用 ≠ 按需加载**。真正实现"按需加载"的是另外两个机制（见下文"三种加载机制对比"）。
 
 ### 为什么不直接全写进 CLAUDE.md
 
-**核心原因：上下文窗口有限**。
+如果 `@` 引用不省 token，为什么还要拆？三个原因：
 
-这个项目的 6 个子文件加起来内容很多（technical-preferences.md 87 行、coordination-rules.md 65 行、coding-standards.md 66 行、context-management.md 99 行……）。如果全塞进 CLAUDE.md：
+1. **可维护性**：主文件几百行难以阅读和修改，拆开后每个子文件独立维护。
+2. **可读性**：主文件保持"目录页"角色，一眼看清项目有哪些配置维度。
+3. **修改隔离**：改编码标准不用动主文件，降低误伤其他部分的风险。
 
-- 主文件几百行，**难以阅读和维护**。
-- 每次对话启动都加载全部，**上下文成本高**。
-- 修改一处要动主文件，**容易误伤其他部分**。
-
-`@` 引用让主文件保持"目录"的角色，细节进子文件。
+**注意**：拆出去不等于省上下文。如果子文件内容很多，`@` 引用后总 token 一样多。要真正减少上下文成本，用下面两种机制。
 
 ### `@` 引用的设计原则
 
@@ -327,6 +339,105 @@ Every task follows: Question -> Options -> Decision -> Draft -> Approval
 
 ---
 
+## 核心问题 4.5：三种"加载机制"别搞混（官方文档澄清）
+
+这是编写 CLAUDE.md 最容易混淆的地方。很多人把三种机制搞混，导致配置不符合预期。根据 [Claude Code 官方文档](https://code.claude.com/docs/zh-CN/memory)，有三种**完全不同**的机制：
+
+### 机制 1：`@路径` 引用 —— 启动时全量加载
+
+**是什么**：在 CLAUDE.md 里写 `@.claude/docs/xxx.md`，把那个文件内容内联展开。
+
+**加载时机**：**会话启动时全量加载**。CLAUDE.md 的所有内容（含 `@` 引用展开后的内容）在启动时一次性注入上下文。
+
+**官方原文**（[memory 文档](https://code.claude.com/docs/zh-CN/memory#import-additional-files)）：
+
+> Use `@path/to/import/file.md` to import additional files... Claude Code reads CLAUDE.md files at session start.
+
+**能省 token 吗**：**不能**。`@` 引用的文件内容会被展开后一起加载，总 token 不变。
+
+**真正价值**：可维护性、可读性、关注点分离（见上文）。
+
+### 机制 2：路径特定规则（path-specific rules）—— 按路径生效
+
+**是什么**：在 `.claude/rules/` 下放规则文件，用 frontmatter 的 `paths` 字段限定只在哪些路径生效。
+
+**加载时机**：**启动时全量注入** `.claude/rules/` 下所有规则文件的内容。但 `paths` frontmatter 让规则**只在 AI 处理匹配路径的文件时才"激活约束"**。
+
+**官方原文**（[memory 文档 path-specific-rules](https://code.claude.com/docs/zh-CN/memory#path-specific-rules)）：
+
+> Rules can be scoped to specific file paths using `globs` in the YAML frontmatter.
+
+**和 `@` 引用的区别**：
+- `@` 引用是"把文件内容塞进 CLAUDE.md"，没有路径限定。
+- path-specific rules 是"规则文件独立存在，用 `paths` 限定生效范围"。
+
+**这个项目的实例**：[gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md)
+
+```markdown
+---
+paths:
+  - "src/gameplay/**"
+---
+# Gameplay Code Rules
+- ALL gameplay values MUST come from external config/data files, NEVER hardcoded
+...
+```
+
+这条规则只在 AI 写 `src/gameplay/` 下的文件时激活约束。详见 [06 Rules 路径规则](file:///workspace/study-docs/06-Rules路径规则.md)。
+
+### 机制 3：子目录 CLAUDE.md —— 懒加载（真正的按需加载）
+
+**是什么**：在子目录放 CLAUDE.md（如 `src/CLAUDE.md`、`design/CLAUDE.md`）。
+
+**加载时机**：**懒加载**。启动时**不加载**，只有当 Claude 真正读取或修改该子目录下的文件时，那个子目录（及其路径上）的 CLAUDE.md 才被加载。
+
+**官方原文**（[memory 文档](https://code.claude.com/docs/zh-CN/memory#how-claude-md-files-load)）：
+
+> Claude Code does not load CLAUDE.md files in subdirectories at launch. Instead, they are included when Claude reads files in those subdirectories.
+
+**这是唯一真正"按需加载"的机制**。如果整个会话没碰过 `frontend/`，它的 CLAUDE.md 始终不加载，不占 token。
+
+### 三种机制对比表
+
+| 维度 | `@路径` 引用 | 路径特定规则 | 子目录 CLAUDE.md |
+|------|-------------|-------------|------------------|
+| **放哪** | CLAUDE.md 里写 `@路径` | `.claude/rules/` 下放 `.md` | 子目录下放 `CLAUDE.md` |
+| **加载时机** | 启动时全量加载 | 启动时全量注入 | 懒加载（处理该目录文件时） |
+| **能省 token 吗** | ❌ 不能 | ❌ 不能（启动全注入） | ✅ 能（不碰就不加载） |
+| **路径限定** | 无 | `paths` frontmatter 限定 | 天然按目录限定 |
+| **主要价值** | 可维护性、关注点分离 | 按路径激活不同约束 | 真正的按需加载 |
+| **适合放什么** | 详细规范、长文档 | 编码规则、命名规范 | 目录专属规则 |
+
+### 完整加载顺序
+
+根据官方文档和社区分析，Claude Code 会话启动时的加载顺序：
+
+```
+1. settings.json          → 系统能力（权限、hooks、env）
+2. settings.local.json    → 本地覆盖（个人配置）
+3. CLAUDE.md              → 项目入口（含 @ 引用展开后的全部内容）
+   （向上递归到根目录的所有 CLAUDE.md 也加载）
+4. .claude/rules/         → 全量注入所有规则文件
+5. Auto Memory            → 自动记忆（MEMORY.md 索引）
+```
+
+**注意**：子目录 CLAUDE.md **不在启动时加载**，是懒加载。
+
+### 这个项目三种机制都用了
+
+| 机制 | 项目里的实例 | 解决什么问题 |
+|------|-------------|-------------|
+| `@` 引用 | CLAUDE.md 里 `@.claude/docs/coding-standards.md` | 把详细规范拆出主文件，可维护 |
+| 路径特定规则 | `.claude/rules/gameplay-code.md` 的 `paths: src/gameplay/**` | 玩法代码必须数据驱动 |
+| 子目录 CLAUDE.md | `src/CLAUDE.md`、`design/CLAUDE.md` | 源码/设计目录专属规则，不碰不加载 |
+
+**编排启示**：三种机制各有所长，组合使用：
+- 用 `@` 引用拆分长文档（可维护）
+- 用路径特定规则约束不同路径的代码（精准）
+- 用子目录 CLAUDE.md 隔离目录专属规则（省 token）
+
+---
+
 ## 核心问题 5：子目录的 CLAUDE.md 有什么用
 
 这个项目有**多个 CLAUDE.md**，分布在不同目录：
@@ -338,11 +449,17 @@ Every task follows: Question -> Options -> Decision -> Draft -> Approval
 /workspace/docs/CLAUDE.md      ← 技术文档目录
 ```
 
-### 分层 CLAUDE.md 的原理
+### 分层 CLAUDE.md 的原理（懒加载）
 
-Claude Code 支持**分层 CLAUDE.md**：当 AI 在某个目录工作时，会读取该目录的 CLAUDE.md（如果有），叠加到主 CLAUDE.md 之上。
+Claude Code 支持**分层 CLAUDE.md**：在子目录放 CLAUDE.md，当 AI 读取/修改该子目录下的文件时，那个子目录的 CLAUDE.md 才被加载，叠加到主 CLAUDE.md 之上。
 
-**作用**：让"目录专属规则"只在那个目录生效，不污染全局上下文。
+**官方机制**（[memory 文档](https://code.claude.com/docs/zh-CN/memory#how-claude-md-files-load)）：
+
+> Claude Code does not load CLAUDE.md files in subdirectories at launch. Instead, they are included when Claude reads files in those subdirectories.
+
+**关键**：子目录 CLAUDE.md 是**懒加载**——启动时不加载，只有处理该目录文件时才加载。这是它和 `@` 引用（启动时全量加载）的根本区别。
+
+**作用**：让"目录专属规则"只在那个目录生效，**不碰就不占 token**，真正实现按需加载。
 
 看 [src/CLAUDE.md](file:///workspace/src/CLAUDE.md)：
 
@@ -365,8 +482,8 @@ The LLM's training data predates the pinned engine version.
 
 **为什么不放主 CLAUDE.md**：
 - 这些规则只在写 `src/` 下代码时相关，写 `design/` 文档时无关。
-- 放主 CLAUDE.md 会增加无关上下文成本。
-- 分层让规则"按需加载"。
+- 放主 CLAUDE.md 会**启动时全量加载**，增加无关上下文成本。
+- 放子目录 CLAUDE.md 是**懒加载**，不碰 `src/` 就不加载，真正省 token。
 
 ### 看 [design/CLAUDE.md](file:///workspace/design/CLAUDE.md) 的对比
 
@@ -395,21 +512,29 @@ Every GDD must include all **8 required sections** in this order:
 
 ## 核心问题 6：怎么避免 CLAUDE.md 撑爆上下文
 
-这是编写 CLAUDE.md 最实际的挑战。这个项目用了几个策略：
+这是编写 CLAUDE.md 最实际的挑战。根据官方文档，要区分"启动时加载"和"懒加载"两种机制，对症下药。
 
-### 策略 1：主文件精简，细节 `@` 引用
+### 策略 1：主文件精简，细节 `@` 引用（可维护性）
 
 主 CLAUDE.md 只有 53 行，但通过 6 个 `@` 引用加载了完整配置。
 
-**原则**：主文件是"目录页"，不是"正文"。
+**注意**：`@` 引用**不省 token**（启动时全量加载），但让主文件可读、可维护。
 
-### 策略 2：分层 CLAUDE.md 按需加载
+**原则**：主文件是"目录页"，不是"正文"。`@` 引用是为了可维护性，不是为了省 token。
 
-`src/CLAUDE.md` 只在写源码时加载，`design/CLAUDE.md` 只在写设计文档时加载。
+### 策略 2：子目录 CLAUDE.md 懒加载（真正省 token）
 
-**原则**：局部规则放局部，不污染全局。
+`src/CLAUDE.md` 只在写源码时加载，`design/CLAUDE.md` 只在写设计文档时加载。**这是唯一真正省 token 的机制**——不碰那个目录就不加载。
 
-### 策略 3：CLAUDE.md vs CLAUDE.local.md
+**原则**：目录专属规则放子目录 CLAUDE.md，利用懒加载省上下文。
+
+### 策略 3：路径特定规则精准约束（启动加载，但按路径激活）
+
+`.claude/rules/` 下的规则文件用 `paths` frontmatter 限定生效范围。虽然启动时全量注入，但约束只在匹配路径激活。
+
+**原则**：不同路径要不同约束时，用路径特定规则，不要堆进 CLAUDE.md。
+
+### 策略 4：CLAUDE.md vs CLAUDE.local.md
 
 看 [CLAUDE-local-template.md](file:///workspace/.claude/docs/CLAUDE-local-template.md)：
 
@@ -434,7 +559,7 @@ Every GDD must include all **8 required sections** in this order:
 
 **原则**：团队共享的写 CLAUDE.md，个人的写 CLAUDE.local.md。不要把个人偏好污染团队配置。
 
-### 策略 4：区分"每次都要见"和"按需见"
+### 策略 5：区分"每次都要见"和"按需见"
 
 **每次都要见**（直接写 CLAUDE.md）：
 - 项目定位
@@ -442,7 +567,7 @@ Every GDD must include all **8 required sections** in this order:
 - 技术栈
 - 入门指引
 
-**按需见**（`@` 引用或子目录 CLAUDE.md）：
+**按需见**（子目录 CLAUDE.md 懒加载）：
 - 详细编码标准
 - 目录结构
 - 上下文管理策略
@@ -819,20 +944,29 @@ The LLM's training data predates the pinned engine version.
 
 ---
 
-## 总结：CLAUDE.md 编写的五条铁律
+## 总结：CLAUDE.md 编写的六条铁律
 
 1. **先定位，后细节**——开头一句话锚定领域和特征，后续所有内容在这个上下文里理解。
-2. **主文件精简，细节 `@` 引用**——主文件是目录页，不是正文。超过 100 行就该拆。
-3. **核心铁律直接写，长文档拆出去**——每次都要见的直接写，按需见的 `@` 引用。
-4. **局部规则放子目录 CLAUDE.md**——不污染全局上下文，按需加载。
-5. **团队配置和个人偏好分开**——CLAUDE.md 提交 git，CLAUDE.local.md 不提交。
+2. **主文件精简，细节 `@` 引用**——主文件是目录页，不是正文。超过 100 行就该拆。**注意：`@` 引用是为了可维护性，不省 token**（启动时全量加载）。
+3. **核心铁律直接写，长文档 `@` 引用拆出去**——每次都要见的直接写，详细规范用 `@` 引用。
+4. **目录专属规则放子目录 CLAUDE.md**——这是唯一**真正省 token**的机制（懒加载，不碰不加载）。
+5. **不同路径要不同约束，用路径特定规则**——`.claude/rules/` 下用 `paths` frontmatter，不要堆进 CLAUDE.md。
+6. **团队配置和个人偏好分开**——CLAUDE.md 提交 git，CLAUDE.local.md 不提交。
 
-**一句话**：CLAUDE.md 是"项目宪法"——简短、稳定、锚定方向；细节法律拆到子文件，地方法规放地方。
+**一句话**：CLAUDE.md 是"项目宪法"——简短、稳定、锚定方向；细节法律用 `@` 引用拆到子文件（可维护），地方法规放子目录 CLAUDE.md（懒加载省 token），路径专属约束用 `.claude/rules/`（精准激活）。
 
 ---
 
 ## 延伸阅读
 
+### 官方文档（权威依据）
+- [探索 .claude 目录](https://code.claude.com/docs/zh-CN/claude-directory)——官方 .claude 目录说明
+- [存储指令和记忆](https://code.claude.com/docs/zh-CN/memory)——官方 CLAUDE.md 和记忆机制说明
+- [特定路径的规则](https://code.claude.com/docs/zh-CN/memory#path-specific-rules)——官方 path-specific rules 说明
+- [导入其他文件](https://code.claude.com/docs/zh-CN/memory#import-additional-files)——官方 `@` 引用语法说明
+- [CLAUDE.md 文件如何加载](https://code.claude.com/docs/zh-CN/memory#how-claude-md-files-load)——官方加载机制说明
+
+### 项目内文件（实例参考）
 - [这个项目的 CLAUDE.md](file:///workspace/CLAUDE.md)——本文的主要分析对象
 - [CLAUDE-local-template.md](file:///workspace/.claude/docs/CLAUDE-local-template.md)——个人配置模板
 - [src/CLAUDE.md](file:///workspace/src/CLAUDE.md)——源码目录分层 CLAUDE.md
@@ -840,5 +974,7 @@ The LLM's training data predates the pinned engine version.
 - [docs/CLAUDE.md](file:///workspace/docs/CLAUDE.md)——文档目录分层 CLAUDE.md
 - [technical-preferences.md](file:///workspace/.claude/docs/technical-preferences.md)——技术偏好子文件范例
 - [coding-standards.md](file:///workspace/.claude/docs/coding-standards.md)——编码标准子文件范例
+- [gameplay-code.md](file:///workspace/.claude/rules/gameplay-code.md)——路径特定规则范例
 - [study-docs/02-Claude-Code基础概念.md](file:///workspace/study-docs/02-Claude-Code基础概念.md)——本系列的基础概念篇
+- [study-docs/06-Rules路径规则.md](file:///workspace/study-docs/06-Rules路径规则.md)——路径特定规则详解
 - [study-docs/07-协作协议与人在环.md](file:///workspace/study-docs/07-协作协议与人在环.md)——协作协议详解

--- a/study-docs/11-CLAUDE.md编写指导.md
+++ b/study-docs/11-CLAUDE.md编写指导.md
@@ -1,0 +1,844 @@
+# CLAUDE.md 编写指导
+
+> 基于 [Claude Code Game Studios](file:///workspace/CLAUDE.md) 项目的实战范例，结合编写实践与原理，教你写出高质量的 CLAUDE.md。
+
+---
+
+## 这份文档解决什么问题
+
+很多人写 CLAUDE.md 容易陷入两个极端：
+
+- **太简陋**：只写一句"你是一个 Python 专家"，浪费了 CLAUDE.md 这个最强配置入口。
+- **太冗长**：把所有规范、流程、上下文都塞进去，撑爆上下文窗口，AI 反而抓不住重点。
+
+这个项目示范了**第三条路**：精简的主文件 + `@` 引用拆分 + 分层 CLAUDE.md。我们用它当活教材，回答这些常见问题：
+
+- 一开始要设定"专家角色"吗？
+- 为什么这个项目先写项目名称和介绍？
+- `@路径` 引用语法背后是什么原理？
+- 哪些内容该放 CLAUDE.md，哪些该拆出去？
+- 子目录的 CLAUDE.md 有什么用？
+- 怎么避免 CLAUDE.md 撑爆上下文？
+
+---
+
+## 第一性原理：CLAUDE.md 到底是什么
+
+在讲"怎么写"之前，先讲"它是什么、为什么"。
+
+### CLAUDE.md 是"项目级系统提示词"
+
+Claude Code 启动时会**自动读取**项目根目录的 `CLAUDE.md`，把它的内容注入到 AI 的系统提示词里。这意味着：
+
+- **它是对话开始前就生效的"预设"**，不是对话中临时给的指令。
+- **它对每次对话都生效**，不需要你每次重复说。
+- **它和 `.claude/settings.json` 是两大配置入口**：CLAUDE.md 管"AI 该知道什么、该怎么做"，settings.json 管"AI 能做什么、不能做什么"。
+
+**类比**：CLAUDE.md 是"新员工入职手册"，settings.json 是"门禁系统"。新员工上班第一天先读入职手册（知道公司是干嘛的、怎么干活），门禁系统决定他能进哪些门。
+
+### 为什么 CLAUDE.md 比单次对话指令强
+
+| 维度 | 单次对话指令 | CLAUDE.md |
+|------|--------------|-----------|
+| 持久性 | 只对当前对话生效 | 每次对话自动加载 |
+| 一致性 | 容易忘、容易变 | 始终一致 |
+| 可维护性 | 改一次要重发 | 改文件即生效 |
+| 团队协作 | 各人各写 | 团队共享一份 |
+| 上下文成本 | 占用对话 token | 启动时加载，对话中不重复 |
+
+**关键洞察**：CLAUDE.md 是"投入产出比最高"的配置。写一次，每次对话都受益。
+
+---
+
+## 核心问题 1：一开始要设定"专家角色"吗
+
+**短答**：不一定。这个项目**没有**在 CLAUDE.md 开头设定"你是一个游戏开发专家"。
+
+看这个项目的 [CLAUDE.md](file:///workspace/CLAUDE.md) 开头：
+
+```markdown
+# Claude Code Game Studios -- Game Studio Agent Architecture
+
+Indie game development managed through 49 coordinated Claude Code subagents.
+Each agent owns a specific domain, enforcing separation of concerns and quality.
+```
+
+它做的是**介绍项目**，不是设定角色。
+
+### 为什么不在主 CLAUDE.md 设定角色
+
+这个项目的角色设定在**每个 agent 的定义文件里**，不在主 CLAUDE.md。看 [creative-director.md](file:///workspace/.claude/agents/creative-director.md)：
+
+```markdown
+---
+name: creative-director
+model: opus
+---
+
+You are the Creative Director for an indie game project. You are the final
+authority on all creative decisions...
+```
+
+**角色设定下沉到 agent 层**，主 CLAUDE.md 只管"项目是什么、怎么协作"。
+
+### 背后的技术原理
+
+Claude Code 的多智能体架构里，主会话和子智能体是**不同的上下文**：
+
+- **主会话**读 CLAUDE.md → 它是"协调者/调度者"，不需要是专家。
+- **子智能体**读自己的 agent 定义 → 它才是"专家"，有明确角色。
+
+如果在主 CLAUDE.md 写"你是创意总监"，会和子智能体的角色设定**冲突或冗余**。主会话既不是创意总监，也不该是——它是调度创意总监的人。
+
+### 什么时候该在 CLAUDE.md 设定角色
+
+**单智能体场景**（不用 subagent）：可以在 CLAUDE.md 开头设定角色。比如：
+
+```markdown
+# 我的 Python 项目
+
+你是一个资深 Python 后端工程师，精通 FastAPI 和 SQLAlchemy。
+```
+
+**多智能体场景**（这个项目）：主 CLAUDE.md 不设定角色，角色下沉到 agent 定义。
+
+**判断标准**：你的项目用 `Task` 派子智能体吗？用 → 角色放 agent 文件。不用 → 角色可以放 CLAUDE.md。
+
+---
+
+## 核心问题 2：为什么先写项目名称和介绍
+
+看这个项目 CLAUDE.md 的前 4 行：
+
+```markdown
+# Claude Code Game Studios -- Game Studio Agent Architecture
+
+Indie game development managed through 49 coordinated Claude Code subagents.
+Each agent owns a specific domain, enforcing separation of concerns and quality.
+```
+
+**两件事**：项目名 + 一句话定位。
+
+### 背后的技术原理：上下文锚定
+
+大语言模型的工作方式是**基于上下文预测下一个 token**。上下文的"开头"有**锚定效应（priming effect）**——开头的设定会影响后续所有推理。
+
+**写"项目名称 + 一句话定位"的作用**：
+
+1. **建立领域上下文**：让 AI 知道"我们在做游戏开发"，后续所有对话都在这个领域里理解。比如"player"在游戏语境是"玩家"，在音乐语境是"播放器"。
+2. **设定项目身份**：49 个 subagent、领域分离、质量把关——这三个关键词定义了项目的"性格"。AI 后续决策会向这个性格靠拢。
+3. **提供决策依据**：当 AI 面对模糊指令时，会用项目定位消歧。"加一个登录系统"在游戏项目里可能是"玩家账号系统"，在企业项目里是"员工 SSO"。
+
+**类比**：你进一家餐厅，墙上写着"本店主营川菜"。这句话决定了你后续所有点菜、问询、期待的基调。没有这句话，你可能会问"有寿司吗"，浪费来回。
+
+### 怎么写好这一句定位
+
+**好定位的三要素**：领域 + 规模/方式 + 核心特征。
+
+看这个项目：
+- 领域：indie game development（独立游戏开发）
+- 规模/方式：managed through 49 coordinated Claude Code subagents（49 个协同子智能体管理）
+- 核心特征：each agent owns a specific domain, enforcing separation of concerns and quality（领域分离、关注点分离、质量）
+
+**反例**：
+```
+# 我的项目
+这是一个用 Claude Code 做的项目。
+```
+← 没有领域、没有规模、没有特征。AI 知道等于不知道。
+
+**正例**：
+```
+# 电商后台管理系统
+
+基于 Spring Boot 3 + Vue 3 的 B2C 电商后台，管理商品、订单、用户、营销。
+采用领域驱动设计，每个模块有独立的聚合根和仓储。
+```
+← 领域（电商后台）、技术栈（Spring Boot 3 + Vue 3）、架构方式（DDD）。
+
+---
+
+## 核心问题 3：`@路径` 引用语法背后是什么原理
+
+看这个项目 CLAUDE.md 的主体：
+
+```markdown
+## Project Structure
+@.claude/docs/directory-structure.md
+
+## Engine Version Reference
+@docs/engine-reference/godot/VERSION.md
+
+## Technical Preferences
+@.claude/docs/technical-preferences.md
+
+## Coordination Rules
+@.claude/docs/coordination-rules.md
+
+## Coding Standards
+@.claude/docs/coding-standards.md
+
+## Context Management
+@.claude/docs/context-management.md
+```
+
+**6 个 `@` 引用**。主文件只有 53 行，但实际加载的内容是这 6 个子文件的总和。
+
+### `@` 引用的技术原理
+
+`@路径` 是 Claude Code 的**文件引用语法**。它的作用是：
+
+> 在读取 CLAUDE.md 时，把 `@` 后面那个文件的内容**内联展开**到当前位置。
+
+**等价于**：你手动把那个文件的内容复制粘贴到 CLAUDE.md 里。但比手动复制有三个优势：
+
+1. **可维护性**：子文件独立修改，主文件不动。
+2. **可复用性**：一个子文件可以被多个地方引用（虽然 CLAUDE.md 里通常只引一次）。
+3. **按需加载**：某些实现支持延迟加载，不一定全部塞进初始上下文。
+
+### 为什么不直接全写进 CLAUDE.md
+
+**核心原因：上下文窗口有限**。
+
+这个项目的 6 个子文件加起来内容很多（technical-preferences.md 87 行、coordination-rules.md 65 行、coding-standards.md 66 行、context-management.md 99 行……）。如果全塞进 CLAUDE.md：
+
+- 主文件几百行，**难以阅读和维护**。
+- 每次对话启动都加载全部，**上下文成本高**。
+- 修改一处要动主文件，**容易误伤其他部分**。
+
+`@` 引用让主文件保持"目录"的角色，细节进子文件。
+
+### `@` 引用的设计原则
+
+**该用 `@` 引用的**：
+- 详细规范（编码标准、命名规范、测试要求）
+- 长文档（架构说明、协作规则）
+- 可独立维护的内容（技术栈配置、引擎版本）
+- 多个 agent/skill 共同引用的"公共知识"
+
+**不该用 `@` 引用（直接写在 CLAUDE.md）的**：
+- 项目定位（开头一句话）
+- 核心协作协议（几条铁律）
+- 紧急提醒（"第一次会话跑 /start"）
+- 跨所有子文件的总原则
+
+看这个项目的对比：
+
+```markdown
+# 直接写（核心、简短、每次都要见）
+## Collaboration Protocol
+**User-driven collaboration, not autonomous execution.**
+Every task follows: Question -> Options -> Decision -> Draft -> Approval
+- Agents MUST ask "May I write this to [filepath]?" before using Write/Edit tools
+...
+
+# @ 引用（详细、长、可独立维护）
+## Coding Standards
+@.claude/docs/coding-standards.md
+```
+
+**判断标准**：内容超过 20 行且能独立成篇 → 拆出去用 `@` 引用。内容少于 10 行且是核心铁律 → 直接写。
+
+---
+
+## 核心问题 4：哪些内容该放 CLAUDE.md
+
+这个项目的 CLAUDE.md 包含这些章节：
+
+| 章节 | 内容 | 直接写还是 @ 引用 |
+|------|------|---------------------|
+| 标题 + 定位 | 项目名 + 一句话 | 直接写 |
+| Technology Stack | 技术栈选择 | 直接写（简短） |
+| Project Structure | 目录结构 | `@` 引用 |
+| Engine Version Reference | 引擎版本 | `@` 引用 |
+| Technical Preferences | 技术偏好 | `@` 引用 |
+| Coordination Rules | 协作规则 | `@` 引用 |
+| Collaboration Protocol | 协作协议 | 直接写（核心铁律） |
+| Coding Standards | 编码标准 | `@` 引用 |
+| Context Management | 上下文管理 | `@` 引用 |
+
+### CLAUDE.md 应该包含的"标准章节"
+
+基于这个项目和编写实践，推荐结构：
+
+#### 1. 项目定位（必写，直接写）
+```markdown
+# 项目名 -- 一句话副标题
+
+一段话定位：领域 + 规模/方式 + 核心特征。
+```
+
+#### 2. 技术栈（必写，直接写）
+```markdown
+## Technology Stack
+- **Language**: Python 3.12
+- **Framework**: FastAPI 0.110
+- **Database**: PostgreSQL 16
+- **ORM**: SQLAlchemy 2.0
+```
+← 简短的关键决策，直接写。AI 一眼知道用什么。
+
+#### 3. 项目结构（推荐，@ 引用）
+```markdown
+## Project Structure
+@.claude/docs/directory-structure.md
+```
+← 目录结构可能长，拆出去。
+
+#### 4. 编码标准（必写，@ 引用）
+```markdown
+## Coding Standards
+@.claude/docs/coding-standards.md
+```
+← 编码标准通常详细，拆出去。
+
+#### 5. 协作协议（必写，直接写核心 + @ 引用细节）
+```markdown
+## Collaboration Protocol
+**User-driven collaboration, not autonomous execution.**
+- 写文件前必须问"可以写到 [路径] 吗？"
+- 不经批准不提交
+
+详见 @docs/collaboration-principle.md
+```
+← 核心铁律直接写（每次都要见），细节拆出去。
+
+#### 6. 上下文管理（推荐，@ 引用）
+```markdown
+## Context Management
+@.claude/docs/context-management.md
+```
+← 长会话项目必写，告诉 AI 怎么管理上下文。
+
+#### 7. 入门指引（推荐，直接写）
+```markdown
+> **第一次会话？** 跑 `/start` 开始引导流程。
+```
+← 新人入门提示，简短直接写。
+
+### 不该放 CLAUDE.md 的内容
+
+- **具体业务逻辑**：放代码注释或专门文档。
+- **临时指令**：放对话里，不要污染 CLAUDE.md。
+- **个人偏好**：放 `CLAUDE.local.md`（见下文）。
+- **agent 定义**：放 `.claude/agents/`。
+- **skill 定义**：放 `.claude/skills/`。
+- **hook 脚本**：放 `.claude/hooks/`。
+
+---
+
+## 核心问题 5：子目录的 CLAUDE.md 有什么用
+
+这个项目有**多个 CLAUDE.md**，分布在不同目录：
+
+```
+/workspace/CLAUDE.md           ← 主配置（项目根）
+/workspace/src/CLAUDE.md       ← 源码目录
+/workspace/design/CLAUDE.md    ← 设计文档目录
+/workspace/docs/CLAUDE.md      ← 技术文档目录
+```
+
+### 分层 CLAUDE.md 的原理
+
+Claude Code 支持**分层 CLAUDE.md**：当 AI 在某个目录工作时，会读取该目录的 CLAUDE.md（如果有），叠加到主 CLAUDE.md 之上。
+
+**作用**：让"目录专属规则"只在那个目录生效，不污染全局上下文。
+
+看 [src/CLAUDE.md](file:///workspace/src/CLAUDE.md)：
+
+```markdown
+# Source Directory
+
+When writing or editing game code in this directory, follow these standards.
+
+## Engine Version Warning
+The LLM's training data predates the pinned engine version.
+**Always check `docs/engine-reference/` before using any engine API.**
+
+## Coding Standards
+- All public APIs require doc comments
+- Gameplay values must be **data-driven** (external config files), never hardcoded
+...
+```
+
+**关键内容**：源码目录专属的规则——引擎版本警告、编码标准、文件路由、测试要求。
+
+**为什么不放主 CLAUDE.md**：
+- 这些规则只在写 `src/` 下代码时相关，写 `design/` 文档时无关。
+- 放主 CLAUDE.md 会增加无关上下文成本。
+- 分层让规则"按需加载"。
+
+### 看 [design/CLAUDE.md](file:///workspace/design/CLAUDE.md) 的对比
+
+```markdown
+# Design Directory
+
+## GDD Files (`design/gdd/`)
+Every GDD must include all **8 required sections** in this order:
+1. Overview
+2. Player Fantasy
+...
+```
+
+**这里强调的是 GDD 的 8 章节要求**——只在写设计文档时相关，和写代码无关。
+
+### 分层 CLAUDE.md 的设计原则
+
+1. **主 CLAUDE.md 写全局的**：项目定位、技术栈、总协作协议、引用子文档。
+2. **子目录 CLAUDE.md 写局部的**：该目录的专属规则、文件命名、结构要求。
+3. **不要重复**：子目录 CLAUDE.md 不重复主 CLAUDE.md 的内容，只补充。
+4. **按目录性质分**：源码目录、文档目录、测试目录各有不同规则。
+
+**判断标准**：如果某个规则只在一类文件下相关，就放那个目录的 CLAUDE.md。如果所有文件都相关，放主 CLAUDE.md。
+
+---
+
+## 核心问题 6：怎么避免 CLAUDE.md 撑爆上下文
+
+这是编写 CLAUDE.md 最实际的挑战。这个项目用了几个策略：
+
+### 策略 1：主文件精简，细节 `@` 引用
+
+主 CLAUDE.md 只有 53 行，但通过 6 个 `@` 引用加载了完整配置。
+
+**原则**：主文件是"目录页"，不是"正文"。
+
+### 策略 2：分层 CLAUDE.md 按需加载
+
+`src/CLAUDE.md` 只在写源码时加载，`design/CLAUDE.md` 只在写设计文档时加载。
+
+**原则**：局部规则放局部，不污染全局。
+
+### 策略 3：CLAUDE.md vs CLAUDE.local.md
+
+看 [CLAUDE-local-template.md](file:///workspace/.claude/docs/CLAUDE-local-template.md)：
+
+```markdown
+# Personal Preferences
+## Model Preferences
+- Prefer Opus for complex design tasks
+## Local Environment
+- Python command: python (or py / python3)
+## Personal Shortcuts
+- When I say "review", run /code-review on the last changed files
+```
+
+**`CLAUDE.local.md` 是个人配置**：
+- 不提交到 git（gitignored）
+- 个人偏好（模型选择、本地环境、个人快捷方式）
+- 叠加在 CLAUDE.md 之上
+
+**分工**：
+- `CLAUDE.md`：团队共享的项目配置，提交到 git。
+- `CLAUDE.local.md`：个人偏好，不提交。
+
+**原则**：团队共享的写 CLAUDE.md，个人的写 CLAUDE.local.md。不要把个人偏好污染团队配置。
+
+### 策略 4：区分"每次都要见"和"按需见"
+
+**每次都要见**（直接写 CLAUDE.md）：
+- 项目定位
+- 核心协作协议（"写文件前问"）
+- 技术栈
+- 入门指引
+
+**按需见**（`@` 引用或子目录 CLAUDE.md）：
+- 详细编码标准
+- 目录结构
+- 上下文管理策略
+- 引擎版本参考
+
+### 策略 5：定期审查和精简
+
+CLAUDE.md 不是"写一次就完"。定期问：
+- 这条规则是不是每次对话都需要？不是 → 拆出去。
+- 这段内容是不是太长了？是 → 拆出去。
+- 这条是不是个人偏好？是 → 移到 CLAUDE.local.md。
+- 这条是不是只对某类文件相关？是 → 移到子目录 CLAUDE.md。
+
+---
+
+## 实战范例：这个项目 CLAUDE.md 的逐段解析
+
+让我们逐段拆解 [CLAUDE.md](file:///workspace/CLAUDE.md)，看每段为什么这么写。
+
+### 第 1-4 行：标题 + 定位
+
+```markdown
+# Claude Code Game Studios -- Game Studio Agent Architecture
+
+Indie game development managed through 49 coordinated Claude Code subagents.
+Each agent owns a specific domain, enforcing separation of concerns and quality.
+```
+
+**为什么这么写**：
+- 标题用 `--` 加副标题，副标题点明"这是关于 agent 架构的"。
+- 定位句三要素齐全：领域（indie game dev）+ 方式（49 subagents）+ 特征（domain ownership、separation of concerns、quality）。
+- "separation of concerns"和"quality"是后续所有规则的根基，提前锚定。
+
+### 第 6-15 行：技术栈
+
+```markdown
+## Technology Stack
+- **Engine**: [CHOOSE: Godot 4 / Unity / Unreal Engine 5]
+- **Language**: [CHOOSE: GDScript / C# / C++ / Blueprint]
+- **Version Control**: Git with trunk-based development
+- **Build System**: [SPECIFY after choosing engine]
+- **Asset Pipeline**: [SPECIFY after choosing engine]
+
+> **Note**: Engine-specialist agents exist for Godot, Unity, and Unreal with
+> dedicated sub-specialists. Use the set matching your engine.
+```
+
+**为什么这么写**：
+- 用 `[CHOOSE: ...]` 占位符标记待决策项，AI 知道这些还没定。
+- 已决策的（Git with trunk-based development）直接写。
+- Note 补充说明引擎专家 agent 的存在，引导用户选引擎后用对应 agent。
+
+**技术原理**：技术栈是 AI 做所有技术决策的"约束条件"。不写技术栈，AI 可能建议用 React（但项目用 Vue），用 PostgreSQL（但项目用 MySQL），全跑偏。
+
+### 第 17-19 行：项目结构（@ 引用）
+
+```markdown
+## Project Structure
+@.claude/docs/directory-structure.md
+```
+
+**为什么 @ 引用**：[directory-structure.md](file:///workspace/.claude/docs/directory-structure.md) 是个目录树图，相对独立，拆出去主文件更干净。
+
+### 第 21-23 行：引擎版本参考（@ 引用）
+
+```markdown
+## Engine Version Reference
+@docs/engine-reference/godot/VERSION.md
+```
+
+**为什么重要**：大模型训练数据有截止日期，引擎 API 可能已变。这个引用提醒 AI"用引擎 API 前先查版本参考"。
+
+### 第 25-27 行：技术偏好（@ 引用）
+
+```markdown
+## Technical Preferences
+@.claude/docs/technical-preferences.md
+```
+
+**为什么 @ 引用**：[technical-preferences.md](file:///workspace/.claude/docs/technical-preferences.md) 是个 87 行的详细配置（命名规范、性能预算、测试要求、禁止模式、引擎专家路由表）。太长，拆出去。
+
+### 第 29-31 行：协作规则（@ 引用）
+
+```markdown
+## Coordination Rules
+@.claude/docs/coordination-rules.md
+```
+
+**为什么 @ 引用**：[coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) 包含委派规则、模型分层、subagent vs agent team、并行协议。长且独立。
+
+### 第 33-43 行：协作协议（直接写）
+
+```markdown
+## Collaboration Protocol
+
+**User-driven collaboration, not autonomous execution.**
+Every task follows: **Question -> Options -> Decision -> Draft -> Approval**
+
+- Agents MUST ask "May I write this to [filepath]?" before using Write/Edit tools
+- Agents MUST show drafts or summaries before requesting approval
+- Multi-file changes require explicit approval for the full changeset
+- No commits without user instruction
+
+See `docs/COLLABORATIVE-DESIGN-PRINCIPLE.md` for full protocol and examples.
+
+> **First session?** If the project has no engine configured and no game concept,
+> run `/start` to begin the guided onboarding flow.
+```
+
+**为什么直接写**：
+- 这是**核心铁律**，每次对话每次写文件都要见。
+- 短（10 行），不撑上下文。
+- "No commits without user instruction"这种红线必须显式。
+
+**为什么还引用 `docs/COLLABORATIVE-DESIGN-PRINCIPLE.md`**：细节（五步协作的完整范例、AskUserQuestion 用法）在那儿，主文件只放铁律。
+
+**为什么有"First session?"提示**：新人入门指引。简短、直接写、用 `>` 引用块视觉强调。
+
+### 第 48-53 行：编码标准 + 上下文管理（@ 引用）
+
+```markdown
+## Coding Standards
+@.claude/docs/coding-standards.md
+
+## Context Management
+@.claude/docs/context-management.md
+```
+
+**为什么 @ 引用**：两个都是长文档，独立性强。
+
+---
+
+## 编写 CLAUDE.md 的完整流程
+
+基于以上分析，给你一个可操作的编写流程：
+
+### 第 1 步：写项目定位（5 分钟）
+
+回答三个问题：
+1. 这是什么领域的项目？
+2. 用什么方式/规模做的？
+3. 核心特征是什么？
+
+写成一句话 + 一个标题。
+
+### 第 2 步：写技术栈（5 分钟）
+
+列出：
+- 语言 + 版本
+- 框架 + 版本
+- 数据库
+- 关键依赖
+- 版本控制策略
+
+已定的直接写，未定的用 `[CHOOSE: ...]` 占位。
+
+### 第 3 步：写核心协作协议（10 分钟）
+
+回答：
+- AI 写文件前要不要问？
+- AI 能不能自己提交？
+- 多文件改动怎么批准？
+- 决策模式是什么（自治 vs 协作）？
+
+写成 3-5 条铁律，直接放 CLAUDE.md。
+
+### 第 4 步：识别"该拆出去"的内容（10 分钟）
+
+问自己：
+- 编码标准会不会超过 20 行？→ 拆 `@.claude/docs/coding-standards.md`
+- 目录结构要不要详细说明？→ 拆 `@.claude/docs/directory-structure.md`
+- 有没有专门的协作规则？→ 拆 `@.claude/docs/coordination-rules.md`
+- 有没有上下文管理策略？→ 拆 `@.claude/docs/context-management.md`
+
+为每个拆出去的内容创建子文件，在 CLAUDE.md 用 `@` 引用。
+
+### 第 5 步：识别"该分层"的内容（10 分钟）
+
+问自己：
+- 源码目录有没有专属规则？→ 写 `src/CLAUDE.md`
+- 文档目录有没有专属规则？→ 写 `docs/CLAUDE.md`
+- 测试目录有没有专属规则？→ 写 `tests/CLAUDE.md`
+
+每个子目录 CLAUDE.md 只写该目录专属的规则，不重复主 CLAUDE.md。
+
+### 第 6 步：写入门指引（5 分钟）
+
+新人打开项目第一眼该干嘛？写一句提示，用 `>` 引用块强调。
+
+### 第 7 步：审查和精简（持续）
+
+定期问：
+- 主 CLAUDE.md 超过 100 行了吗？超了 → 拆。
+- 有没有内容每次对话都用不到？有 → 拆。
+- 有没有个人偏好混进来了？有 → 移到 CLAUDE.local.md。
+
+---
+
+## CLAUDE.md 编写检查清单
+
+写完 CLAUDE.md 后，用这个清单自检：
+
+### 必备项
+- [ ] 有标题和一句话定位（领域 + 方式 + 特征）
+- [ ] 有技术栈（语言、框架、版本）
+- [ ] 有核心协作协议（写文件前问、不自动提交）
+- [ ] 有入门指引（新人第一眼知道干嘛）
+
+### 结构项
+- [ ] 主文件不超过 100 行（超过就拆）
+- [ ] 长内容用 `@` 引用拆出去
+- [ ] 局部规则放子目录 CLAUDE.md
+- [ ] 个人偏好放 CLAUDE.local.md
+
+### 内容项
+- [ ] 没有具体业务逻辑（放代码注释）
+- [ ] 没有临时指令（放对话里）
+- [ ] 没有 agent/skill/hook 定义（放 .claude/ 对应目录）
+- [ ] 没有重复内容
+
+### 可读性项
+- [ ] 用 `##` 分章节，清晰
+- [ ] 用 `-` 列表，不堆段落
+- [ ] 用 `>` 引用块强调重要提示
+- [ ] 用 `**加粗**` 标记关键词
+
+---
+
+## 常见反模式
+
+### 反模式 1：一句话 CLAUDE.md
+
+```markdown
+# 我的项目
+你是一个 Python 专家，帮我写代码。
+```
+
+**问题**：没有领域、没有技术栈、没有协作协议。AI 知道等于不知道。
+
+**修正**：补充定位、技术栈、协作协议。
+
+### 反模式 2：万字 CLAUDE.md
+
+把所有规范、流程、上下文都塞进 CLAUDE.md，几百行。
+
+**问题**：撑爆上下文，AI 抓不住重点，修改困难。
+
+**修正**：主文件精简到 100 行内，细节用 `@` 引用拆出去。
+
+### 反模式 3：角色冲突
+
+```markdown
+# 我的项目
+你是一个创意总监，负责游戏愿景。
+```
+
+但项目用了 subagent，subagent 定义里也写了"你是创意总监"。
+
+**问题**：主会话和子智能体角色冲突。
+
+**修正**：多智能体项目，主 CLAUDE.md 不设定角色，角色放 agent 定义。
+
+### 反模式 4：个人偏好污染团队配置
+
+```markdown
+# 项目 CLAUDE.md
+## 个人偏好
+- 我喜欢用 Opus
+- 我的 Python 命令是 py
+```
+
+**问题**：个人偏好提交到 git，团队其他人被影响。
+
+**修正**：个人偏好放 CLAUDE.local.md（gitignored）。
+
+### 反模式 5：规则重复
+
+主 CLAUDE.md 写了"写文件前问"，子目录 CLAUDE.md 又写一遍。
+
+**问题**：重复内容浪费上下文，修改时容易漏改。
+
+**修正**：子目录 CLAUDE.md 只补充，不重复主文件内容。
+
+### 反模式 6：临时指令永久化
+
+```markdown
+# 项目 CLAUDE.md
+## 当前任务
+今天帮我修登录页的 bug。
+```
+
+**问题**：临时任务写进 CLAUDE.md，每次对话都加载，任务完成后还在。
+
+**修正**：临时任务放对话里，CLAUDE.md 只放长期有效的配置。
+
+---
+
+## 一个最小可用模板
+
+如果你只想快速起步，用这个最小模板：
+
+```markdown
+# 项目名 -- 一句话副标题
+
+领域 + 规模/方式 + 核心特征的一句话定位。
+
+## Technology Stack
+- **Language**: Python 3.12
+- **Framework**: FastAPI
+- **Database**: PostgreSQL
+
+## Collaboration Protocol
+- 写文件前必须问"可以写到 [路径] 吗？"
+- 不经批准不提交
+- 决策模式：Question → Options → Decision → Draft → Approval
+
+## Coding Standards
+@.claude/docs/coding-standards.md
+
+## Project Structure
+@.claude/docs/directory-structure.md
+
+> **第一次会话？** 跑 `/start` 开始。
+```
+
+存成 `CLAUDE.md`，按需扩展。
+
+---
+
+## 进阶：这个项目还示范了什么
+
+如果你已经掌握基础，这个项目还有几个进阶技巧值得学：
+
+### 1. 用 CLAUDE.md 引导 agent 路由
+
+[technical-preferences.md](file:///workspace/.claude/docs/technical-preferences.md) 里的"Engine Specialists"和"File Extension Routing"表，告诉 skill 该为每种文件派哪个 agent。这是"用 CLAUDE.md 驱动编排"的进阶用法。
+
+### 2. 用 CLAUDE.md 锚定"模型知识边界"
+
+[src/CLAUDE.md](file:///workspace/src/CLAUDE.md) 里写：
+
+```markdown
+## Engine Version Warning
+The LLM's training data predates the pinned engine version.
+**Always check `docs/engine-reference/` before using any engine API.**
+```
+
+**这是很聪明的设计**：承认 AI 知识有截止日期，强制它查最新文档。防止 AI 用过时 API。
+
+### 3. 用 CLAUDE.md 强制"验证驱动开发"
+
+[coding-standards.md](file:///workspace/.claude/docs/coding-standards.md) 里写：
+
+```markdown
+- **Verification-driven development**: Write tests first when adding gameplay systems.
+  For UI changes, verify with screenshots. Compare expected output to actual output
+  before marking work complete.
+```
+
+**这是把方法论写进 CLAUDE.md**：不只规定"做什么"，还规定"怎么验证做了"。
+
+### 4. 用 CLAUDE.md 区分"BLOCKING"和"ADVISORY"
+
+[coding-standards.md](file:///workspace/.claude/docs/coding-standards.md) 的测试证据表：
+
+```markdown
+| Story Type | Required Evidence | Gate Level |
+|---|---|---|
+| Logic | Automated unit test | BLOCKING |
+| Visual/Feel | Screenshot + lead sign-off | ADVISORY |
+```
+
+**这是给 AI 明确"严格度等级"**：BLOCKING 必须满足，ADVISORY 建议满足。AI 知道哪些能通融，哪些不能。
+
+---
+
+## 总结：CLAUDE.md 编写的五条铁律
+
+1. **先定位，后细节**——开头一句话锚定领域和特征，后续所有内容在这个上下文里理解。
+2. **主文件精简，细节 `@` 引用**——主文件是目录页，不是正文。超过 100 行就该拆。
+3. **核心铁律直接写，长文档拆出去**——每次都要见的直接写，按需见的 `@` 引用。
+4. **局部规则放子目录 CLAUDE.md**——不污染全局上下文，按需加载。
+5. **团队配置和个人偏好分开**——CLAUDE.md 提交 git，CLAUDE.local.md 不提交。
+
+**一句话**：CLAUDE.md 是"项目宪法"——简短、稳定、锚定方向；细节法律拆到子文件，地方法规放地方。
+
+---
+
+## 延伸阅读
+
+- [这个项目的 CLAUDE.md](file:///workspace/CLAUDE.md)——本文的主要分析对象
+- [CLAUDE-local-template.md](file:///workspace/.claude/docs/CLAUDE-local-template.md)——个人配置模板
+- [src/CLAUDE.md](file:///workspace/src/CLAUDE.md)——源码目录分层 CLAUDE.md
+- [design/CLAUDE.md](file:///workspace/design/CLAUDE.md)——设计目录分层 CLAUDE.md
+- [docs/CLAUDE.md](file:///workspace/docs/CLAUDE.md)——文档目录分层 CLAUDE.md
+- [technical-preferences.md](file:///workspace/.claude/docs/technical-preferences.md)——技术偏好子文件范例
+- [coding-standards.md](file:///workspace/.claude/docs/coding-standards.md)——编码标准子文件范例
+- [study-docs/02-Claude-Code基础概念.md](file:///workspace/study-docs/02-Claude-Code基础概念.md)——本系列的基础概念篇
+- [study-docs/07-协作协议与人在环.md](file:///workspace/study-docs/07-协作协议与人在环.md)——协作协议详解

--- a/study-docs/12-从零编排智能体协作.md
+++ b/study-docs/12-从零编排智能体协作.md
@@ -1,0 +1,815 @@
+# 12 · 从零编排智能体协作流程
+
+前面 11 篇讲了"零件是什么"。这一篇是**综合实操**——回答四个问题：
+
+1. 主会话是怎么触发智能体调用的？
+2. 智能体触发规则写在哪里？
+3. 一个完整的智能体调用流程长什么样？
+4. 这个工作室从零开始怎么搭起来？
+
+读完这篇，你应该能拿着任何一个空项目，照着步骤把一套多智能体协作编排搭出来。
+
+---
+
+## 第一部分：原理篇 —— 主会话如何触发智能体
+
+### 1.1 触发的本质：`Task` 工具 + `subagent_type`
+
+Claude Code 的主会话（你在终端里敲 `claude` 开的那个会话）本身就是一个 AI。它要"变成一支团队"，靠的不是魔法，而是一个内置工具：**`Task`**。
+
+`Task` 工具的作用是：**在当前会话里派生一个子智能体**。子智能体在自己的上下文窗口里独立运行，干完活把结果返回给主会话。
+
+最简的调用长这样：
+
+```
+Task(
+  subagent_type: "gameplay-programmer",
+  description: "实现近战命中检测",
+  prompt: "读 production/epics/combat/melee-hitbox.md，按 ADR 实现到 src/gameplay/combat/，写测试到 tests/combat/"
+)
+```
+
+- `subagent_type` —— 指定派哪个智能体。这个名字必须对应 [.claude/agents/](file:///workspace/.claude/agents/) 下一个 `[name].md` 文件。
+- `prompt` —— 给子智能体的任务说明。
+- 子智能体跑完后，返回一段文本结果给主会话。
+
+**类比**：主会话是"项目经理"，`Task` 是它"派活"的动作。它喊一声"gameplay-programmer，把这个故事实现了"，gameplay-programmer 就在自己的工位（独立上下文）干完活，把成果交回来。
+
+**关键点**：主会话**不会自动**派智能体。它什么时候派、派谁、派几个，全靠**技能（skill）的正文**告诉它。这就是下一节要讲的"触发规则"。
+
+---
+
+### 1.2 触发规则写在哪里：三层规则源
+
+智能体的触发规则分散在三层文件里，各管一摊：
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  第 1 层：智能体定义文件（"员工档案"）                    │
+│  .claude/agents/[name].md                                │
+│  → 定义：这个智能体是谁、能用什么工具、用什么模型        │
+├─────────────────────────────────────────────────────────┤
+│  第 2 层：技能编排文件（"作业指导书"）                   │
+│  .claude/skills/[name]/SKILL.md                          │
+│  → 定义：什么时候派哪个智能体、按什么顺序、并行还是串行  │
+├─────────────────────────────────────────────────────────┤
+│  第 3 层：协调规则文档（"公司制度")                      │
+│  .claude/docs/coordination-rules.md                      │
+│  .claude/docs/agent-coordination-map.md                 │
+│  .claude/docs/director-gates.md                         │
+│  → 定义：谁能委派给谁、冲突怎么升级、门禁怎么过         │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### 第 1 层：智能体定义（员工档案）
+
+位置：[.claude/agents/](file:///workspace/.claude/agents/)，每个智能体一个 `.md` 文件。
+
+看 [creative-director.md](file:///workspace/.claude/agents/creative-director.md) 的开头：
+
+```yaml
+---
+name: creative-director
+description: "The Creative Director is the highest-level creative authority..."
+tools: Read, Glob, Grep, Write, Edit, WebSearch
+model: opus
+maxTurns: 30
+disallowedTools: Bash
+skills: [brainstorm, design-review]
+---
+```
+
+**这里定义的是"这个智能体长什么样"**：
+
+| 字段 | 作用 | 编排意义 |
+|------|------|----------|
+| `name` | 智能体名（= `subagent_type` 的值） | 主会话靠这个名字派它 |
+| `tools` | 能用哪些工具 | **最小权限原则**——总监禁 `Bash`，QA 用 Haiku |
+| `model` | 用哪个模型 | 总监用 Opus（贵但聪明），格式化任务用 Haiku（便宜） |
+| `maxTurns` | 最多跑几轮 | 防止子智能体跑飞 |
+| `disallowedTools` | 显式禁用的工具 | 防止越权（总监不该跑命令） |
+
+**这一层不管"什么时候派"，只管"派出来之后它是什么样"**。
+
+#### 第 2 层：技能编排（作业指导书）
+
+位置：[.claude/skills/](file:///workspace/.claude/skills/)，每个技能一个子目录，里面有 `SKILL.md`。
+
+**这是触发规则的核心**。主会话什么时候派智能体、派谁、派几个、按什么顺序，全写在 skill 的正文里。
+
+看 [team-combat/SKILL.md](file:///workspace/.claude/skills/team-combat/SKILL.md) 的编排指令：
+
+```markdown
+## How to Delegate
+
+Use the Task tool to spawn each team member as a subagent:
+- subagent_type: game-designer — Design the mechanic
+- subagent_type: gameplay-programmer — Implement the core gameplay code
+- subagent_type: ai-programmer — Implement NPC/enemy AI behavior
+- subagent_type: technical-artist — Create VFX, shader effects
+- subagent_type: sound-designer — Define audio events
+- subagent_type: [primary engine specialist] — Engine idiom validation
+- subagent_type: qa-tester — Write test cases
+
+## Pipeline
+### Phase 1: Design → Delegate to game-designer
+### Phase 2: Architecture → Delegate to gameplay-programmer (+ ai-programmer)
+### Phase 3: Implementation (parallel where possible)
+  - gameplay-programmer: Implement core combat code
+  - ai-programmer: Implement AI behaviors
+  - technical-artist: Create VFX
+  - sound-designer: Define audio event list
+### Phase 4: Integration
+### Phase 5: Validation → Delegate to qa-tester
+```
+
+**这就是触发规则**。它告诉主会话：
+
+- **派谁**：7 个智能体（用 `subagent_type` 列出来）
+- **顺序**：Phase 1 → 2 → 3 → 4 → 5
+- **并行还是串行**：Phase 3 标了 "parallel where possible"——4 个独立的实现智能体一起派
+- **决策点**：每个 Phase 之间用 `AskUserQuestion` 让用户确认
+
+**关键设计**：skill 用**自然语言**写编排逻辑，AI 读了之后照着执行。不是代码，是"给 AI 看的 SOP"。
+
+#### 第 3 层：协调规则（公司制度）
+
+位置：[.claude/docs/](file:///workspace/.claude/docs/)。
+
+这一层管"跨技能的通用规则"——单个 skill 管不到的全局纪律。
+
+| 文件 | 管什么 | 关键规则 |
+|------|--------|----------|
+| [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) | 委派/并行/冲突 | 垂直委派不跳层、同级可咨询不能下命令、冲突找共同上级 |
+| [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md) | 谁能指挥谁 | 委派关系表、升级路径表、9 种工作流模式 |
+| [director-gates.md](file:///workspace/.claude/docs/director-gates.md) | 总监门禁 | 20+ 个门禁 ID（CD-PILLARS、TD-ARCHITECTURE 等）、三态裁决（APPROVE/CONCERNS/REJECT） |
+| [workflow-catalog.yaml](file:///workspace/.claude/docs/workflow-catalog.yaml) | 7 阶段流水线 | Concept → Systems Design → Technical Setup → Pre-Production → Production → Polish → Release |
+
+**这一层是"宪法"**。任何 skill 在派智能体时，都要遵守这里的规则（比如不能跳层委派、跨域改动要 producer 协调）。
+
+#### 三层的关系
+
+```
+用户敲 /team-combat
+       │
+       ▼
+主会话读 team-combat/SKILL.md（第 2 层：作业指导书）
+       │
+       │  SKILL.md 说"派 game-designer"
+       ▼
+主会话读 .claude/agents/game-designer.md（第 1 层：员工档案）
+       │  → 知道它用 Sonnet、能用 Read/Write/Task、maxTurns 20
+       │
+       │  SKILL.md 说"并行派 4 个实现智能体"
+       ▼
+主会话查 coordination-rules.md（第 3 层：公司制度）
+       │  → 确认并行协议：先发后等、收齐再走、阻塞立即上报
+       ▼
+主会话发 4 个 Task 调用（并行）
+```
+
+---
+
+### 1.3 三种触发路径
+
+智能体被派生有三种典型路径：
+
+#### 路径 A：用户直接调用单智能体 skill
+
+```
+用户敲 /dev-story path
+  → skill 内部路由表决定派哪个 programmer
+  → Task 派 1 个子智能体
+```
+
+**特征**：单智能体、串行、用户驱动。最高频的路径。
+
+#### 路径 B：编排 skill 派生多智能体
+
+```
+用户敲 /team-combat "melee parry system"
+  → skill 按 Phase 1→2→3→4→5 编排
+  → Phase 3 并行派 4 个子智能体
+  → 每个 Phase 之间 AskUserQuestion 让用户确认
+```
+
+**特征**：多智能体、有并行有串行、人在环中决策。复杂功能的路径。
+
+#### 路径 C：总监门禁并行派生
+
+```
+用户敲 /gate-check production
+  → skill 并行派 4 个总监（creative/technical/producer/art-director）
+  → 每个总监跑各自的 PHASE-GATE
+  → 收齐 4 个裁决，取最严格的（一个 NOT READY 全部 FAIL）
+```
+
+**特征**：纯并行、裁决式、取最严。阶段切换的把关路径。来自 [director-gates.md](file:///workspace/.claude/docs/director-gates.md) 的 "Parallel Gate Protocol"。
+
+---
+
+## 第二部分：流程篇 —— 一个完整的智能体调用流程
+
+以最高频的 `/dev-story` 为例，画出从用户敲命令到子智能体返回的**完整调用链**。
+
+### 2.1 调用流程图
+
+```
+用户敲: /dev-story production/epics/combat/melee-hitbox.md
+  │
+  ▼
+[1] Claude Code 识别 slash 命令
+  │   → 加载 .claude/skills/dev-story/SKILL.md 到主会话上下文
+  │
+  ▼
+[2] Phase 1: 找故事
+  │   → Read 故事文件 production/epics/combat/melee-hitbox.md
+  │   → 提取: 标题、ID、层、类型、TR-ID、ADR、验收标准、依赖
+  │
+  ▼
+[3] Phase 2: 加载上下文（并行读 5 个文件）
+  │   → Read docs/architecture/tr-registry.yaml        (查 TR-COMBAT-003)
+  │   → Read docs/architecture/adr-002-melee-combat.md  (治理 ADR)
+  │   → Read docs/architecture/control-manifest.md      (Core 层规则)
+  │   → Read .claude/docs/technical-preferences.md      (命名规范)
+  │   → Glob production/epics/**/*.md                   (依赖校验)
+  │
+  │   依赖没完成? → AskUserQuestion → 用户选 A/B/C
+  │   清单版本不一致? → AskUserQuestion → 用户选 A/B/C
+  │
+  ▼
+[4] Phase 3: 路由到正确的程序员
+  │   → 查路由表: Core 层 + Logic 类型 + 玩法机制 → gameplay-programmer
+  │   → 查 ADR 引擎风险: HIGH? → 额外派 godot-specialist
+  │
+  ▼
+[5] Phase 4: 派生子智能体（关键步骤）
+  │   主会话调用 Task 工具:
+  │   ┌─────────────────────────────────────────────┐
+  │   │ Task(                                         │
+  │   │   subagent_type: "gameplay-programmer",       │
+  │   │   prompt: "1. 读故事文件 [path]               │
+  │   │            2. 查 TR-ID 在 tr-registry.yaml    │
+  │   │            3. 读 ADR 的 Decision + Guidelines  │
+  │   │            4. 读 control-manifest 的 Core 层  │
+  │   │            5. 读 technical-preferences        │
+  │   │            6. 创建测试文件 [path]              │
+  │   │            7. 按 ADR 实现，不越 Out of Scope"  │
+  │   │ )                                            │
+  │   └─────────────────────────────────────────────┘
+  │
+  ▼
+[6] Hook 触发: SubagentStart
+  │   → .claude/hooks/log-agent.sh 运行
+  │   → 记录到 production/session-logs/agent-audit.log:
+  │     "20260622_143022 | Agent invoked: gameplay-programmer"
+  │
+  ▼
+[7] 子智能体在独立上下文里工作
+  │   → 读它被告知要读的文件
+  │   → 按 ADR 实现指南写代码到 src/gameplay/combat/melee_hitbox.gd
+  │   → 写测试到 tests/combat/melee_hitbox_test.gd
+  │   → 遵守 "May I write to [path]?" 协议（先问用户）
+  │   → 写完返回一段总结文本
+  │
+  ▼
+[8] Hook 触发: SubagentStop
+  │   → .claude/hooks/log-agent-stop.sh 运行
+  │   → 完成审计记录
+  │
+  ▼
+[9] 主会话收到子智能体的返回结果
+  │   → Phase 6: 汇总（改了哪些文件、测试写了几个、有无偏差）
+  │   → 输出实现摘要给用户
+  │
+  ▼
+[10] Phase 7: 更新会话状态
+  │   → 追加到 production/session-state/active.md
+  │   → "Story: melee-hitbox — Files changed: [list] — Next: /code-review"
+  │
+  ▼
+[11] 推荐下一步
+      → "Ready for: /code-review [files] then /story-done [story-path]"
+```
+
+### 2.2 关键节点详解
+
+#### 节点 [3]：为什么并行读 5 个文件？
+
+来自 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md) Phase 2：
+
+> Read all of the following simultaneously — these are independent reads. Do not start implementation until all context is loaded.
+
+**编排智慧**：这 5 个文件互不依赖（读 ADR 不需要先读 TR registry），所以一起发、一起等。如果串行读，要等 5 倍时间。这是 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) "Parallel Task Protocol" 的体现：**先发后等，收齐再走**。
+
+#### 节点 [5]：为什么给路径不给内容？
+
+skill 告诉子智能体"读 [path]"，而不是把文件内容塞进 prompt。原因：
+
+- **省 token**：主会话不复制大段内容到子智能体的 prompt
+- **子智能体自己读最新版**：避免主会话读了之后文件被改，子智能体拿到旧内容
+- **职责清晰**：子智能体自己决定读哪几行，主会话不替它做决定
+
+#### 节点 [6][8]：Hook 在流程里的角色
+
+Hook 不是"触发智能体"的机制，而是"智能体被触发时自动记录"的机制。
+
+来自 [.claude/settings.json](file:///workspace/.claude/settings.json)：
+
+```json
+"SubagentStart": [{ "matcher": "", "hooks": [{ "command": "bash .claude/hooks/log-agent.sh" }] }],
+"SubagentStop":  [{ "matcher": "", "hooks": [{ "command": "bash .claude/hooks/log-agent-stop.sh" }] }]
+```
+
+每次主会话派生子智能体，`log-agent.sh` 自动记一行审计日志。这是"无侵入观测"——编排逻辑不用改，hook 自动记录谁被派了、什么时候派的、派了多久。
+
+#### 节点 [9]：子智能体返回什么？
+
+子智能体不直接修改主会话的上下文。它返回一段**文本结果**给主会话，主会话再基于这段文本决定下一步。
+
+**这是编排的关键约束**：子智能体的"成果"是它写的文件（代码、测试、文档），不是它返回的文本。返回的文本只是"汇报"。主会话要汇总、要决策、要推荐下一步，都基于这段汇报 + 它自己再读一遍文件。
+
+---
+
+### 2.3 三种触发模式的对比
+
+| 模式 | 触发命令 | 派几个 | 并行/串行 | 人在环 |
+|------|----------|--------|-----------|--------|
+| 单智能体 | `/dev-story` | 1 | 串行 | 派之前确认上下文 |
+| 编排团队 | `/team-combat` | 4-7 | 混合（Phase 3 并行） | 每个 Phase 之间确认 |
+| 总监门禁 | `/gate-check` | 4 | 纯并行 | 收齐裁决后用户决定是否推进 |
+
+---
+
+## 第三部分：搭建篇 —— 工作室如何从零建立
+
+这一部分是**实操指南**。假设你拿到一个空项目，要照着这个范例搭一套多智能体协作编排，按 8 步走。
+
+### 步骤 1：写 `CLAUDE.md`（定方向）
+
+**目的**：告诉 AI 这个项目是什么、技术栈是什么、要遵守哪些总原则。
+
+**最小可用版本**：
+
+```markdown
+# 我的项目 — 多智能体编排示范
+
+## Technology Stack
+- **语言**: Python 3.11
+- **框架**: FastAPI
+- **版本控制**: Git
+
+## Coordination Rules
+@.claude/docs/coordination-rules.md
+
+## Collaboration Protocol
+**User-driven collaboration, not autonomous execution.**
+Every task follows: Question -> Options -> Decision -> Draft -> Approval
+```
+
+**关键点**：
+- 用 `@路径` 引用子文件，保持 `CLAUDE.md` 精简（参考本项目的 [CLAUDE.md](file:///workspace/CLAUDE.md) 只有 60 行）
+- 写明"人在环"协议——这是防止 AI 越权的总开关
+- 技术栈要写清楚，智能体会读这个决定用什么 API
+
+**类比**：公司章程。开篇定调子，细节引用到各部门制度。
+
+---
+
+### 步骤 2：创建 `.claude/` 目录骨架
+
+**目的**：搭好"配置零件"的容器。
+
+```
+.claude/
+  settings.json          # 机器配置（权限+钩子）
+  agents/                # 智能体定义（员工档案）
+  skills/                # 技能定义（作业指导书）
+  hooks/                 # 钩子脚本（自动守卫）
+  rules/                 # 路径规则（按目录生效）
+  docs/                  # 协调规则文档（公司制度）
+    coordination-rules.md
+    agent-coordination-map.md
+    director-gates.md
+    workflow-catalog.yaml
+```
+
+**关键点**：先建空目录，后面逐步填内容。不要一上来就写 49 个智能体——先跑通一个，再扩展。
+
+---
+
+### 步骤 3：定义第一个智能体（`.claude/agents/`）
+
+**目的**：先定义一个最小可用的智能体，验证 `Task` 工具能派生它。
+
+**最小可用智能体**（参考 [gameplay-programmer.md](file:///workspace/.claude/agents/gameplay-programmer.md)）：
+
+```markdown
+---
+name: backend-programmer
+description: "后端程序员，实现 API 和业务逻辑代码"
+tools: Read, Glob, Grep, Write, Edit, Bash
+model: sonnet
+maxTurns: 20
+---
+
+You are a Backend Programmer. You translate design documents into clean,
+tested code following the project's architecture decisions.
+
+### Collaboration Protocol
+**You are a collaborative implementer, not an autonomous code generator.**
+1. Read the design document
+2. Ask architecture questions if ambiguous
+3. Propose approach before implementing
+4. Get approval before writing files: "May I write this to [path]?"
+5. Implement with transparency
+6. Offer next steps
+
+### What This Agent Must NOT Do
+- Make architectural decisions (delegate to tech-lead)
+- Modify files outside src/api/ without delegation
+- Skip tests for logic stories
+```
+
+**关键设计**：
+- `tools` 用**最小权限**——只给真正需要的工具
+- `maxTurns` 设上限（20）防止跑飞
+- 正文写"协作协议"——明确它是"提议者"不是"决定者"
+- 写"Must NOT Do"——防止越权
+
+**验证**：在主会话里手动派一次，确认能跑通：
+
+```
+Task(subagent_type: "backend-programmer", prompt: "读 README.md，总结项目结构")
+```
+
+---
+
+### 步骤 4：定义第一个技能（`.claude/skills/`）
+
+**目的**：把"派智能体"的逻辑固化成可复用的 `/命令`。
+
+**最小可用技能**（参考 [dev-story/SKILL.md](file:///workspace/.claude/skills/dev-story/SKILL.md)）：
+
+```markdown
+---
+name: implement-story
+description: "读一个故事文件，路由到正确的程序员，实现它"
+argument-hint: "[story-path]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Bash, Task, AskUserQuestion
+model: sonnet
+---
+
+# Implement Story
+
+## Phase 1: 找故事
+- 如果有参数: Read 那个文件
+- 如果没参数: Glob production/stories/**/*.md，列出 Status: Ready 的
+
+## Phase 2: 加载上下文
+并行读:
+- 故事文件（提取验收标准、依赖、Out of Scope）
+- 治理 ADR（如果故事里写了 ADR 路径）
+- 技术偏好（.claude/docs/technical-preferences.md）
+
+依赖没完成? → AskUserQuestion 让用户选 A/B/C
+
+## Phase 3: 路由
+| 故事类型 | 派给 |
+|----------|------|
+| API 逻辑 | backend-programmer |
+| 数据库迁移 | db-engineer |
+| 前端组件 | frontend-programmer |
+
+## Phase 4: 实现
+用 Task 工具派生子智能体:
+Task(
+  subagent_type: "[路由结果]",
+  prompt: "1. 读故事 [path]  2. 读 ADR [path]  3. 按 ADR 实现  4. 写测试"
+)
+
+## Phase 5: 汇总
+- 收集子智能体返回的结果
+- 输出: 改了哪些文件、测试写了几个、有无偏差
+- 推荐: /code-review [files] 然后 /story-done [path]
+```
+
+**关键设计**：
+- `allowed-tools` 必须包含 `Task`——否则 skill 不能派子智能体
+- `user-invocable: true`——用户能直接敲 `/implement-story` 触发
+- 正文分 Phase——给 AI 读的 SOP，每步做什么写清楚
+- 路由表——明确什么情况派谁，不让 AI 猜
+
+**验证**：敲 `/implement-story production/stories/xxx.md`，看主会话是否按 Phase 走、是否派对了智能体。
+
+---
+
+### 步骤 5：配置 `settings.json`（钩子 + 权限）
+
+**目的**：搭好"门禁系统"——自动放行安全操作、拦住危险操作、在关键事件自动校验。
+
+**最小可用配置**（参考 [.claude/settings.json](file:///workspace/.claude/settings.json)）：
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status*)", "Bash(git diff*)", "Bash(git log*)",
+      "Bash(pytest*)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)", "Bash(git push --force*)",
+      "Bash(git reset --hard*)", "Read(**/.env*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [
+        { "type": "command", "command": "bash .claude/hooks/validate-commit.sh", "timeout": 15 }
+      ]}
+    ],
+    "SubagentStart": [
+      { "matcher": "", "hooks": [
+        { "type": "command", "command": "bash .claude/hooks/log-agent.sh", "timeout": 5 }
+      ]}
+    ],
+    "SubagentStop": [
+      { "matcher": "", "hooks": [
+        { "type": "command", "command": "bash .claude/hooks/log-agent-stop.sh", "timeout": 5 }
+      ]}
+    ]
+  }
+}
+```
+
+**关键设计**：
+- `permissions.allow`——白名单自动放行（git status、测试），减少用户确认摩擦
+- `permissions.deny`——黑名单永远拦（`rm -rf`、强推、读 `.env`）
+- `SubagentStart/Stop` hook——自动记录审计日志，无侵入观测智能体调用
+
+**类比**：门禁系统。白名单的进，黑名单的拦，特定时刻自动巡检。
+
+---
+
+### 步骤 6：写协调规则（`.claude/docs/`）
+
+**目的**：定"公司制度"——跨技能通用的纪律。
+
+**最小规则集**（参考 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md)）：
+
+```markdown
+# Agent Coordination Rules
+
+1. **Vertical Delegation**: 主管委派给专家，不跳层。
+2. **Horizontal Consultation**: 同级可咨询，不能下命令。
+3. **Conflict Resolution**: 冲突找共同上级。
+4. **Change Propagation**: 跨域改动由总协调者协调。
+5. **No Unilateral Cross-Domain Changes**: 不许改别人家的文件。
+
+## Parallel Task Protocol
+1. 先发后等：所有独立的 Task 调用一起发出
+2. 收齐再走：所有结果收齐再进依赖阶段
+3. 阻塞立即上报：任何智能体 BLOCKED 立刻告诉用户
+4. 必出部分报告：哪怕部分阻塞也要汇报已完成的部分
+```
+
+**委派关系表**（参考 [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md)）：
+
+```markdown
+## Delegation Rules
+| 谁委派 | 能委派给 |
+|--------|----------|
+| tech-lead | backend-programmer, frontend-programmer, db-engineer |
+| product-manager | 任何智能体（只能在对方领域内） |
+
+## Escalation Paths
+| 冲突场景 | 升级给谁 |
+|----------|----------|
+| 两个程序员对实现有分歧 | tech-lead |
+| 产品 vs 技术可行性 | product-manager 协调 |
+```
+
+**关键点**：规则要**少而硬**。5 条核心规则 + 1 张委派表 + 1 张升级表，足够起步。规则越多，AI 越容易绕过。
+
+---
+
+### 步骤 7：跑通第一个端到端流程
+
+**目的**：验证整条链路能走通——从用户敲命令到子智能体返回。
+
+**测试用例**：
+
+1. 创建一个最小故事文件 `production/stories/test-001.md`：
+   ```markdown
+   # Story: 实现健康检查接口
+   - Type: Logic
+   - Layer: Core
+   - Acceptance Criteria:
+     - [ ] GET /health 返回 200
+     - [ ] 响应体包含 {"status": "ok"}
+   ```
+
+2. 敲 `/implement-story production/stories/test-001.md`
+
+3. 验证：
+   - 主会话是否按 Phase 1→2→3→4→5 走？
+   - 是否派了 `backend-programmer`？
+   - `agent-audit.log` 是否有记录？
+   - 子智能体是否遵守"May I write to [path]?"协议？
+   - 是否输出了汇总和下一步推荐？
+
+**跑不通的常见原因**：
+- skill 的 `allowed-tools` 没包含 `Task` → 不能派子智能体
+- 智能体名拼错 → `subagent_type` 找不到对应文件
+- `maxTurns` 太小 → 子智能体没干完就停了
+- 没写协作协议 → 子智能体直接写文件不问用户
+
+---
+
+### 步骤 8：扩展到多智能体协作
+
+**目的**：从单智能体扩展到团队编排。
+
+**扩展顺序**（参考本项目的演化路径）：
+
+1. **加第二个智能体**：比如 `qa-tester`，让 `/implement-story` 完成后能派 QA 写测试
+2. **加编排 skill**：参考 [team-combat/SKILL.md](file:///workspace/.claude/skills/team-combat/SKILL.md) 写一个 `/team-feature`，编排多个智能体并行
+3. **加总监层**：加一个 `tech-lead`（Opus 模型），让它做架构决策和代码审查
+4. **加门禁**：参考 [director-gates.md](file:///workspace/.claude/docs/director-gates.md) 定义 `TL-ARCHITECTURE`、`TL-CODE-REVIEW` 等门禁 ID
+5. **加阶段流水线**：参考 [workflow-catalog.yaml](file:///workspace/.claude/docs/workflow-catalog.yaml) 定义 Concept → ... → Release 的 7 阶段
+6. **加路径规则**：参考 [.claude/rules/](file:///workspace/.claude/rules/) 给 `src/api/`、`src/db/` 等目录写专属规则
+
+**关键原则**：**每加一层，先验证不破坏已有流程**。不要一次性加 10 个智能体——加一个、跑通、再加下一个。
+
+---
+
+## 第四部分：编排篇 —— 如何从零设计协作流程
+
+这一部分回答最核心的问题：**拿到一个业务需求，怎么设计智能体协作流程？**
+
+### 4.1 编排的五个核心问题
+
+设计任何协作流程前，先回答这五个问题：
+
+| 问题 | 回答了什么 | 写在哪里 |
+|------|-----------|----------|
+| **谁干？** | 派哪些智能体 | skill 的 "Team Composition" 段 |
+| **什么顺序？** | 串行还是并行、谁先谁后 | skill 的 "Pipeline" 段 |
+| **什么时候问用户？** | 哪些决策点要人在环 | skill 里 `AskUserQuestion` 的位置 |
+| **出错怎么办？** | 子智能体 BLOCKED 的处理 | skill 的 "Error Recovery Protocol" |
+| **怎么收尾？** | 汇总什么、推荐什么下一步 | skill 的 "Output" 和 "Next Steps" |
+
+**这五个问题答完，协作流程就成型了**。本项目的所有 `team-*` skill 都按这个结构写。
+
+---
+
+### 4.2 编排模式库（从本项目提炼）
+
+本项目示范了 9 种可复用的编排模式，全在 [agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md) 的 "Common Workflow Patterns" 里。提炼成模式库：
+
+#### 模式 1：单智能体实现（最简）
+
+```
+用户 → skill → 路由表 → Task(1 个智能体) → 汇总
+```
+- **适用**：明确单一职责的任务（实现一个故事、写一个测试）
+- **范例**：`/dev-story`
+
+#### 模式 2：流水线编排（串行多阶段）
+
+```
+Phase 1 → Phase 2 → Phase 3 → ... → Phase N
+每个 Phase 派 1 个智能体，串行
+```
+- **适用**：有明确阶段依赖的流程（设计→架构→实现→测试）
+- **范例**：`/team-combat` 的 Phase 1→2→4→5
+
+#### 模式 3：并行扇出（同阶段多智能体）
+
+```
+       ┌→ Agent A ┐
+Phase →├→ Agent B ├→ 汇总
+       └→ Agent C ┘
+```
+- **适用**：同一阶段多个互不依赖的子任务
+- **范例**：`/team-combat` Phase 3（gameplay + ai + vfx + audio 并行）
+
+#### 模式 4：门禁并行裁决（取最严）
+
+```
+       ┌→ Director 1 → APPROVE    ┐
+gate →├→ Director 2 → CONCERNS    ├→ 取最严 → PASS/FAIL
+       ├→ Director 3 → NOT READY  ┤
+       └→ Director 4 → APPROVE    ┘
+```
+- **适用**：阶段切换前的多维度把关
+- **范例**：`/gate-check` 并行派 4 个总监
+
+#### 模式 5：升级链（冲突找上级）
+
+```
+Specialist A ⟷ Specialist B（谈不拢）
+       ↓ 升级
+Lead（仲裁）
+       ↓ 还谈不拢
+Director（最终裁决）
+```
+- **适用**：智能体之间有分歧
+- **范例**：[agent-coordination-map.md](file:///workspace/.claude/docs/agent-coordination-map.md) 的 "Escalation Paths"
+
+#### 模式 6：变更传播（跨域协调）
+
+```
+Design 变更 → 通知 Lead Programmer + QA Lead + Producer
+            → Producer 协调跨部门影响
+```
+- **适用**：一个变更影响多个域
+- **范例**：[coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) 第 4 条
+
+#### 模式 7：循环迭代（冲刺周期）
+
+```
+sprint-plan → [所有智能体执行] → sprint-status → retrospective → 下一个 sprint
+```
+- **适用**：周期性重复流程
+- **范例**：`/sprint-plan` → `/dev-story` ×N → `/retrospective`
+
+#### 模式 8：错误恢复（部分失败）
+
+```
+Task 派 4 个智能体 → 1 个 BLOCKED
+  → 立即上报用户
+  → AskUserQuestion: 跳过/重试/停下
+  → 必出部分报告
+```
+- **适用**：任何并行编排
+- **范例**：所有 `team-*` skill 的 "Error Recovery Protocol"
+
+#### 模式 9：人在环决策（每个 Phase 确认）
+
+```
+Phase 1 → AskUserQuestion → 用户选 A/B/C → Phase 2 → AskUserQuestion → ...
+```
+- **适用**：高 stakes 流程，每步都要人确认
+- **范例**：`/team-combat` 每个 Phase 之间
+
+---
+
+### 4.3 编排清单（设计新流程时逐项检查）
+
+设计一个新的协作流程时，照这个清单逐项确认：
+
+- [ ] **角色**：派哪些智能体？每个的 `subagent_type` 对应 `.claude/agents/` 里有文件吗？
+- [ ] **顺序**：哪些 Phase 串行、哪些并行？并行的真的互不依赖吗？
+- [ ] **上下文**：每个子智能体被告知要读哪些文件？给路径还是给内容？（给路径）
+- [ ] **决策点**：哪些地方要 `AskUserQuestion`？选项设计好了吗？
+- [ ] **错误恢复**：子智能体 BLOCKED 怎么办？跳过/重试/停下？
+- [ ] **汇总**：收齐结果后输出什么格式？改了哪些文件、测试几个、有无偏差？
+- [ ] **下一步**：推荐用户接下来跑什么命令？
+- [ ] **权限**：skill 的 `allowed-tools` 包含 `Task` 吗？
+- [ ] **协调规则**：派智能体时遵守了"不跳层、不跨域"吗？
+- [ ] **审计**：`SubagentStart/Stop` hook 会自动记录，不用手动管
+
+---
+
+## 小测验
+
+**Q1**：主会话派智能体靠什么工具？`subagent_type` 的值对应哪个文件？
+> **A**：靠 `Task` 工具。`subagent_type` 的值对应 `.claude/agents/[name].md` 文件。
+
+**Q2**：智能体的"触发规则"主要写在哪一层？
+> **A**：第 2 层——`.claude/skills/[name]/SKILL.md` 的正文。它用自然语言告诉主会话"什么时候派谁、按什么顺序"。
+
+**Q3**：为什么 `/dev-story` 的 Phase 2 要并行读 5 个文件而不是串行？
+> **A**：这 5 个文件互不依赖（读 ADR 不需要先读 TR registry），并行读省 5 倍时间。这是 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) "Parallel Task Protocol" 的体现：先发后等，收齐再走。
+
+**Q4**：`SubagentStart` hook 和 `Task` 工具是什么关系？
+> **A**：`Task` 是主会话"派"智能体的动作；`SubagentStart` hook 是"智能体被派时自动触发的脚本"。hook 不派智能体，只记录"谁被派了"。这是无侵入观测。
+
+**Q5**：从零搭建工作室，为什么要先跑通单智能体再扩展到多智能体？
+> **A**：每加一层都要验证不破坏已有流程。一次性加 10 个智能体，出问题不知道是哪个的锅。增量验证是工程化的基本纪律。
+
+---
+
+## 动手
+
+1. 打开 [team-combat/SKILL.md](file:///workspace/.claude/skills/team-combat/SKILL.md)，对照"4.2 编排模式库"，找出它用了哪几种模式（答案：模式 2 流水线 + 模式 3 并行扇出 + 模式 8 错误恢复 + 模式 9 人在环）。
+
+2. 打开 [director-gates.md](file:///workspace/.claude/docs/director-gates.md)，找到 "Parallel Gate Protocol"，看它怎么实现"取最严裁决"——这是模式 4 的范例。
+
+3. 拿一个你自己的业务需求（不一定是游戏开发），试着回答"4.1 编排的五个核心问题"，画出协作流程草图。不需要写代码，纸上画出来就行。
+
+4. 在一个空项目里照着"第三部分：搭建篇"走一遍，跑到步骤 7（跑通第一个端到端流程）为止。能跑通，说明你已经掌握了从零编排的基本功。
+
+---
+
+## 一句话总结
+
+> **从零编排智能体协作 = 写 `CLAUDE.md` 定方向 + 写 `agents/` 定角色 + 写 `skills/` 定流程 + 写 `settings.json` 定守卫 + 写 `docs/` 定制度 + 用 `Task` 工具把流程跑起来。**
+
+核心不是"定义很多智能体"，而是"设计好它们怎么协作"。先跑通一个，再扩展到多个，最后加门禁和阶段流水线。
+
+---
+
+上一篇 → [11 CLAUDE.md 编写指导](file:///workspace/study-docs/11-CLAUDE.md编写指导.md)

--- a/study-docs/12-从零编排智能体协作.md
+++ b/study-docs/12-从零编排智能体协作.md
@@ -11,31 +11,61 @@
 
 ---
 
+## 0. 官方文档勘误与补充（先读这段）
+
+本篇依据 [Claude Code 官方文档](https://code.claude.com/docs/zh-CN/agents) 校对，纠正几个容易混淆的关键点：
+
+| 问题 | 正确答案 | 出处 |
+|------|----------|------|
+| Task 工具是用户定义的吗？ | **不是**。它是 Claude Code **内置工具**，和 Read/Write/Bash 一样自带，用户不需要在任何文件里"定义"它 | [sub-agents 文档](https://code.claude.com/docs/zh-CN/sub-agents) |
+| Task 工具现在还叫 Task 吗？ | v2.1.63 起改名为 **`Agent`**。`Task(...)` 仍作为别名工作，但新写法是 `Agent(...)` | 同上 |
+| 用户能定义的是什么？ | **智能体（agent）本身**——用 `.claude/agents/[name].md` 文件定义。Task/Agent 工具只是"派生"它的内置机制 | 同上 |
+| agent 文件放哪？ | 两个位置：项目级 `.claude/agents/`（可提交 git 共享）、全局级 `~/.claude/agents/`（个人配置） | [claude-directory 文档](https://code.claude.com/docs/zh-CN/claude-directory) |
+| 有没有内置 agent？ | 有。Explore（只读搜索）、Plan（规划）、general-purpose（通用）是自带的，不用定义就能派 | [sub-agents 文档](https://code.claude.com/docs/zh-CN/sub-agents#built-in-subagents) |
+| 怎么交互式创建 agent？ | 敲 `/agents` 打开管理面板，有 Library 标签可创建/编辑 | 同上 |
+
+**一句话澄清**：**用户定义 agent（.md 文件），Claude Code 自带 Task/Agent 工具来派生 agent**。这两件事不要搞混。
+
+---
+
 ## 第一部分：原理篇 —— 主会话如何触发智能体
 
-### 1.1 触发的本质：`Task` 工具 + `subagent_type`
+### 1.1 触发的本质：内置 `Agent` 工具（旧名 `Task`）+ `subagent_type`
 
-Claude Code 的主会话（你在终端里敲 `claude` 开的那个会话）本身就是一个 AI。它要"变成一支团队"，靠的不是魔法，而是一个内置工具：**`Task`**。
+Claude Code 的主会话（你在终端里敲 `claude` 开的那个会话）本身就是一个 AI。它要"变成一支团队"，靠的是 Claude Code **自带的内置工具**：`Agent`（在 v2.1.63 之前叫 `Task`，现在 `Task` 仍作为别名可用）。
 
-`Task` 工具的作用是：**在当前会话里派生一个子智能体**。子智能体在自己的上下文窗口里独立运行，干完活把结果返回给主会话。
+**关键澄清**：`Agent`/`Task` 工具**不是用户定义的**。它和 `Read`、`Write`、`Bash` 一样，是 Claude Code 启动时就自带的内置工具。用户不需要在任何配置文件里"定义"这个工具——你定义的是**被它派生的 agent**（`.claude/agents/[name].md`），而不是派生的动作本身。
 
-最简的调用长这样：
+这个内置工具的作用是：**在当前会话里派生一个子智能体**。子智能体在自己的上下文窗口里独立运行，干完活把结果返回给主会话。
+
+最简的调用长这样（新版写法）：
 
 ```
-Task(
+Agent(
   subagent_type: "gameplay-programmer",
   description: "实现近战命中检测",
   prompt: "读 production/epics/combat/melee-hitbox.md，按 ADR 实现到 src/gameplay/combat/，写测试到 tests/combat/"
 )
 ```
 
-- `subagent_type` —— 指定派哪个智能体。这个名字必须对应 [.claude/agents/](file:///workspace/.claude/agents/) 下一个 `[name].md` 文件。
-- `prompt` —— 给子智能体的任务说明。
-- 子智能体跑完后，返回一段文本结果给主会话。
+旧版写法 `Task(...)` 仍然有效（别名），本项目所有 skill 文件里写的 `Task` 都能正常工作。
 
-**类比**：主会话是"项目经理"，`Task` 是它"派活"的动作。它喊一声"gameplay-programmer，把这个故事实现了"，gameplay-programmer 就在自己的工位（独立上下文）干完活，把成果交回来。
+**工具的参数**（来自官方文档）：
+
+| 参数 | 作用 | 必填 |
+|------|------|------|
+| `subagent_type` | 派哪个 agent。值对应 `.claude/agents/[name].md` 文件名（去 `.md`） | 是 |
+| `description` | 一行简介，主要给观测/日志用 | 是 |
+| `prompt` | **唯一的父→子数据通道**。给子智能体的任务说明 | 是 |
+| `model` | 可选，覆盖 agent 文件里设的模型 | 否 |
+| `run_in_background` | 可选，是否后台运行（默认 false，前台阻塞） | 否 |
+
+**类比**：主会话是"项目经理"，`Agent` 工具是它"派活"的内置动作。它喊一声"gameplay-programmer，把这个故事实现了"，gameplay-programmer 就在自己的工位（独立上下文）干完活，把成果交回来。
 
 **关键点**：主会话**不会自动**派智能体。它什么时候派、派谁、派几个，全靠**技能（skill）的正文**告诉它。这就是下一节要讲的"触发规则"。
+
+> **小测验**：既然 `Agent`/`Task` 是内置工具，为什么本项目 skill 文件里到处写 `Task(...)`？
+> **答**：因为本项目写于 `Task` 改名 `Agent` 之前。`Task` 作为别名仍然有效，所以不需要改。新项目可以直接用 `Agent(...)`。两者等价。
 
 ---
 
@@ -63,7 +93,14 @@ Task(
 
 #### 第 1 层：智能体定义（员工档案）
 
-位置：[.claude/agents/](file:///workspace/.claude/agents/)，每个智能体一个 `.md` 文件。
+**位置有两个**（来自官方 [claude-directory 文档](https://code.claude.com/docs/zh-CN/claude-directory)）：
+
+| 位置 | 作用域 | 是否提交 git |
+|------|--------|--------------|
+| `.claude/agents/` | **项目级**——只对当前项目生效 | 是，团队共享 |
+| `~/.claude/agents/` | **全局级**——对你所有项目生效 | 否，个人配置 |
+
+每个智能体一个 `[name].md` 文件。本项目 49 个智能体全在项目级 [.claude/agents/](file:///workspace/.claude/agents/)。
 
 看 [creative-director.md](file:///workspace/.claude/agents/creative-director.md) 的开头：
 
@@ -79,15 +116,38 @@ skills: [brainstorm, design-review]
 ---
 ```
 
-**这里定义的是"这个智能体长什么样"**：
+**官方支持的 frontmatter 字段**（来自 [sub-agents 文档](https://code.claude.com/docs/zh-CN/sub-agents#supported-frontmatter-fields)，比本项目用到的更全）：
 
-| 字段 | 作用 | 编排意义 |
-|------|------|----------|
-| `name` | 智能体名（= `subagent_type` 的值） | 主会话靠这个名字派它 |
-| `tools` | 能用哪些工具 | **最小权限原则**——总监禁 `Bash`，QA 用 Haiku |
-| `model` | 用哪个模型 | 总监用 Opus（贵但聪明），格式化任务用 Haiku（便宜） |
-| `maxTurns` | 最多跑几轮 | 防止子智能体跑飞 |
-| `disallowedTools` | 显式禁用的工具 | 防止越权（总监不该跑命令） |
+| 字段 | 必填 | 作用 | 编排意义 |
+|------|------|------|----------|
+| `name` | 是 | 智能体名（= `subagent_type` 的值） | 主会话靠这个名字派它 |
+| `description` | 是 | 用途描述（Claude 据此判断何时自动委派） | **写清楚才能被自动路由** |
+| `tools` | 否 | 能用哪些工具（省略则继承全部） | **最小权限原则**——总监禁 `Bash` |
+| `disallowedTools` | 否 | 显式禁用的工具（与 `tools` 互补） | 防止越权 |
+| `model` | 否 | 用哪个模型（sonnet/opus/haiku/inherit） | 总监用 Opus，格式化用 Haiku |
+| `maxTurns` | 否 | 最多跑几轮 | 防止子智能体跑飞 |
+| `permissionMode` | 否 | 权限模式（default/acceptEdits/auto/dontAsk） | 控制是否每次问用户 |
+| `memory` | 否 | 持久记忆（user/project/local） | 跨会话保留状态 |
+| `background` | 否 | 是否始终后台运行 | 长任务不阻塞主会话 |
+| `effort` | 否 | 推理强度（low/medium/high/xhigh/max） | 控制思考深度 |
+| `isolation` | 否 | 隔离方式（如 worktree） | 防止文件冲突 |
+| `color` | 否 | UI 显示颜色 | 纯视觉 |
+
+**模型选择优先级**（从高到低，来自官方文档）：
+1. `CLAUDE_CODE_SUBAGENT_MODEL` 环境变量
+2. 调用时传入的 `model` 参数（Agent 工具的 `model` 字段）
+3. frontmatter 里的 `model` 字段
+4. 主会话模型
+
+**内置 subagents**（不用定义就能派，来自官方文档）：
+
+| 内置 agent | 模型 | 工具 | 用途 |
+|-----------|------|------|------|
+| `Explore` | Haiku | 只读（Read/Grep/Glob/LS） | 快速代码库搜索，跳过 CLAUDE.md 加载 |
+| `Plan` | 继承主会话 | 只读 | Plan 模式下收集上下文 |
+| `general-purpose` | 继承主会话 | 全部工具 | 复杂多步骤任务，无需定义即可用 |
+
+**交互式创建 agent**：在 Claude Code 里敲 `/agents`，打开管理面板，Library 标签可创建/编辑/禁用 agent。比手写 `.md` 文件更直观。
 
 **这一层不管"什么时候派"，只管"派出来之后它是什么样"**。
 
@@ -205,6 +265,54 @@ Use the Task tool to spawn each team member as a subagent:
 ```
 
 **特征**：纯并行、裁决式、取最严。阶段切换的把关路径。来自 [director-gates.md](file:///workspace/.claude/docs/director-gates.md) 的 "Parallel Gate Protocol"。
+
+#### 路径 D：自动委派（官方机制，本项目未显式使用）
+
+来自官方 [sub-agents 文档](https://code.claude.com/docs/zh-CN/sub-agents#understand-automatic-delegation)：
+
+```
+用户在主会话里说："帮我审查 src/auth 的安全性"
+  → Claude 读所有 agent 的 description 字段
+  → 匹配到 security-audit 的描述"Reviews code for vulnerabilities"
+  → 自动派 security-audit subagent（不需要用户敲 /命令）
+```
+
+**机制**：Claude 会读所有 agent 文件的 `description` 字段，根据用户的话自动判断该派谁。**description 写得越清楚，自动委派越准**。
+
+**本项目的选择**：本项目**不依赖自动委派**，而是用 skill 显式编排（路径 A/B/C）。原因：
+- 自动委派不可控——同一个问题可能派不同 agent
+- skill 编排可复现——每次跑 `/dev-story` 都按同样的 Phase 走
+- 适合工程化场景——需要可审计、可追溯
+
+**什么时候用自动委派**：探索性任务、一次性任务、不需要可复现流程时。比如"帮我找一下哪里处理了用户登录"——直接说，Claude 自动派 `Explore`。
+
+**显式委派**：在 prompt 里直接点名，比如"Use the gameplay-programmer agent to implement..."。本项目 skill 用的就是这种——SKILL.md 正文里写死 `subagent_type: gameplay-programmer`。
+
+---
+
+### 1.4 子智能体的"一根通道"原理（重要）
+
+这是官方文档和社区反复强调的核心机制，理解了它，所有"为什么"都能回答：
+
+> **子智能体是一个全新的 Claude 实例，父子之间只有一根数据通道：`Agent`/`Task` 工具的 `prompt` 字符串。**
+
+这意味着：
+
+| 问题 | 答案 |
+|------|------|
+| 子智能体能看到主会话的对话历史吗？ | **不能**。它只看到 `prompt` 里的内容 |
+| 子智能体能看到主会话读过的文件吗？ | **不能**。它得自己重新 Read |
+| 主会话的 CLAUDE.md 会传给子智能体吗？ | **会**（自定义 agent 会加载），但主会话对话历史不会 |
+| 子智能体写的文件主会话能直接看到吗？ | **能**（文件系统共享），但子智能体的"思考过程"不会返回 |
+| 子智能体返回什么给主会话？ | **只有一段文本**（最终消息），中间的工具调用结果都留在子智能体自己的上下文里 |
+
+**编排启示**：
+1. 给子智能体的 `prompt` 要**自包含**——把所有它需要的信息都写进去（或给路径让它自己读）
+2. 不要指望子智能体"记得"主会话之前聊过什么——它是全新的实例
+3. 子智能体的"成果"是它写的**文件**，不是它返回的**文本**——返回的文本只是汇报
+4. 这就是为什么 `/dev-story` 的 Phase 4 要给子智能体列一串"读 [path]"——它得自己读，不能继承主会话的上下文
+
+**类比**：你给助理发一封邮件派活。助理不会读你电脑里的其他邮件，也不会知道你之前和谁聊过什么——他只看这封邮件，然后自己去找资料、干活、写报告交回来。
 
 ---
 
@@ -400,14 +508,29 @@ Every task follows: Question -> Options -> Decision -> Draft -> Approval
 
 ### 步骤 3：定义第一个智能体（`.claude/agents/`）
 
-**目的**：先定义一个最小可用的智能体，验证 `Task` 工具能派生它。
+**目的**：先定义一个最小可用的智能体，验证 `Agent`/`Task` 工具能派生它。
+
+**两种创建方式**（来自官方文档）：
+
+| 方式 | 操作 | 适合 |
+|------|------|------|
+| **交互式** | 在 Claude Code 里敲 `/agents` → Library 标签 → Create new agent → 选 Personal/Project → 输入描述自动生成 | 新手、快速原型 |
+| **手写文件** | 直接创建 `.claude/agents/[name].md` | 精细控制、批量管理、纳入版本控制 |
+
+**先试内置 agent**：在定义自己的之前，先试官方自带的 `general-purpose`——不用任何配置就能派：
+
+```
+Agent(subagent_type: "general-purpose", description: "探索项目结构", prompt: "读 README.md，总结项目结构")
+```
+
+这能验证 `Agent` 工具本身可用。然后再定义自己的。
 
 **最小可用智能体**（参考 [gameplay-programmer.md](file:///workspace/.claude/agents/gameplay-programmer.md)）：
 
 ```markdown
 ---
 name: backend-programmer
-description: "后端程序员，实现 API 和业务逻辑代码"
+description: "后端程序员，实现 API 和业务逻辑代码。当任务涉及写后端代码、实现 API、业务逻辑时使用。"
 tools: Read, Glob, Grep, Write, Edit, Bash
 model: sonnet
 maxTurns: 20
@@ -432,6 +555,7 @@ tested code following the project's architecture decisions.
 ```
 
 **关键设计**：
+- `description` 要写清楚**何时用**——这是自动委派匹配的依据（即使你用 skill 显式编排，写清楚也有备无患）
 - `tools` 用**最小权限**——只给真正需要的工具
 - `maxTurns` 设上限（20）防止跑飞
 - 正文写"协作协议"——明确它是"提议者"不是"决定者"
@@ -440,8 +564,12 @@ tested code following the project's architecture decisions.
 **验证**：在主会话里手动派一次，确认能跑通：
 
 ```
-Task(subagent_type: "backend-programmer", prompt: "读 README.md，总结项目结构")
+Agent(subagent_type: "backend-programmer", description: "探索项目", prompt: "读 README.md，总结项目结构")
 ```
+
+**放哪**：
+- 想团队共享 → `.claude/agents/backend-programmer.md`（提交 git）
+- 只自己用 → `~/.claude/agents/backend-programmer.md`（个人配置）
 
 ---
 
@@ -775,20 +903,26 @@ Phase 1 → AskUserQuestion → 用户选 A/B/C → Phase 2 → AskUserQuestion 
 
 ## 小测验
 
-**Q1**：主会话派智能体靠什么工具？`subagent_type` 的值对应哪个文件？
-> **A**：靠 `Task` 工具。`subagent_type` 的值对应 `.claude/agents/[name].md` 文件。
+**Q1**：主会话派智能体靠什么工具？这个工具是用户定义的吗？
+> **A**：靠 `Agent` 工具（旧名 `Task`，v2.1.63 改名，`Task` 仍作别名可用）。**这个工具不是用户定义的**——它是 Claude Code 内置工具，和 Read/Write/Bash 一样自带。用户定义的是被它派生的 agent（`.claude/agents/[name].md`）。
 
 **Q2**：智能体的"触发规则"主要写在哪一层？
-> **A**：第 2 层——`.claude/skills/[name]/SKILL.md` 的正文。它用自然语言告诉主会话"什么时候派谁、按什么顺序"。
+> **A**：第 2 层——`.claude/skills/[name]/SKILL.md` 的正文。它用自然语言告诉主会话"什么时候派谁、按什么顺序"。但还有一条官方机制：自动委派——Claude 读 agent 的 `description` 字段自动匹配，不需要 skill 也能派。
 
 **Q3**：为什么 `/dev-story` 的 Phase 2 要并行读 5 个文件而不是串行？
 > **A**：这 5 个文件互不依赖（读 ADR 不需要先读 TR registry），并行读省 5 倍时间。这是 [coordination-rules.md](file:///workspace/.claude/docs/coordination-rules.md) "Parallel Task Protocol" 的体现：先发后等，收齐再走。
 
-**Q4**：`SubagentStart` hook 和 `Task` 工具是什么关系？
-> **A**：`Task` 是主会话"派"智能体的动作；`SubagentStart` hook 是"智能体被派时自动触发的脚本"。hook 不派智能体，只记录"谁被派了"。这是无侵入观测。
+**Q4**：`SubagentStart` hook 和 `Agent` 工具是什么关系？
+> **A**：`Agent` 是主会话"派"智能体的内置动作；`SubagentStart` hook 是"智能体被派时自动触发的脚本"。hook 不派智能体，只记录"谁被派了"。这是无侵入观测。
 
-**Q5**：从零搭建工作室，为什么要先跑通单智能体再扩展到多智能体？
+**Q5**：子智能体能看到主会话之前读过的文件吗？为什么？
+> **A**：**不能**。子智能体是全新的 Claude 实例，父子之间只有一根数据通道——`Agent` 工具的 `prompt` 字符串。主会话读过的文件内容不会自动传给子智能体，它得自己重新 Read。这就是为什么 skill 给子智能体的 prompt 要列一串"读 [path]"。
+
+**Q6**：从零搭建工作室，为什么要先跑通单智能体再扩展到多智能体？
 > **A**：每加一层都要验证不破坏已有流程。一次性加 10 个智能体，出问题不知道是哪个的锅。增量验证是工程化的基本纪律。
+
+**Q7**：agent 文件放 `.claude/agents/` 和放 `~/.claude/agents/` 有什么区别？
+> **A**：前者是**项目级**，只对当前项目生效，可提交 git 团队共享；后者是**全局级**，对你所有项目生效，是个人配置不提交。本项目 49 个 agent 全在项目级。
 
 ---
 
@@ -802,11 +936,25 @@ Phase 1 → AskUserQuestion → 用户选 A/B/C → Phase 2 → AskUserQuestion 
 
 4. 在一个空项目里照着"第三部分：搭建篇"走一遍，跑到步骤 7（跑通第一个端到端流程）为止。能跑通，说明你已经掌握了从零编排的基本功。
 
+5. **读官方文档对照**：打开 [sub-agents 官方文档](https://code.claude.com/docs/zh-CN/sub-agents)，重点看 "Built-in subagents" 和 "Understand automatic delegation" 两节，对比本项目的做法（显式 skill 编排）和官方推荐的自动委派，想想各自适合什么场景。
+
+---
+
+## 参考文档
+
+- [Claude Code 官方：代理和并行工作（概述）](https://code.claude.com/docs/zh-CN/agents)
+- [Claude Code 官方：创建自定义 subagents](https://code.claude.com/docs/zh-CN/sub-agents)
+- [Claude Code 官方：探索 .claude 目录](https://code.claude.com/docs/zh-CN/claude-directory)
+- [Claude Code 官方：Agent view](https://code.claude.com/docs/zh-CN/agent-view)
+- [Claude Code 官方：运行代理团队](https://code.claude.com/docs/zh-CN/agent-teams)
+
 ---
 
 ## 一句话总结
 
-> **从零编排智能体协作 = 写 `CLAUDE.md` 定方向 + 写 `agents/` 定角色 + 写 `skills/` 定流程 + 写 `settings.json` 定守卫 + 写 `docs/` 定制度 + 用 `Task` 工具把流程跑起来。**
+> **从零编排智能体协作 = 写 `CLAUDE.md` 定方向 + 写 `agents/` 定角色（.md 文件）+ 写 `skills/` 定流程 + 写 `settings.json` 定守卫 + 写 `docs/` 定制度 + 用内置 `Agent`/`Task` 工具把流程跑起来。**
+
+**关键澄清**：`Agent`/`Task` 工具是 Claude Code **内置的**，不需要用户定义；用户定义的是 agent（`.md` 文件）和 skill（编排逻辑）。两者不要搞混。
 
 核心不是"定义很多智能体"，而是"设计好它们怎么协作"。先跑通一个，再扩展到多个，最后加门禁和阶段流水线。
 

--- a/study-docs/13-术语对照表.md
+++ b/study-docs/13-术语对照表.md
@@ -1,0 +1,454 @@
+# 13 · 术语对照表 —— 看懂这个项目的行话
+
+这个项目借用了游戏开发流程的术语 + Claude Code 的术语 + 自创的缩写体系。初学者会被 `TD-ENGINE-RISK`、`ADR Accepted`、`LP-FEASIBILITY`、`TR-COMBAT-003` 这些词砸晕。
+
+这篇文档把所有行话提取出来，按"游戏开发流程 / 智能体编排 / 项目自创缩写"三类分组，逐一解释。
+
+---
+
+## 第一类：游戏开发流程术语
+
+### Stage / Phase（阶段）
+
+游戏开发被本项目切成 **7 个阶段**，每个阶段有明确的进出条件：
+
+| 阶段 | 英文 | 干什么 | 出口门禁 |
+|------|------|--------|----------|
+| 概念 | Concept | 把游戏点子写成文档（核心支柱、玩法循环） | Concept → Systems Design |
+| 系统设计 | Systems Design | 拆成系统，每个系统写一份 GDD | Systems Design → Technical Setup |
+| 技术搭建 | Technical Setup | 定架构、写 ADR、搭引擎、配置测试 | Technical Setup → Pre-Production |
+| 预制作 | Pre-Production | 写故事卡、跑冲刺、验证可行性 | Pre-Production → Production |
+| 制作 | Production | 大规模实现功能 | Production → Polish |
+| 打磨 | Polish | 修 bug、调手感、优化性能 | Polish → Release |
+| 发布 | Release | 上线 | — |
+
+**关键概念**：阶段之间**不能直接跳**，必须过"门禁"（见下文）。这是游戏工业的标准流水线，源自 [workflow-catalog.yaml](file:///workspace/.claude/docs/workflow-catalog.yaml)。
+
+---
+
+### GDD — Game Design Document（游戏设计文档）
+
+**是什么**：描述一个游戏系统"该怎么玩"的文档。一个系统一份 GDD。
+
+**放哪**：[design/gdd/](file:///workspace/design/gdd/)，比如 `combat.md`（战斗系统）、`inventory.md`（背包系统）。
+
+**包含什么**：机制概述、玩家幻想、详细规则、公式、边缘情况、依赖、调参旋钮、验收标准。
+
+**类比**：盖楼前的"设计图纸"——说清楚这栋楼要几个房间、每间多大、什么用途，但不涉及用几号钢筋。
+
+---
+
+### ADR — Architecture Decision Record（架构决策记录）
+
+**是什么**：记录一个架构决策的文档——**为什么选 A 不选 B**。
+
+**放哪**：`docs/architecture/adr-NNNN-标题.md`，比如 `adr-0003-melee-combat.md`。
+
+**4 种状态**（重要！）：
+
+| 状态 | 含义 | 能不能据此实现代码 |
+|------|------|---------------------|
+| `Proposed`（已提议） | 还在讨论，没定下来 | **不能**。`/dev-story` 会拒绝实现 |
+| `Accepted`（已接受） | 定稿了，可以执行 | 能 |
+| `Deprecated`（已废弃） | 不再使用 | 不能 |
+| `Superseded by ADR-NNNN`（被取代） | 被另一个 ADR 替换 | 看新 ADR |
+
+**"ADR Approve" 的意思**：决策经过评审，状态从 `Proposed` → `Accepted`。只有 `Accepted` 的 ADR 才能指导编码。
+
+**类比**：工程会议纪要——"我们决定用 Godot 而不是 Unity，原因是 X、Y、Z"。后人翻出来就知道为什么这么选的。
+
+**为什么重要**：本项目 `/dev-story` 在派程序员前会先查 ADR 状态。如果是 `Proposed`，直接拒绝实现，让你先跑 `/architecture-decision` 把它定下来。这防止"基于没定稿的决策写代码"。
+
+---
+
+### TR — Technical Requirement（技术需求）
+
+**是什么**：从 GDD 里提炼出的"架构必须满足什么"的技术需求条目。
+
+**编号格式**：`TR-[系统]-NNN`，比如 `TR-COMBAT-003`（战斗系统的第 3 条技术需求）。
+
+**放哪**：登记在 [docs/architecture/tr-registry.yaml](file:///workspace/docs/architecture/tr-registry.yaml)。
+
+**和 GDD/ADR 的关系**：
+
+```
+GDD（设计文档）
+  ↓ 提炼出
+TR（技术需求）—— 比如"命中检测必须 < 1 帧"
+  ↓ 被满足于
+ADR（架构决策）—— 比如"用 Godot Area3D 做命中检测"
+  ↓ 被实现于
+Story（故事卡）—— 比如"实现近战命中盒"
+```
+
+**类比**：GDD 说"战斗要爽"，TR 把它翻译成"命中检测延迟 < 16ms"这种可衡量的技术指标，ADR 决定怎么实现，Story 是具体任务卡。
+
+---
+
+### Story / Epic（故事卡 / 史诗）
+
+**Story（故事卡）**：最小可执行的任务单元。一张卡 = 一个程序员一两天能干完的活。
+
+**Epic（史诗）**：一组相关 Story 的集合，规模更大。
+
+**放哪**：[production/epics/](file:///workspace/production/epics/)，比如 `production/epics/combat/melee-hitbox.md`。
+
+**包含什么**：标题、ID、层（Layer）、类型（Type）、关联的 TR-ID、关联的 ADR、验收标准、依赖、Out of Scope（明确不做的事）。
+
+**类比**：敏捷开发里的 User Story。一张卡问"作为 X，我想 Y，以便 Z"。
+
+---
+
+### Pillar（支柱）
+
+**是什么**：游戏的 3-5 条核心体验承诺。所有设计决策都要服从支柱。
+
+**举例**：
+- "每一场战斗都必须紧张刺激"
+- "玩家始终感觉资源稀缺"
+- "世界对玩家选择有反应"
+
+**用途**：`CD-PILLARS` 门禁就是拿设计文档去"压测"支柱——你的设计是否违背了你自己定的核心承诺？
+
+**类比**：公司价值观。任何决策都要和价值观对齐。
+
+---
+
+## 第二类：智能体编排术语
+
+### Agent（智能体）
+
+**是什么**：一个用 `.md` 文件定义的"专家角色"。Claude Code 通过内置 `Agent`/`Task` 工具派生它。
+
+**放哪**：`.claude/agents/[name].md`（项目级）或 `~/.claude/agents/[name].md`（全局级）。
+
+**本项目 49 个 agent**：比如 `gameplay-programmer`（玩法程序员）、`creative-director`（创意总监）、`qa-tester`（QA 测试员）。
+
+详见上一篇 [12-从零编排智能体协作](file:///workspace/study-docs/12-从零编排智能体协作.md)。
+
+---
+
+### Subagent（子智能体）
+
+**是什么**：被 `Agent`/`Task` 工具派生出来的智能体实例。它在**独立上下文**里干活，干完返回一段文本给主会话。
+
+**关键特性**：父子之间只有一根数据通道——`prompt` 字符串。子智能体看不到主会话历史，得自己读文件。
+
+---
+
+### Skill（技能）
+
+**是什么**：一段可复用的"作业指导书"，定义主会话在某个任务里该派谁、按什么顺序、怎么决策。
+
+**放哪**：`.claude/skills/[name]/SKILL.md`。
+
+**怎么触发**：敲 `/技能名`，比如 `/dev-story`、`/team-combat`、`/gate-check`。
+
+**和 Agent 的区别**：Agent 是"角色档案"（谁），Skill 是"流程编排"（怎么干）。Skill 可以派多个 Agent。
+
+---
+
+### Hook（钩子）
+
+**是什么**：在特定事件自动触发的脚本。比如每次派子智能体时自动记日志。
+
+**放哪**：[.claude/hooks/](file:///workspace/.claude/hooks/)，配置在 [.claude/settings.json](file:///workspace/.claude/settings.json)。
+
+**常用事件**：`PreToolUse`（工具调用前）、`PostToolUse`（工具调用后）、`SubagentStart`（子智能体启动）、`SubagentStop`（子智能体停止）。
+
+---
+
+### Task / Agent 工具
+
+**是什么**：Claude Code **内置工具**，用来派生子智能体。v2.1.63 前叫 `Task`，之后叫 `Agent`，`Task` 仍作别名可用。
+
+**关键澄清**：这个工具**不是用户定义的**。用户定义的是 agent（`.md` 文件），工具是自带的。
+
+---
+
+## 第三类：项目自创缩写（门禁 ID 体系）
+
+这是最容易让初学者懵的部分。项目用 `XX-YYYY` 格式给每个"门禁"编了号。**前面两个字母 = 谁的门禁**，**后面 = 这个门禁查什么**。
+
+### 门禁前缀对照表
+
+| 前缀 | 全称 | 是谁 | 什么领域 |
+|------|------|------|----------|
+| `CD-` | Creative Director | 创意总监 | 游戏愿景、支柱、叙事、玩家体验 |
+| `TD-` | Technical Director | 技术总监 | 架构、引擎、可行性、技术风险 |
+| `PR-` | Producer | 制作人 | 范围、时间线、冲刺、里程碑 |
+| `AD-` | Art Director | 美术总监 | 视觉风格、美术圣经 |
+| `LP-` | Lead Programmer | 主程序员 | 实现可行性、代码审查 |
+| `QL-` | QA Lead | QA 主管 | 故事就绪度、测试覆盖 |
+| `ND-` | Narrative Director | 叙事总监 | 叙事一致性 |
+
+**记忆法**：
+- `C/T/P/A` 开头的是 **4 大总监**（Tier 1），管宏观
+- `L/Q/N` 开头的是 **Lead 主管**（Tier 2），管执行
+- `-PHASE-GATE` 结尾的是 **阶段切换门禁**，最关键
+
+---
+
+### 门禁（Gate）是什么
+
+**门禁 = 一道质量检查关卡**。在某个动作之前或阶段切换时，派一个总监 agent 去审一遍，给出 APPROVE / CONCERNS / REJECT 的裁决。
+
+**三态裁决**（来自 [director-gates.md](file:///workspace/.claude/docs/director-gates.md)）：
+
+| 裁决 | 含义 | 后续动作 |
+|------|------|----------|
+| `APPROVE` / `READY` | 通过 | 继续下一步 |
+| `CONCERNS` | 有顾虑但可推进 | 记录顾虑，继续，后续解决 |
+| `REJECT` / `NOT READY` | 不通过 | 必须解决问题才能推进 |
+
+**门禁的两种触发方式**：
+
+1. **阶段门禁**（PHASE-GATE）：阶段切换时由 `/gate-check` 并行派 4 个总监，每个跑自己的 `-PHASE-GATE`。一个 NOT READY 全部 FAIL。
+2. **技能内门禁**：某个 skill 执行中派特定总监跑特定门禁。比如 `/architecture-decision` 写完 ADR 后跑 `TD-ADR` 审一遍。
+
+---
+
+### 所有门禁 ID 速查表
+
+下面是 [director-gates.md](file:///workspace/.claude/docs/director-gates.md) 里定义的全部门禁，按总监分组。
+
+#### CD- 创意总监门禁（6 个）
+
+| ID | 全名 | 查什么 |
+|----|------|--------|
+| `CD-PILLARS` | Pillar Stress Test | 设计是否违背游戏支柱 |
+| `CD-GDD-ALIGN` | GDD Pillar Alignment | GDD 和支柱对齐吗 |
+| `CD-SYSTEMS` | Systems Decomposition Vision | 系统拆分是否符合愿景 |
+| `CD-NARRATIVE` | Narrative Consistency | 叙事一致性 |
+| `CD-PLAYTEST` | Player Experience Validation | 玩家体验验证 |
+| `CD-PHASE-GATE` | Creative Readiness at Phase Transition | 阶段切换的创意就绪度 |
+
+#### TD- 技术总监门禁（6 个）
+
+| ID | 全名 | 查什么 |
+|----|------|--------|
+| `TD-SYSTEM-BOUNDARY` | System Boundary Architecture | 系统边界架构审查 |
+| `TD-FEASIBILITY` | Technical Feasibility | 技术可行性评估 |
+| `TD-ARCHITECTURE` | Architecture Sign-Off | 架构签收 |
+| `TD-ADR` | Architecture Decision Review | ADR 决策审查 |
+| `TD-ENGINE-RISK` | Engine Version Risk Review | **引擎版本风险审查**（见下文详解） |
+| `TD-PHASE-GATE` | Technical Readiness at Phase Transition | 阶段切换的技术就绪度 |
+
+#### PR- 制作人门禁（5 个）
+
+| ID | 全名 | 查什么 |
+|----|------|--------|
+| `PR-SCOPE` | Scope and Timeline Validation | 范围和时间线 |
+| `PR-SPRINT` | Sprint Feasibility | 冲刺可行性 |
+| `PR-MILESTONE` | Milestone Risk Assessment | 里程碑风险评估 |
+| `PR-EPIC` | Epic Structure Feasibility | 史诗结构可行性 |
+| `PR-PHASE-GATE` | Production Readiness at Phase Transition | 阶段切换的制作就绪度 |
+
+#### AD- 美术总监门禁（3 个）
+
+| ID | 全名 | 查什么 |
+|----|------|--------|
+| `AD-CONCEPT-VISUAL` | Visual Identity Anchor | 视觉身份锚定 |
+| `AD-ART-BIBLE` | Art Bible Sign-Off | 美术圣经签收 |
+| `AD-PHASE-GATE` | Visual Readiness at Phase Transition | 阶段切换的视觉就绪度 |
+
+#### Tier 2 Lead 门禁（5 个）
+
+| ID | 全名 | 是谁 | 查什么 |
+|----|------|------|--------|
+| `LP-FEASIBILITY` | Lead Programmer Implementation Feasibility | 主程序员 | 实现可行性 |
+| `LP-CODE-REVIEW` | Lead Programmer Code Review | 主程序员 | 代码审查 |
+| `QL-STORY-READY` | QA Lead Story Readiness Check | QA 主管 | 故事卡是否可开工 |
+| `QL-TEST-COVERAGE` | QA Lead Test Coverage Review | QA 主管 | 测试覆盖率 |
+| `ND-CONSISTENCY` | Narrative Director Consistency Check | 叙事总监 | 叙事一致性 |
+
+---
+
+### TD-ENGINE-RISK 详解（你问的这个）
+
+**全名**：Engine Version Risk Review（引擎版本风险审查）
+
+**谁跑**：`technical-director` agent
+
+**什么时候触发**（来自 [director-gates.md#L371](file:///workspace/.claude/docs/director-gates.md)）：
+> When making architecture decisions that touch post-cutoff engine APIs, or before finalizing any engine-specific implementation approach
+
+翻译：当架构决策用到**超出 LLM 知识截止日期**的引擎 API，或定稿任何引擎特定实现方案之前。
+
+**为什么需要这个门禁**：LLM 的训练数据有截止日期。如果 Godot 4.4 在 LLM 截止后改了某 API 签名，LLM 会"自信地"写出过时代码。这个门禁让技术总监去查 `docs/engine-reference/[engine]/VERSION.md`，核对 API 是否还存在、签名是否变了。
+
+**审什么**：
+- 这个 API 在当前引擎版本里还存在吗？
+- 自 LLM 知识截止以来，签名、行为、命名空间变了吗？
+- 有已知废弃或新版替代吗？
+
+**三种裁决**：
+- `APPROVE`：按描述用，安全
+- `CONCERNS [要核实的事项]`：可能有风险，实现前核实
+- `REJECT [API 已变 — 提供正确用法]`：API 变了，给正确方案
+
+**类比**：你 2023 年学过 React，2026 年要写 React 代码。这个门禁就是"先查一下 React 现在的文档，你记忆里的 API 还对不对"。
+
+---
+
+### 门禁的三种审查模式（Review Mode）
+
+来自 [director-gates.md#L26](file:///workspace/.claude/docs/director-gates.md)：
+
+| 模式 | 跑哪些门禁 | 适合 |
+|------|-----------|------|
+| `full` | 全部门禁都跑 | 团队、学习者、要彻底反馈 |
+| `lean` | **只跑 PHASE-GATE**（阶段门禁），跳过技能内门禁 | **默认**。单人开发、小团队 |
+| `solo` | 全部跳过 | Game Jam、原型、最大速度 |
+
+**配置位置**：[production/review-mode.txt](file:///workspace/production/review-mode.txt)，一个单词：`full` / `lean` / `solo`。
+
+**单次覆盖**：任何技能支持 `--review [full|lean|solo]` 参数，只影响这次运行。
+
+**为什么默认 lean**：单人开发者不需要每写一个 ADR 就跑 4 个总监。只在阶段切换时（`/gate-check`）跑一次就够。
+
+---
+
+## 第四类：其他高频缩写
+
+### Control Manifest（控制清单）
+
+**是什么**：从所有 `Accepted` ADR 提炼出的"程序员速查表"——**什么必须做、什么绝不能做**，按系统按层组织。
+
+**放哪**：`docs/architecture/control-manifest.md`
+
+**和 ADR 的区别**：
+- ADR 解释 **why**（为什么这么决策）
+- Control Manifest 告诉你 **what**（具体做什么/不做什么）
+
+**生成命令**：`/create-control-manifest`
+
+---
+
+### Layer（层）
+
+本项目把代码分成几个层，每个层有不同的规则。故事卡里的 `Layer` 字段决定派哪个程序员。
+
+常见层：`Foundation`（基础层）、`Core`（核心层）、`Gameplay`（玩法层）、`UI`、`Audio`、`VFX` 等。
+
+---
+
+### MDA Framework
+
+**是什么**：一种游戏设计分析框架——Mechanics（机制）/ Dynamics（动态）/ Aesthetics（美学/体验）。
+
+**用在哪**：`/brainstorm` 和 `/design-system` 用 MDA 拆解游戏概念。
+
+- **Mechanics**：规则、数据、算法（命中判定公式）
+- **Dynamics**：机制运行时产生的行为（玩家发现连招）
+- **Aesthetics**：玩家体验到的情感（紧张、爽快）
+
+---
+
+### MVP — Minimum Viable Product（最小可行产品）
+
+**是什么**：最简版本的游戏，包含核心玩法，用于验证可行性。
+
+**本项目用法**：Systems Design 阶段要挑出 MVP 系统，先设计先实现这些。
+
+---
+
+### Sprint（冲刺）
+
+**是什么**：敏捷开发的时间盒，通常 1-2 周。一个冲刺完成一批故事卡。
+
+**相关门禁**：`PR-SPRINT`（冲刺开始前评估可行性）、`QL-TEST-COVERAGE`（冲刺结束时查测试覆盖率）。
+
+---
+
+### Out of Scope（范围外）
+
+**是什么**：故事卡里明确写"不做的事"。防止范围蔓延。
+
+**为什么重要**：程序员看到这个故事卡时，知道哪些不该碰。防止"顺手改了别的"导致越权。
+
+---
+
+## 术语关系总图
+
+```
+游戏愿景
+  │
+  ▼
+Pillars（支柱）── CD-PILLARS 门禁压测
+  │
+  ▼
+GDD（设计文档）── CD-GDD-ALIGN 门禁对齐
+  │ 提炼
+  ▼
+TR（技术需求）── 登记在 tr-registry.yaml
+  │ 被满足
+  ▼
+ADR（架构决策）── TD-ADR 门禁审查
+  │ 状态: Proposed → Accepted ── TD-ENGINE-RISK 查引擎兼容
+  │ 提炼
+  ▼
+Control Manifest（控制清单）── 程序员速查
+  │ 拆解
+  ▼
+Epic（史诗）── PR-EPIC 门禁查可行性
+  │ 拆成
+  ▼
+Story（故事卡）── QL-STORY-READY 门禁查就绪度
+  │ 实现
+  ▼
+Code（代码）── LP-CODE-REVIEW 门禁审查
+  │ 测试
+  ▼
+Tests（测试）── QL-TEST-COVERAGE 门禁查覆盖
+  │
+  ▼
+阶段切换 ── 4 个 -PHASE-GATE 并行门禁
+  │
+  ▼
+下一阶段
+```
+
+---
+
+## 小测验
+
+**Q1**：`TD-ENGINE-RISK` 是谁的门禁？查什么？
+> **A**：技术总监（TD = Technical Director）的门禁。查架构决策用到的引擎 API 是否在 LLM 知识截止后发生了变化，防止写过时代码。
+
+**Q2**：ADR 的 4 种状态是什么？"ADR Approve" 指哪种？
+> **A**：`Proposed`（已提议）、`Accepted`（已接受）、`Deprecated`（已废弃）、`Superseded by ADR-NNNN`（被取代）。"ADR Approve" 指从 `Proposed` 变为 `Accepted`，只有 `Accepted` 的 ADR 才能指导编码。
+
+**Q3**：`LP-` 和 `QL-` 开头的门禁是谁的？属于哪一层？
+> **A**：`LP-` 是主程序员（Lead Programmer），`QL-` 是 QA 主管（QA Lead）。都属于 Tier 2 Lead 层，管执行细节（代码审查、测试覆盖），区别于 Tier 1 总监层（管宏观）。
+
+**Q4**：门禁的三种裁决是什么？一个 NOT READY 会怎样？
+> **A**：`APPROVE/READY`（通过）、`CONCERNS`（有顾虑但可推进）、`REJECT/NOT READY`（不通过）。阶段门禁取最严——一个 NOT READY 整个阶段切换 FAIL。
+
+**Q5**：`full` / `lean` / `solo` 三种审查模式有什么区别？默认哪种？
+> **A**：`full` 跑全部门禁；`lean` 只跑 PHASE-GATE（阶段门禁），跳过技能内门禁；`solo` 全部跳过。**默认 lean**，适合单人开发。
+
+**Q6**：GDD、TR、ADR、Story 是什么关系？
+> **A**：GDD（设计文档）提炼出 TR（技术需求），TR 被 ADR（架构决策）满足，ADR 被拆成 Story（故事卡）实现。一条链：设计 → 技术指标 → 架构方案 → 任务卡。
+
+---
+
+## 动手
+
+1. 打开 [director-gates.md](file:///workspace/.claude/docs/director-gates.md)，对照"所有门禁 ID 速查表"，数一数一共多少个门禁（答案：25 个）。
+
+2. 打开 [gate-check/SKILL.md](file:///workspace/.claude/skills/gate-check/SKILL.md)，看 "Gate: Concept → Systems Design" 部分，看一个阶段门禁具体审什么。
+
+3. 打开 [architecture-decision/SKILL.md](file:///workspace/.claude/skills/architecture-decision/SKILL.md)，找 `Status: Proposed` 的部分，理解为什么新 ADR 必须从 Proposed 开始。
+
+4. 打开 [production/review-mode.txt](file:///workspace/production/review-mode.txt)（如果存在），看当前是哪种审查模式。
+
+---
+
+## 一句话总结
+
+> **`XX-YYYY` 门禁 ID = "谁（XX）查什么（YYYY）"**。前缀 C/T/P/A 是 4 大总监，L/Q/N 是 Lead 主管，`-PHASE-GATE` 结尾是阶段切换门禁。门禁给 APPROVE/CONCERNS/REJECT 三态裁决，阶段门禁取最严。
+
+---
+
+上一篇 → [12 从零编排智能体协作](file:///workspace/study-docs/12-从零编排智能体协作.md)

--- a/study-docs/README.md
+++ b/study-docs/README.md
@@ -46,6 +46,7 @@
 | 08 | [上下文管理艺术](file:///workspace/study-docs/08-上下文管理艺术.md) | 长会话怎么不失忆？ | 文件即记忆、增量写入、压缩 |
 | 09 | [实战案例剖析](file:///workspace/study-docs/09-实战案例剖析.md) | 一个功能从设计到上线全流程 | `/dev-story`、`/team-combat` |
 | 10 | [学习路径与练习](file:///workspace/study-docs/10-学习路径与练习.md) | 我该怎么练？ | 阶梯任务、自检清单 |
+| 11 | [CLAUDE.md 编写指导](file:///workspace/study-docs/11-CLAUDE.md编写指导.md) | CLAUDE.md 怎么写？ | 定位、`@` 引用、分层、反模式 |
 
 ---
 

--- a/study-docs/README.md
+++ b/study-docs/README.md
@@ -48,6 +48,7 @@
 | 10 | [学习路径与练习](file:///workspace/study-docs/10-学习路径与练习.md) | 我该怎么练？ | 阶梯任务、自检清单 |
 | 11 | [CLAUDE.md 编写指导](file:///workspace/study-docs/11-CLAUDE.md编写指导.md) | CLAUDE.md 怎么写？ | 定位、`@` 引用、分层、反模式 |
 | 12 | [从零编排智能体协作](file:///workspace/study-docs/12-从零编排智能体协作.md) | 主会话怎么触发智能体？工作室怎么从零搭？ | `Task` 工具、三层规则源、调用流程、8 步搭建、9 种编排模式 |
+| 13 | [术语对照表](file:///workspace/study-docs/13-术语对照表.md) | TD-ENGINE-RISK 是什么？ADR Approve 是什么？ | 门禁 ID 体系、游戏开发流程术语、智能体编排术语、25 个门禁速查 |
 
 ---
 

--- a/study-docs/README.md
+++ b/study-docs/README.md
@@ -1,0 +1,67 @@
+# Claude Code 智能体编排学习文档
+
+> 以 [Claude Code Game Studios](file:///workspace/README.md) 项目为范例，带你从零理解 Claude Code 的智能体编排（Agent Orchestration）。
+
+---
+
+## 这套文档是给谁的
+
+给**小白**。你不需要懂游戏开发，也不需要写过智能体。只要你：
+
+- 大致知道 Claude Code 是一个能在终端里读写文件、跑命令的 AI 编程助手；
+- 想搞明白"一个 AI 怎么变成一支团队"这件事。
+
+我们会用这个项目当"活教材"——它把一个 Claude Code 会话编排成了 **49 个智能体、73 个技能、12 个钩子、11 条规则**的虚拟游戏工作室。这是目前公开范围内最完整、最工程化的 Claude Code 编排范例之一。
+
+---
+
+## 为什么用这个项目学编排
+
+市面上大部分 Claude Code 教程停留在"写个好 prompt"。这个项目不一样，它示范了**真正的工程化编排**：
+
+| 维度 | 这个项目示范了什么 | 你能学到什么 |
+|------|---------------------|--------------|
+| **角色分工** | 49 个智能体分三层（总监/主管/专家） | 如何用 subagent 做职责隔离 |
+| **流程编排** | 7 阶段流水线（概念→发布） | 如何用 skill 串成可控的工作流 |
+| **自动守卫** | 12 个 hook 在提交/推送/会话事件自动校验 | 如何让 AI"不敢"犯错 |
+| **规则约束** | 11 条按路径生效的编码规则 | 如何让规则只在该管的地方管 |
+| **人在环中** | Question→Options→Decision→Draft→Approval | 如何让 AI 提议而非独断 |
+| **上下文管理** | 文件即记忆 + 增量写入 + 压缩恢复 | 如何让长会话不"失忆" |
+
+---
+
+## 文档地图
+
+建议按顺序读，每篇都自包含。
+
+| # | 文档 | 核心问题 | 关键概念 |
+|---|------|----------|----------|
+| 01 | [项目概览](file:///workspace/study-docs/01-项目概览.md) | 这是什么？为什么值得学？ | 49/73/12/11、工作室隐喻 |
+| 02 | [Claude Code 基础概念](file:///workspace/study-docs/02-Claude-Code基础概念.md) | Claude Code 的"配置文件"长啥样？ | `CLAUDE.md`、`.claude/`、`settings.json` |
+| 03 | [Agent 编排体系](file:///workspace/study-docs/03-Agent编排体系.md) | 49 个智能体怎么分工合作？ | 三层层级、委派规则、升级路径 |
+| 04 | [Skill 技能系统](file:///workspace/study-docs/04-Skill技能系统.md) | `/dev-story` 这种命令怎么来的？ | slash 命令、7 阶段流水线、路由 |
+| 05 | [Hook 自动化守卫](file:///workspace/study-docs/05-Hook自动化守卫.md) | 怎么让 AI 自动守规矩？ | 8 类钩子、退出码语义 |
+| 06 | [Rules 路径规则](file:///workspace/study-docs/06-Rules路径规则.md) | 规则怎么"按目录"生效？ | `paths` frontmatter |
+| 07 | [协作协议与人在环](file:///workspace/study-docs/07-协作协议与人在环.md) | AI 怎么提议而不越权？ | 五步协作、`AskUserQuestion` |
+| 08 | [上下文管理艺术](file:///workspace/study-docs/08-上下文管理艺术.md) | 长会话怎么不失忆？ | 文件即记忆、增量写入、压缩 |
+| 09 | [实战案例剖析](file:///workspace/study-docs/09-实战案例剖析.md) | 一个功能从设计到上线全流程 | `/dev-story`、`/team-combat` |
+| 10 | [学习路径与练习](file:///workspace/study-docs/10-学习路径与练习.md) | 我该怎么练？ | 阶梯任务、自检清单 |
+
+---
+
+## 一句话总览
+
+> **Claude Code 编排 = 用 `CLAUDE.md` 定方向 + 用 `agents/` 分角色 + 用 `skills/` 串流程 + 用 `hooks/` 守底线 + 用 `rules/` 管细节 + 用文件当记忆。**
+
+这套文档就是把这六个部件一个一个拆给你看。
+
+---
+
+## 阅读约定
+
+- **代码引用**：所有提到项目里文件的地方都是可点击链接，形如 [creative-director.md](file:///workspace/.claude/agents/creative-director.md)，点开就能看原文。
+- **类比**：每讲一个抽象概念，都会配一个生活化的类比，帮你建立直觉。
+- **"小测验"**：部分章节末尾有 1-2 个小问题，答案就在当节，帮你自检。
+- **"动手"**：标着"动手"的小节是建议你亲自去项目里翻一翻的地方。
+
+开始吧 → [01 项目概览](file:///workspace/study-docs/01-项目概览.md)

--- a/study-docs/README.md
+++ b/study-docs/README.md
@@ -47,6 +47,7 @@
 | 09 | [实战案例剖析](file:///workspace/study-docs/09-实战案例剖析.md) | 一个功能从设计到上线全流程 | `/dev-story`、`/team-combat` |
 | 10 | [学习路径与练习](file:///workspace/study-docs/10-学习路径与练习.md) | 我该怎么练？ | 阶梯任务、自检清单 |
 | 11 | [CLAUDE.md 编写指导](file:///workspace/study-docs/11-CLAUDE.md编写指导.md) | CLAUDE.md 怎么写？ | 定位、`@` 引用、分层、反模式 |
+| 12 | [从零编排智能体协作](file:///workspace/study-docs/12-从零编排智能体协作.md) | 主会话怎么触发智能体？工作室怎么从零搭？ | `Task` 工具、三层规则源、调用流程、8 步搭建、9 种编排模式 |
 
 ---
 


### PR DESCRIPTION
## Summary

Brief description of what this PR does.

## Type of Change

- [ ] New agent
- [ ] New skill
- [ ] New hook or rule
- [ ] Bug fix
- [ ] Documentation improvement
- [ ] Other:

## Changes

-
-
-

## Checklist

- [ ] I've tested this in a Claude Code session
- [ ] New agents include the Collaboration Protocol section
- [ ] New skills use the subdirectory format (`.claude/skills/<name>/SKILL.md`)
- [ ] Reference docs are updated (agent-roster, skills-reference, hooks-reference, rules-reference)
- [ ] Hooks use `grep -E` (POSIX) and fail gracefully without jq/python
- [ ] No hardcoded paths or platform-specific assumptions
