### PR TITLE
docs: migrate TripMeta design docs to Ark

### DIFF
--- a/.claude/docs/technical-preferences.md
+++ b/.claude/docs/technical-preferences.md
@@ -5,32 +5,34 @@
 
 ## Engine & Language
 
-- **Engine**: [TO BE CONFIGURED — run /setup-engine]
-- **Language**: [TO BE CONFIGURED]
-- **Rendering**: [TO BE CONFIGURED]
-- **Physics**: [TO BE CONFIGURED]
+- **Engine**: Unity 2021.3.11f1 (LTS)
+- **Language**: C#
+- **Rendering**: URP 17.0.3
+- **Physics**: PhysX (Unity built-in)
 
 ## Naming Conventions
 
-- **Classes**: [TO BE CONFIGURED]
-- **Variables**: [TO BE CONFIGURED]
-- **Signals/Events**: [TO BE CONFIGURED]
-- **Files**: [TO BE CONFIGURED]
-- **Scenes/Prefabs**: [TO BE CONFIGURED]
-- **Constants**: [TO BE CONFIGURED]
+- **Classes**: PascalCase (e.g., `PlayerController`)
+- **Public fields/properties**: PascalCase (e.g., `MoveSpeed`)
+- **Private fields**: _camelCase (e.g., `_moveSpeed`)
+- **Methods**: PascalCase (e.g., `TakeDamage()`)
+- **Events**: PascalCase with On prefix (e.g., `OnHealthChanged`)
+- **Files**: PascalCase matching class (e.g., `PlayerController.cs`)
+- **Prefabs**: PascalCase (e.g., `PlayerCharacter.prefab`)
+- **Constants**: PascalCase or UPPER_SNAKE_CASE
 
 ## Performance Budgets
 
-- **Target Framerate**: [TO BE CONFIGURED]
-- **Frame Budget**: [TO BE CONFIGURED]
-- **Draw Calls**: [TO BE CONFIGURED]
-- **Memory Ceiling**: [TO BE CONFIGURED]
+- **Target Framerate**: 90 FPS (PICO VR requirement)
+- **Frame Budget**: 11.1ms
+- **Draw Calls**: <100 per frame
+- **Memory Ceiling**: <4GB
 
 ## Testing
 
-- **Framework**: [TO BE CONFIGURED]
+- **Framework**: NUnit (Unity Test Framework)
 - **Minimum Coverage**: [TO BE CONFIGURED]
-- **Required Tests**: Balance formulas, gameplay systems, networking (if applicable)
+- **Required Tests**: AI service integration, VR interaction, networking, balance formulas
 
 ## Forbidden Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,34 +1,54 @@
-# Claude Code Game Studios -- Game Studio Agent Architecture
+# CLAUDE.md
 
-Indie game development managed through 48 coordinated Claude Code subagents.
-Each agent owns a specific domain, enforcing separation of concerns and quality.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A Claude Code agent architecture for indie game development. 48 specialized subagents
+are organized into a 3-tier studio hierarchy (Directors > Leads > Specialists), with
+37 slash-command workflows, 8 automated hooks, and 11 path-scoped coding rules.
+This is a template — not a game itself. There is no source code to build or test until
+the user creates a game project using the workflows below.
+
+## Agent Architecture
+
+Three tiers with model assignments reflecting decision weight:
+
+- **Tier 1 — Directors (Opus)**: `creative-director`, `technical-director`, `producer`
+  High-level vision, architecture, and coordination decisions.
+- **Tier 2 — Department Leads (Sonnet)**: `game-designer`, `lead-programmer`, `art-director`,
+  `audio-director`, `narrative-director`, `qa-lead`, `release-manager`, `localization-lead`
+- **Tier 3 — Specialists (Sonnet/Haiku)**: 30+ agents for implementation, testing, content.
+
+Agent definitions live in `.claude/agents/`. Delegation flows downward; conflicts escalate
+upward. Cross-department coordination goes through `producer`. See
+`.claude/docs/agent-coordination-map.md` for full delegation and escalation paths.
+
+Engine-specialist agent sets exist for Godot, Unity, and Unreal — each with 3-4
+sub-specialists. Use whichever set matches the configured engine.
 
 ## Technology Stack
 
-- **Engine**: [CHOOSE: Godot 4 / Unity / Unreal Engine 5]
-- **Language**: [CHOOSE: GDScript / C# / C++ / Blueprint]
+- **Engine**: Unity 2021.3.11f1 (LTS)
+- **Language**: C#
 - **Version Control**: Git with trunk-based development
-- **Build System**: [SPECIFY after choosing engine]
-- **Asset Pipeline**: [SPECIFY after choosing engine]
+- **Build System**: Unity Build Pipeline
+- **Asset Pipeline**: Unity Asset Import Pipeline + Addressables
 
-> **Note**: Engine-specialist agents exist for Godot, Unity, and Unreal with
-> dedicated sub-specialists. Use the set matching your engine.
+## Automated Safety (Hooks)
 
-## Project Structure
+Hooks in `.claude/settings.json` run automatically — no manual invocation needed:
 
-@.claude/docs/directory-structure.md
-
-## Engine Version Reference
-
-@docs/engine-reference/godot/VERSION.md
-
-## Technical Preferences
-
-@.claude/docs/technical-preferences.md
-
-## Coordination Rules
-
-@.claude/docs/coordination-rules.md
+| Hook | Trigger | Purpose |
+|------|---------|---------|
+| `session-start.sh` | Session open | Loads sprint context, recent git activity |
+| `detect-gaps.sh` | Session open | Detects fresh projects, missing docs |
+| `validate-commit.sh` | `git commit` (PreToolUse) | Checks hardcoded values, TODO format, JSON validity |
+| `validate-push.sh` | `git push` (PreToolUse) | Warns on pushes to protected branches |
+| `validate-assets.sh` | Write/Edit in `assets/` (PostToolUse) | Validates naming, JSON structure |
+| `pre-compact.sh` | Context compression | Preserves session progress notes |
+| `session-stop.sh` | Session close | Logs accomplishments |
+| `log-agent.sh` | Subagent spawn | Audit trail of all agent invocations |
 
 ## Collaboration Protocol
 
@@ -42,8 +62,37 @@ Every task follows: **Question -> Options -> Decision -> Draft -> Approval**
 
 See `docs/COLLABORATIVE-DESIGN-PRINCIPLE.md` for full protocol and examples.
 
-> **First session?** If the project has no engine configured and no game concept,
-> run `/start` to begin the guided onboarding flow.
+## Key Workflows
+
+| Starting point | Run this |
+|---------------|----------|
+| No idea what to build | `/start` or `/brainstorm` |
+| Have a concept, need engine | `/setup-engine` |
+| Have concept + engine, need design | `/map-systems` then `/design-system` |
+| Have existing project | `/project-stage-detect` then `/gate-check` |
+| Ready to implement | `/sprint-plan new` |
+
+## Session Recovery
+
+After compaction, crash, or `/clear`: read `production/session-state/active.md` first.
+This file is the living checkpoint — it tracks current task, progress, decisions, and
+files being worked on. The file is the memory, not the conversation.
+
+## Project Structure
+
+@.claude/docs/directory-structure.md
+
+## Engine Version Reference
+
+@docs/engine-reference/unity/VERSION.md
+
+## Technical Preferences
+
+@.claude/docs/technical-preferences.md
+
+## Coordination Rules
+
+@.claude/docs/coordination-rules.md
 
 ## Coding Standards
 

--- a/design/gdd/ark-service-integration.md
+++ b/design/gdd/ark-service-integration.md
@@ -1,13 +1,13 @@
-# GLM Service Integration
+# Ark Service Integration
 
 > **Status**: Implemented
 > **Author**: user + ai-programmer
-> **Last Updated**: 2026-03-30
-> **Implements Pillar**: 对话 — 与 GLM 驱动的 AI 导游进行自然语言对话
+> **Last Updated**: 2026-06-27
+> **Implements Pillar**: 对话 — 与火山方舟 Ark 驱动的 AI 导游进行自然语言对话
 
 ## Overview
 
-GLM Service Integration 是 TripMeta 的大语言模型接入层，负责将智谱 AI 的 GLM 系列模型（GLM-4.7 / GLM-4-Flash）接入到现有的 AI 服务架构中，替代当前的 OpenAI GPT-4o 实现。该系统实现 `IGPTService` 接口，为 AI 导游和 NPC 对话提供多轮对话、流式响应、内容生成能力。用户不直接感知该系统——他们感知到的是导游能"说话"了，NPC 能"回应"了。没有该系统，所有 AI 功能处于 Mock 状态，无法产生真实对话。
+Ark Service Integration 是 TripMeta 的大语言模型接入层，负责将火山方舟 Ark CodingPlan 的 OpenAI-compatible chat completion 接入到现有的 AI 服务架构中，替代旧的 OpenAI/第三方直连实现。该系统实现 `IGPTService` 接口，为 AI 导游和 NPC 对话提供多轮对话、流式响应、内容生成能力。用户不直接感知该系统——他们感知到的是导游能"说话"了，NPC 能"回应"了。没有该系统，所有 AI 功能处于 Mock 状态，无法产生真实对话。
 
 ## Player Fantasy
 
@@ -17,18 +17,18 @@ GLM Service Integration 是 TripMeta 的大语言模型接入层，负责将智�
 
 ### Core Rules
 
-1. GLMService 实现 `IGPTService` 接口，作为 GPTService 的替代
-2. API 端点：`https://open.bigmodel.cn/api/paas/v4/chat/completions`
+1. ArkService 实现 `IGPTService` 接口，作为 GPTService 的替代
+2. API 端点：`https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions`
 3. 认证方式：Bearer Token（API Key 从配置读取，不硬编码）
-4. 默认模型：`glm-4-flash-250414`（免费，128K context，开发/测试用）
-5. 生产模型：`glm-4.7`（200K context，128K max output，需付费）
+4. 默认模型：`doubao-seed-2-0-code-preview-260215`
+5. 生产模型：通过 `ARK_CHAT_MODEL` 配置，默认沿用 CodingPlan 模型
 6. 请求格式与 OpenAI 兼容：`{ model, messages[], temperature, max_tokens, stream }`
 7. 非流式响应解析：`response.choices[0].message.content`
 8. 流式响应解析：SSE 格式，`data: {json}\n\n`，`delta.content` 逐 chunk 拼接
 9. 流式结束标志：`data: [DONE]`
 10. 每个对话维护独立的 messages 历史（conversationId 索引）
 11. 速率限制：可配置 `maxRequestsPerMinute`，超限后排队等待
-12. Fallback 策略：GLM 主服务 → Ollama 本地 → Mock 服务（三级降级）
+12. Fallback 策略：Ark 主服务 → Ollama 本地 → Mock 服务（三级降级）
 
 ### States and Transitions
 
@@ -39,18 +39,18 @@ GLM Service Integration 是 TripMeta 的大语言模型接入层，负责将智�
 | Processing | 收到请求 | 响应完成 / 超时 / 错误 | 发送 HTTP 请求，解析响应 |
 | Streaming | 收到流式请求 | SSE `[DONE]` / 超时 / 错误 | 逐 chunk 回调 `onPartialResponse` |
 | Paused | `Pause()` 调用 | `Resume()` 调用 | 拒绝新请求，不影响进行中请求 |
-| Degraded | GLM API 连续失败 N 次 | 健康检查恢复 | 自动切换到 Ollama fallback |
+| Degraded | Ark API 连续失败 N 次 | 健康检查恢复 | 自动切换到 Ollama fallback |
 | Failed | 所有后端不可用 | `ReinitializeAsync()` | 返回 Mock 预设回复或抛异常 |
 
 ### Interactions with Other Systems
 
 | System | Direction | Interface |
 |--------|-----------|-----------|
-| AI Service Layer [6] | 上游 | `AIServiceManager` 通过 `services[AIServiceType.LLM]` 持有 GLMService 引用 |
+| AI Service Layer [6] | 上游 | `AIServiceManager` 通过 `services[AIServiceType.LLM]` 持有 ArkService 引用 |
 | AI Tour Guide [4] | 下游 | 调用 `SendChatAsync()` / `SendStreamChatAsync()` 获取导游回复 |
 | AI NPC System [5] | 下游 | `NPCDialogueManager` 调用 `SendStreamChatAsync()` 获取 NPC 对话 |
 | Infrastructure [15] | 上游 | 使用 `UnityWebRequest` 发送 HTTP 请求 |
-| Core Config [1] | 上游 | 从 `GLMConfig` ScriptableObject 读取 API Key、模型、端点 |
+| Core Config [1] | 上游 | 从 `ArkConfig` ScriptableObject 或 AppSettings 读取 API Key、模型、端点 |
 | Error Handling [2] | 上游 | 使用 `Logger` 记录请求/响应/错误日志 |
 
 ## Formulas
@@ -78,7 +78,7 @@ requestTimeout = baseTimeout + (estimatedTokens / tokensPerSecond)
 |----------|------|-------|--------|-------------|
 | baseTimeout | float | 5-30s | config | 基础超时（网络 + 首 token） |
 | estimatedTokens | int | 10-4096 | request | 预估输出 token 数 |
-| tokensPerSecond | float | 20-100 | measured | GLM 实测吐 token 速度 |
+| tokensPerSecond | float | 20-100 | measured | Ark 实测吐 token 速度 |
 
 **Expected output range**: requestTimeout 在 5s-70s 之间
 **Edge case**: 流式请求使用固定 baseTimeout（无需预估 token 总量）
@@ -88,14 +88,14 @@ requestTimeout = baseTimeout + (estimatedTokens / tokensPerSecond)
 | Scenario | Expected Behavior | Rationale |
 |----------|------------------|-----------|
 | API Key 为空或无效 | 初始化时抛异常，记录日志，fallback 到 Ollama | 快速失败，不浪费请求 |
-| GLM API 返回 429 (Rate Limited) | 指数退避重试（1s → 2s → 4s），最多 3 次 | 避免雪崩，尊重服务端限制 |
+| Ark API 返回 429 (Rate Limited) | 指数退避重试（1s → 2s → 4s），最多 3 次 | 避免雪崩，尊重服务端限制 |
 | 流式响应中途断开 | 返回已接收的部分内容，标记 `partial: true` | 部分回答优于无回答 |
 | 网络完全不可用 | 切换 Ollama → 若也不可用，返回 Mock 预设回复 | 三级降级保证体验不崩溃 |
 | 对话历史超过 context window | 截断最早的消息，保留 system prompt + 最近 N 轮 | 防止请求失败 |
 | 并发请求超过 maxConcurrentRequests | 排队等待，FIFO 顺序处理 | 防止 API 过载 |
 | temperature = 0 | 允许，产出确定性回复（适合事实类问答） | 导游讲历史事实时需要确定性 |
 | 空消息输入 | 拒绝请求，返回错误，不消耗 API 配额 | 防止浪费 |
-| GLM 返回空内容 | 重试 1 次，仍空则返回 "抱歉，请再说一遍" | 避免 UI 显示空白 |
+| Ark 返回空内容 | 重试 1 次，仍空则返回 "抱歉，请再说一遍" | 避免 UI 显示空白 |
 
 ## Dependencies
 
@@ -112,7 +112,7 @@ requestTimeout = baseTimeout + (estimatedTokens / tokensPerSecond)
 
 | Parameter | Default | Safe Range | Effect of Increase | Effect of Decrease |
 |-----------|---------|------------|-------------------|-------------------|
-| model | glm-4-flash-250414 | 见模型列表 | 更强能力，更高成本 | 更快更便宜，能力下降 |
+| model | doubao-seed-2-0-code-preview-260215 | 见 Ark 控制台/CodingPlan 模型列表 | 更强能力，更高成本 | 更快更便宜，能力下降 |
 | temperature | 0.7 | 0.0-1.5 | 更有创意/随机 | 更确定/可预测 |
 | maxTokens | 2048 | 64-16384 | 更长回复，更慢 | 更短更快 |
 | maxRequestsPerMinute | 30 | 1-120 | 更高吞吐 | 更低成本 |
@@ -124,17 +124,17 @@ requestTimeout = baseTimeout + (estimatedTokens / tokensPerSecond)
 
 ## Acceptance Criteria
 
-- [ ] GLMService 实现 `IGPTService` 完整接口
-- [ ] `SendChatAsync` 正确发送请求到 GLM API 并返回文本
+- [ ] ArkService 实现 `IGPTService` 完整接口
+- [ ] `SendChatAsync` 正确发送请求到 Ark API 并返回文本
 - [ ] `SendStreamChatAsync` 通过 SSE 逐 chunk 回调
 - [ ] 流式首 token 延迟 < 2s（正常网络条件下）
 - [ ] API Key 从配置文件读取，代码中无硬编码密钥
-- [ ] GLM 不可用时自动降级到 Ollama
+- [ ] Ark 不可用时自动降级到 Ollama
 - [ ] Ollama 也不可用时降级到 Mock 服务
 - [ ] 对话历史正确维护（多轮上下文连贯）
 - [ ] 速率限制正常工作（超限排队，不丢弃）
 - [ ] 超时机制工作（30s 内无响应则中止）
-- [ ] `AIServiceManager.InitializeLLMService()` 使用 GLMService 替代 OpenAIService
+- [ ] `AIServiceManager.InitializeLLMService()` 使用 ArkService 替代 OpenAIService
 - [ ] 所有日志正确输出到 Logger（无 `Debug.Log` 直接调用）
 - [ ] 无 `[DONE]` 之后的多余解析尝试
 - [ ] Performance: 单次非流式请求处理（不含网络）< 5ms
@@ -144,5 +144,5 @@ requestTimeout = baseTimeout + (estimatedTokens / tokensPerSecond)
 | Question | Owner | Deadline | Resolution |
 |----------|-------|----------|-----------|
 | 语音服务替代方案：是否用讯飞/百度替换 Azure Speech？ | user | Sprint 1 结束前 | 待定 |
-| GLM API Key 的获取和管理流程？ | user | 开发开始前 | 需要注册智谱 AI 开放平台 |
-| 是否需要 JWT 认证（智谱支持 Bearer 和 JWT 两种）？ | ai-programmer | Sprint 1 | Bearer Token 更简单，建议先用 Bearer |
+| Ark API Key 的获取和管理流程？ | user | 开发开始前 | 需要在火山方舟控制台创建并通过 `ARK_API_KEY` 注入 |
+| 是否需要特殊认证协议？ | ai-programmer | Sprint 1 | OpenAI-compatible chat endpoint 使用 Bearer Token |

--- a/design/gdd/game-concept.md
+++ b/design/gdd/game-concept.md
@@ -1,0 +1,55 @@
+# Game Concept: TripMeta
+
+> **Status**: Approved (extracted from existing project)
+> **Created**: 2026-03-30
+> **Source**: TripMeta README, CLAUDE.md, FUTURE_ROADMAP.md
+
+---
+
+## One-Line Pitch
+
+AI 驱动的 VR 元宇宙旅游社区——戴上头显，AI 导游带你沉浸式游览全球景点。
+
+## Core Experience
+
+| Pillar | Description |
+|--------|-------------|
+| **探索** | 用 PICO VR 头显探索世界各地虚拟景点 |
+| **对话** | 与 GLM 驱动的 AI 导游进行自然语言对话 |
+| **学习** | 通过知识图谱了解历史和文化 |
+| **交互** | 语音对话 + VR 控制器直观交互 |
+
+## Technology
+
+- **Engine**: Unity 2021.3.11f1 (LTS) + URP 17.0.3
+- **Platform**: PICO 4 VR (Android)
+- **AI Model**: GLM series (智谱AI)
+- **Speech**: TBD (replacing Azure)
+- **Networking**: Netcode for GameObjects 2.1.1 (deferred)
+
+## Current State
+
+Alpha — 80 C# files, ~6,817 LOC, core systems implemented with Mock AI services.
+
+## Near-Term Goals
+
+1. GLM model integration (replace GPT-4o)
+2. Single-player VR experience polish
+3. Speech service integration
+
+## Long-Term Vision
+
+- Multi-user VR sessions
+- UGC content creation tools
+- Cross-platform (Quest, Vision Pro, WebXR)
+- Global localization (50+ languages)
+
+## Performance Targets
+
+| Metric | Target |
+|--------|--------|
+| Frame Rate | 90 FPS |
+| Latency | <20ms motion-to-photon |
+| AI Response | <2s |
+| Memory | <4GB |
+| Draw Calls | <100/frame |

--- a/design/gdd/game-concept.md
+++ b/design/gdd/game-concept.md
@@ -15,7 +15,7 @@ AI 驱动的 VR 元宇宙旅游社区——戴上头显，AI 导游带你沉浸�
 | Pillar | Description |
 |--------|-------------|
 | **探索** | 用 PICO VR 头显探索世界各地虚拟景点 |
-| **对话** | 与 GLM 驱动的 AI 导游进行自然语言对话 |
+| **对话** | 与火山方舟 Ark 驱动的 AI 导游进行自然语言对话 |
 | **学习** | 通过知识图谱了解历史和文化 |
 | **交互** | 语音对话 + VR 控制器直观交互 |
 
@@ -23,7 +23,7 @@ AI 驱动的 VR 元宇宙旅游社区——戴上头显，AI 导游带你沉浸�
 
 - **Engine**: Unity 2021.3.11f1 (LTS) + URP 17.0.3
 - **Platform**: PICO 4 VR (Android)
-- **AI Model**: GLM series (智谱AI)
+- **AI Model**: Volcengine Ark CodingPlan / Doubao
 - **Speech**: TBD (replacing Azure)
 - **Networking**: Netcode for GameObjects 2.1.1 (deferred)
 
@@ -33,7 +33,7 @@ Alpha — 80 C# files, ~6,817 LOC, core systems implemented with Mock AI service
 
 ## Near-Term Goals
 
-1. GLM model integration (replace GPT-4o)
+1. Ark model integration (replace GPT-4o)
 2. Single-player VR experience polish
 3. Speech service integration
 

--- a/design/gdd/glm-service-integration.md
+++ b/design/gdd/glm-service-integration.md
@@ -1,0 +1,148 @@
+# GLM Service Integration
+
+> **Status**: Implemented
+> **Author**: user + ai-programmer
+> **Last Updated**: 2026-03-30
+> **Implements Pillar**: 对话 — 与 GLM 驱动的 AI 导游进行自然语言对话
+
+## Overview
+
+GLM Service Integration 是 TripMeta 的大语言模型接入层，负责将智谱 AI 的 GLM 系列模型（GLM-4.7 / GLM-4-Flash）接入到现有的 AI 服务架构中，替代当前的 OpenAI GPT-4o 实现。该系统实现 `IGPTService` 接口，为 AI 导游和 NPC 对话提供多轮对话、流式响应、内容生成能力。用户不直接感知该系统——他们感知到的是导游能"说话"了，NPC 能"回应"了。没有该系统，所有 AI 功能处于 Mock 状态，无法产生真实对话。
+
+## Player Fantasy
+
+这是一个用户"不应该注意到"的基础设施系统。当它正常工作时，用户感受到的是：AI 导游的回答自然流畅、知识丰富、响应快速（<2 秒出首个 token）。流式输出让文字像人类打字一样逐步出现，而不是等待一大段文字突然弹出。失败时系统静默降级，用户看到预设回复而不是错误信息。
+
+## Detailed Design
+
+### Core Rules
+
+1. GLMService 实现 `IGPTService` 接口，作为 GPTService 的替代
+2. API 端点：`https://open.bigmodel.cn/api/paas/v4/chat/completions`
+3. 认证方式：Bearer Token（API Key 从配置读取，不硬编码）
+4. 默认模型：`glm-4-flash-250414`（免费，128K context，开发/测试用）
+5. 生产模型：`glm-4.7`（200K context，128K max output，需付费）
+6. 请求格式与 OpenAI 兼容：`{ model, messages[], temperature, max_tokens, stream }`
+7. 非流式响应解析：`response.choices[0].message.content`
+8. 流式响应解析：SSE 格式，`data: {json}\n\n`，`delta.content` 逐 chunk 拼接
+9. 流式结束标志：`data: [DONE]`
+10. 每个对话维护独立的 messages 历史（conversationId 索引）
+11. 速率限制：可配置 `maxRequestsPerMinute`，超限后排队等待
+12. Fallback 策略：GLM 主服务 → Ollama 本地 → Mock 服务（三级降级）
+
+### States and Transitions
+
+| State | Entry Condition | Exit Condition | Behavior |
+|-------|----------------|----------------|----------|
+| Uninitialized | 服务创建 | `InitializeAsync()` 成功 | 拒绝所有请求 |
+| Ready | 初始化成功 / 恢复 | 请求到达 / `Pause()` / 故障 | 接受并处理请求 |
+| Processing | 收到请求 | 响应完成 / 超时 / 错误 | 发送 HTTP 请求，解析响应 |
+| Streaming | 收到流式请求 | SSE `[DONE]` / 超时 / 错误 | 逐 chunk 回调 `onPartialResponse` |
+| Paused | `Pause()` 调用 | `Resume()` 调用 | 拒绝新请求，不影响进行中请求 |
+| Degraded | GLM API 连续失败 N 次 | 健康检查恢复 | 自动切换到 Ollama fallback |
+| Failed | 所有后端不可用 | `ReinitializeAsync()` | 返回 Mock 预设回复或抛异常 |
+
+### Interactions with Other Systems
+
+| System | Direction | Interface |
+|--------|-----------|-----------|
+| AI Service Layer [6] | 上游 | `AIServiceManager` 通过 `services[AIServiceType.LLM]` 持有 GLMService 引用 |
+| AI Tour Guide [4] | 下游 | 调用 `SendChatAsync()` / `SendStreamChatAsync()` 获取导游回复 |
+| AI NPC System [5] | 下游 | `NPCDialogueManager` 调用 `SendStreamChatAsync()` 获取 NPC 对话 |
+| Infrastructure [15] | 上游 | 使用 `UnityWebRequest` 发送 HTTP 请求 |
+| Core Config [1] | 上游 | 从 `GLMConfig` ScriptableObject 读取 API Key、模型、端点 |
+| Error Handling [2] | 上游 | 使用 `Logger` 记录请求/响应/错误日志 |
+
+## Formulas
+
+### Rate Limit
+
+```
+canSendRequest = (requestCount < maxRequestsPerMinute)
+                 OR (now - windowStart >= 60s)
+```
+
+| Variable | Type | Range | Source | Description |
+|----------|------|-------|--------|-------------|
+| requestCount | int | 0-∞ | runtime | 当前窗口内已发请求数 |
+| maxRequestsPerMinute | int | 1-120 | config | 每分钟最大请求数 |
+| windowStart | DateTime | — | runtime | 当前限速窗口起始时间 |
+
+### Timeout Calculation
+
+```
+requestTimeout = baseTimeout + (estimatedTokens / tokensPerSecond)
+```
+
+| Variable | Type | Range | Source | Description |
+|----------|------|-------|--------|-------------|
+| baseTimeout | float | 5-30s | config | 基础超时（网络 + 首 token） |
+| estimatedTokens | int | 10-4096 | request | 预估输出 token 数 |
+| tokensPerSecond | float | 20-100 | measured | GLM 实测吐 token 速度 |
+
+**Expected output range**: requestTimeout 在 5s-70s 之间
+**Edge case**: 流式请求使用固定 baseTimeout（无需预估 token 总量）
+
+## Edge Cases
+
+| Scenario | Expected Behavior | Rationale |
+|----------|------------------|-----------|
+| API Key 为空或无效 | 初始化时抛异常，记录日志，fallback 到 Ollama | 快速失败，不浪费请求 |
+| GLM API 返回 429 (Rate Limited) | 指数退避重试（1s → 2s → 4s），最多 3 次 | 避免雪崩，尊重服务端限制 |
+| 流式响应中途断开 | 返回已接收的部分内容，标记 `partial: true` | 部分回答优于无回答 |
+| 网络完全不可用 | 切换 Ollama → 若也不可用，返回 Mock 预设回复 | 三级降级保证体验不崩溃 |
+| 对话历史超过 context window | 截断最早的消息，保留 system prompt + 最近 N 轮 | 防止请求失败 |
+| 并发请求超过 maxConcurrentRequests | 排队等待，FIFO 顺序处理 | 防止 API 过载 |
+| temperature = 0 | 允许，产出确定性回复（适合事实类问答） | 导游讲历史事实时需要确定性 |
+| 空消息输入 | 拒绝请求，返回错误，不消耗 API 配额 | 防止浪费 |
+| GLM 返回空内容 | 重试 1 次，仍空则返回 "抱歉，请再说一遍" | 避免 UI 显示空白 |
+
+## Dependencies
+
+| System | Direction | Nature |
+|--------|-----------|--------|
+| [6] AI Service Layer | This depends on | 硬依赖 — 通过 AIServiceManager 注册和管理生命周期 |
+| [15] Infrastructure | This depends on | 硬依赖 — HTTP 网络请求能力 |
+| [1] Core Infrastructure | This depends on | 硬依赖 — DI 容器注册、配置加载 |
+| [2] Error Handling | This depends on | 软依赖 — 日志记录（无日志也能工作） |
+| [4] AI Tour Guide | Depends on this | 硬依赖 — 导游对话的 LLM 后端 |
+| [5] AI NPC System | Depends on this | 硬依赖 — NPC 对话的 LLM 后端 |
+
+## Tuning Knobs
+
+| Parameter | Default | Safe Range | Effect of Increase | Effect of Decrease |
+|-----------|---------|------------|-------------------|-------------------|
+| model | glm-4-flash-250414 | 见模型列表 | 更强能力，更高成本 | 更快更便宜，能力下降 |
+| temperature | 0.7 | 0.0-1.5 | 更有创意/随机 | 更确定/可预测 |
+| maxTokens | 2048 | 64-16384 | 更长回复，更慢 | 更短更快 |
+| maxRequestsPerMinute | 30 | 1-120 | 更高吞吐 | 更低成本 |
+| maxConcurrentRequests | 3 | 1-10 | 更快并发 | 更稳定 |
+| requestTimeout | 30s | 5-120s | 容忍慢响应 | 快速失败 |
+| maxConversationLength | 20 | 5-50 | 更长上下文记忆 | 更少 token 消耗 |
+| enableFallback | true | bool | 有降级保护 | 失败即报错 |
+| fallbackRetryCount | 3 | 0-5 | 更多重试机会 | 更快失败 |
+
+## Acceptance Criteria
+
+- [ ] GLMService 实现 `IGPTService` 完整接口
+- [ ] `SendChatAsync` 正确发送请求到 GLM API 并返回文本
+- [ ] `SendStreamChatAsync` 通过 SSE 逐 chunk 回调
+- [ ] 流式首 token 延迟 < 2s（正常网络条件下）
+- [ ] API Key 从配置文件读取，代码中无硬编码密钥
+- [ ] GLM 不可用时自动降级到 Ollama
+- [ ] Ollama 也不可用时降级到 Mock 服务
+- [ ] 对话历史正确维护（多轮上下文连贯）
+- [ ] 速率限制正常工作（超限排队，不丢弃）
+- [ ] 超时机制工作（30s 内无响应则中止）
+- [ ] `AIServiceManager.InitializeLLMService()` 使用 GLMService 替代 OpenAIService
+- [ ] 所有日志正确输出到 Logger（无 `Debug.Log` 直接调用）
+- [ ] 无 `[DONE]` 之后的多余解析尝试
+- [ ] Performance: 单次非流式请求处理（不含网络）< 5ms
+
+## Open Questions
+
+| Question | Owner | Deadline | Resolution |
+|----------|-------|----------|-----------|
+| 语音服务替代方案：是否用讯飞/百度替换 Azure Speech？ | user | Sprint 1 结束前 | 待定 |
+| GLM API Key 的获取和管理流程？ | user | 开发开始前 | 需要注册智谱 AI 开放平台 |
+| 是否需要 JWT 认证（智谱支持 Bearer 和 JWT 两种）？ | ai-programmer | Sprint 1 | Bearer Token 更简单，建议先用 Bearer |

--- a/design/gdd/systems-index.md
+++ b/design/gdd/systems-index.md
@@ -2,7 +2,7 @@
 
 > **Status**: Approved
 > **Created**: 2026-03-30
-> **Last Updated**: 2026-03-30
+> **Last Updated**: 2026-06-27
 > **Source Concept**: design/gdd/game-concept.md
 
 ---
@@ -10,9 +10,9 @@
 ## Overview
 
 TripMeta 是一个 AI 驱动的 VR 旅游平台，需要三类核心系统：(1) 基础设施层——DI 容器、
-配置、错误处理、性能监控；(2) AI 服务层——GLM 模型接入、语音交互、NPC 行为；
+配置、错误处理、性能监控；(2) AI 服务层——火山方舟 Ark 模型接入、语音交互、NPC 行为；
 (3) VR 体验层——设备管理、交互、空间 UI、场景管理。当前 Alpha 阶段的核心任务是
-用 GLM 替换 Mock AI 服务，完善单人 VR 体验。
+用 Ark 替换 Mock AI 服务，完善单人 VR 体验。
 
 ---
 
@@ -23,8 +23,8 @@ TripMeta 是一个 AI 驱动的 VR 旅游平台，需要三类核心系统：(1)
 | 1 | Core Infrastructure | Foundation | Done | Implemented | — | — |
 | 2 | Error Handling & Logging | Foundation | Done | Implemented | — | — |
 | 3 | Performance Monitoring | Foundation | Done | Implemented | — | — |
-| 4 | AI Tour Guide | AI | P1 | Implemented (needs GLM adapt) | — | 6, 16 |
-| 5 | AI NPC System | AI | P1 | Implemented (needs GLM adapt) | — | 6, 16, 7 |
+| 4 | AI Tour Guide | AI | P1 | Implemented (needs Ark adapt) | — | 6, 16 |
+| 5 | AI NPC System | AI | P1 | Implemented (needs Ark adapt) | — | 6, 16, 7 |
 | 6 | AI Service Layer | AI | Done | Implemented | — | 1, 2, 15 |
 | 7 | VR Interaction | VR | Done | Implemented | — | 8 |
 | 8 | VR Manager | VR | Done | Implemented | — | 1, 2 |
@@ -35,7 +35,7 @@ TripMeta 是一个 AI 驱动的 VR 旅游平台，需要三类核心系统：(1)
 | 13 | Editor Tools | Tools | Done | Implemented | — | — |
 | 14 | Test Framework | Quality | Done | Implemented | — | — |
 | 15 | Infrastructure (Network/Cache) | Foundation | Done | Implemented (interfaces) | — | 1 |
-| 16 | GLM Service Integration | AI | **P0** | Designed | [design/gdd/glm-service-integration.md](glm-service-integration.md) | 6, 15 |
+| 16 | Ark Service Integration | AI | **P0** | Designed | [design/gdd/ark-service-integration.md](ark-service-integration.md) | 6, 15 |
 | 17 | Speech Service (国产化) (inferred) | AI | P1 | Not Started | — | 6, 15 |
 | 18 | Scene/World Management (inferred) | Core | P2 | Not Started | — | 1, 3 |
 | 19 | Save/Persistence (inferred) | Persistence | P3 | Not Started | — | 1, 2 |
@@ -66,8 +66,8 @@ TripMeta 是一个 AI 驱动的 VR 旅游平台，需要三类核心系统：(1)
 
 | Tier | Definition | Systems |
 |------|------------|---------|
-| **P0 — Immediate** | Core blocker: GLM integration unlocks all AI features | 16 |
-| **P1 — Sprint 1** | Adapt existing AI features to GLM + speech | 4, 5, 17 |
+| **P0 — Immediate** | Core blocker: Ark integration unlocks all AI features | 16 |
+| **P1 — Sprint 1** | Adapt existing AI features to Ark + speech | 4, 5, 17 |
 | **P2 — Sprint 2** | Scene management, UI enhancement, audio | 9, 18, 22 |
 | **P3 — Alpha Complete** | Persistence, localization, analytics | 19, 20, 21 |
 | **Done** | Already implemented, maintenance only | 1, 2, 3, 6, 7, 8, 10, 11, 12, 13, 14, 15 |
@@ -97,7 +97,7 @@ TripMeta 是一个 AI 驱动的 VR 旅游平台，需要三类核心系统：(1)
 
 ### Layer 3 — Features (depends on Services)
 
-1. **[16] GLM Service Integration** ★P0 → [6][15]
+1. **[16] Ark Service Integration** ★P0 → [6][15]
 2. **[17] Speech Service** → [6][15]
 3. **[4] AI Tour Guide** → [6][16]
 4. **[5] AI NPC System** → [6][16][7]
@@ -122,9 +122,9 @@ TripMeta 是一个 AI 驱动的 VR 旅游平台，需要三类核心系统：(1)
 
 | Order | System | Priority | Layer | Agent(s) | Est. Effort |
 |-------|--------|----------|-------|----------|-------------|
-| 1 | [16] GLM Service Integration | P0 | Feature | ai-programmer, unity-specialist | M |
-| 2 | [4] AI Tour Guide (GLM adapt) | P1 | Feature | ai-programmer, gameplay-programmer | M |
-| 3 | [5] AI NPC System (GLM adapt) | P1 | Feature | ai-programmer, gameplay-programmer | M |
+| 1 | [16] Ark Service Integration | P0 | Feature | ai-programmer, unity-specialist | M |
+| 2 | [4] AI Tour Guide (Ark adapt) | P1 | Feature | ai-programmer, gameplay-programmer | M |
+| 3 | [5] AI NPC System (Ark adapt) | P1 | Feature | ai-programmer, gameplay-programmer | M |
 | 4 | [17] Speech Service | P1 | Feature | ai-programmer | M |
 | 5 | [18] Scene/World Management | P2 | Core | gameplay-programmer, unity-specialist | L |
 | 6 | [22] Audio System | P2 | Service | audio-director, sound-designer | M |
@@ -147,7 +147,7 @@ Effort: S = 1 session, M = 2-3 sessions, L = 4+ sessions.
 
 | System | Risk Type | Risk Description | Mitigation |
 |--------|-----------|-----------------|------------|
-| [16] GLM Service Integration | Technical | GLM API 与 OpenAI API 接口差异，流式响应兼容性 | 先调研 GLM API 文档，建 adapter 层 |
+| [16] Ark Service Integration | Technical | Ark OpenAI-compatible 接口的流式响应兼容性 | 先调研 Ark CodingPlan 文档，建 adapter 层 |
 | [17] Speech Service | Technical | 国产语音服务选型未定，延迟/质量不确定 | 保留接口抽象，支持多后端切换 |
 | [18] Scene/World Management | Scope | 景点数量和复杂度可能膨胀 | 先支持 2-3 个景点，验证流程 |
 
@@ -161,7 +161,7 @@ Effort: S = 1 session, M = 2-3 sessions, L = 4+ sessions.
 | Systems implemented | 15 |
 | Systems needing adaptation | 2 (AI Tour Guide, AI NPC) |
 | Systems not started | 6 (Speech, Scene, Save, Localization, Analytics, Audio) |
-| Design docs completed | 1 (GLM Service Integration) |
+| Design docs completed | 1 (Ark Service Integration) |
 | P0 systems designed | **1/1** ✅ |
 | P1 systems designed | 0/3 |
 
@@ -169,9 +169,9 @@ Effort: S = 1 session, M = 2-3 sessions, L = 4+ sessions.
 
 ## Next Steps
 
-- [ ] Design [16] GLM Service Integration — `/design-system GLM Service Integration`
+- [ ] Design [16] Ark Service Integration — `/design-system Ark Service Integration`
 - [ ] Plan Sprint 1 around P0 + P1 systems — `/sprint-plan new`
-- [ ] Research GLM API documentation before design
-- [ ] Design [4] AI Tour Guide adaptation after GLM design
-- [ ] Design [5] AI NPC System adaptation after GLM design
+- [ ] Research Ark CodingPlan API documentation before design
+- [ ] Design [4] AI Tour Guide adaptation after Ark design
+- [ ] Design [5] AI NPC System adaptation after Ark design
 - [ ] Run `/gate-check` when P0-P1 systems are designed and implemented

--- a/design/gdd/systems-index.md
+++ b/design/gdd/systems-index.md
@@ -1,0 +1,177 @@
+# Systems Index: TripMeta
+
+> **Status**: Approved
+> **Created**: 2026-03-30
+> **Last Updated**: 2026-03-30
+> **Source Concept**: design/gdd/game-concept.md
+
+---
+
+## Overview
+
+TripMeta 是一个 AI 驱动的 VR 旅游平台，需要三类核心系统：(1) 基础设施层——DI 容器、
+配置、错误处理、性能监控；(2) AI 服务层——GLM 模型接入、语音交互、NPC 行为；
+(3) VR 体验层——设备管理、交互、空间 UI、场景管理。当前 Alpha 阶段的核心任务是
+用 GLM 替换 Mock AI 服务，完善单人 VR 体验。
+
+---
+
+## Systems Enumeration
+
+| # | System Name | Category | Priority | Status | Design Doc | Depends On |
+|---|-------------|----------|----------|--------|------------|------------|
+| 1 | Core Infrastructure | Foundation | Done | Implemented | — | — |
+| 2 | Error Handling & Logging | Foundation | Done | Implemented | — | — |
+| 3 | Performance Monitoring | Foundation | Done | Implemented | — | — |
+| 4 | AI Tour Guide | AI | P1 | Implemented (needs GLM adapt) | — | 6, 16 |
+| 5 | AI NPC System | AI | P1 | Implemented (needs GLM adapt) | — | 6, 16, 7 |
+| 6 | AI Service Layer | AI | Done | Implemented | — | 1, 2, 15 |
+| 7 | VR Interaction | VR | Done | Implemented | — | 8 |
+| 8 | VR Manager | VR | Done | Implemented | — | 1, 2 |
+| 9 | Spatial UI | UI | P2 | Implemented (needs enhancement) | — | 7, 4, 10 |
+| 10 | Tour Guide Feature | Gameplay | Done | Implemented | — | 4, 18 |
+| 11 | Demo System | Tools | Done | Implemented | — | 4, 7, 9 |
+| 12 | Video Recording | Tools | Done | Implemented | — | 11 |
+| 13 | Editor Tools | Tools | Done | Implemented | — | — |
+| 14 | Test Framework | Quality | Done | Implemented | — | — |
+| 15 | Infrastructure (Network/Cache) | Foundation | Done | Implemented (interfaces) | — | 1 |
+| 16 | GLM Service Integration | AI | **P0** | Designed | [design/gdd/glm-service-integration.md](glm-service-integration.md) | 6, 15 |
+| 17 | Speech Service (国产化) (inferred) | AI | P1 | Not Started | — | 6, 15 |
+| 18 | Scene/World Management (inferred) | Core | P2 | Not Started | — | 1, 3 |
+| 19 | Save/Persistence (inferred) | Persistence | P3 | Not Started | — | 1, 2 |
+| 20 | Localization (inferred) | Meta | P3 | Not Started | — | 1 |
+| 21 | Analytics (inferred) | Meta | P3 | Not Started | — | 6, 19 |
+| 22 | Audio System (inferred) | Audio | P2 | Not Started | — | 1, 18 |
+
+---
+
+## Categories
+
+| Category | Description |
+|----------|-------------|
+| **Foundation** | DI, configuration, error handling, networking interfaces, performance monitoring |
+| **AI** | LLM integration, NPC behavior, dialogue management, speech services |
+| **VR** | Device management, controller input, gesture recognition, haptic feedback |
+| **Gameplay** | Tour guide logic, scene navigation, location data |
+| **UI** | Spatial panels, HUD, dialogue UI, VR-specific UI |
+| **Persistence** | User preferences, conversation history, tour progress |
+| **Audio** | Spatial audio, ambient sound, voice playback |
+| **Meta** | Analytics, localization, accessibility |
+| **Tools** | Demo, video recording, editor extensions, testing |
+| **Quality** | Test framework, CI/CD |
+
+---
+
+## Priority Tiers
+
+| Tier | Definition | Systems |
+|------|------------|---------|
+| **P0 — Immediate** | Core blocker: GLM integration unlocks all AI features | 16 |
+| **P1 — Sprint 1** | Adapt existing AI features to GLM + speech | 4, 5, 17 |
+| **P2 — Sprint 2** | Scene management, UI enhancement, audio | 9, 18, 22 |
+| **P3 — Alpha Complete** | Persistence, localization, analytics | 19, 20, 21 |
+| **Done** | Already implemented, maintenance only | 1, 2, 3, 6, 7, 8, 10, 11, 12, 13, 14, 15 |
+
+---
+
+## Dependency Map
+
+### Layer 0 — Foundation (no dependencies)
+
+1. **[1] Core Infrastructure** — DI container, bootstrap, configuration loading
+2. **[2] Error Handling & Logging** — Global exception handler, structured logging
+3. **[3] Performance Monitoring** — Frame rate, rendering optimizer, VR perf
+
+### Layer 1 — Core (depends on Foundation)
+
+1. **[15] Infrastructure** — Network/cache/resource interfaces → [1]
+2. **[8] VR Manager** — PICO SDK, XR loader → [1][2]
+3. **[19] Save/Persistence** — User prefs, progress → [1][2]
+4. **[18] Scene/World Management** — Location loading, transitions → [1][3]
+
+### Layer 2 — Services (depends on Core)
+
+1. **[6] AI Service Layer** — Service orchestration, health monitoring → [1][2][15]
+2. **[7] VR Interaction** — Controllers, gestures, haptics → [8]
+3. **[22] Audio System** — Spatial audio, ambient, voice → [1][18]
+
+### Layer 3 — Features (depends on Services)
+
+1. **[16] GLM Service Integration** ★P0 → [6][15]
+2. **[17] Speech Service** → [6][15]
+3. **[4] AI Tour Guide** → [6][16]
+4. **[5] AI NPC System** → [6][16][7]
+5. **[10] Tour Guide Feature** → [4][18]
+6. **[20] Localization** → [1]
+
+### Layer 4 — Presentation (depends on Features)
+
+1. **[9] Spatial UI** → [7][4][10]
+2. **[21] Analytics** → [6][19]
+
+### Layer 5 — Tools (independent)
+
+1. **[11] Demo System** → [4][7][9]
+2. **[12] Video Recording** → [11]
+3. **[13] Editor Tools** — no runtime dependency
+4. **[14] Test Framework** — no runtime dependency
+
+---
+
+## Recommended Design Order
+
+| Order | System | Priority | Layer | Agent(s) | Est. Effort |
+|-------|--------|----------|-------|----------|-------------|
+| 1 | [16] GLM Service Integration | P0 | Feature | ai-programmer, unity-specialist | M |
+| 2 | [4] AI Tour Guide (GLM adapt) | P1 | Feature | ai-programmer, gameplay-programmer | M |
+| 3 | [5] AI NPC System (GLM adapt) | P1 | Feature | ai-programmer, gameplay-programmer | M |
+| 4 | [17] Speech Service | P1 | Feature | ai-programmer | M |
+| 5 | [18] Scene/World Management | P2 | Core | gameplay-programmer, unity-specialist | L |
+| 6 | [22] Audio System | P2 | Service | audio-director, sound-designer | M |
+| 7 | [9] Spatial UI Enhancement | P2 | Presentation | unity-ui-specialist, ux-designer | M |
+| 8 | [19] Save/Persistence | P3 | Core | gameplay-programmer | S |
+| 9 | [20] Localization | P3 | Feature | localization-lead | M |
+| 10 | [21] Analytics | P3 | Presentation | analytics-engineer | S |
+
+Effort: S = 1 session, M = 2-3 sessions, L = 4+ sessions.
+
+---
+
+## Circular Dependencies
+
+- None found. All dependencies flow downward through the layer hierarchy.
+
+---
+
+## High-Risk Systems
+
+| System | Risk Type | Risk Description | Mitigation |
+|--------|-----------|-----------------|------------|
+| [16] GLM Service Integration | Technical | GLM API 与 OpenAI API 接口差异，流式响应兼容性 | 先调研 GLM API 文档，建 adapter 层 |
+| [17] Speech Service | Technical | 国产语音服务选型未定，延迟/质量不确定 | 保留接口抽象，支持多后端切换 |
+| [18] Scene/World Management | Scope | 景点数量和复杂度可能膨胀 | 先支持 2-3 个景点，验证流程 |
+
+---
+
+## Progress Tracker
+
+| Metric | Count |
+|--------|-------|
+| Total systems identified | 22 |
+| Systems implemented | 15 |
+| Systems needing adaptation | 2 (AI Tour Guide, AI NPC) |
+| Systems not started | 6 (Speech, Scene, Save, Localization, Analytics, Audio) |
+| Design docs completed | 1 (GLM Service Integration) |
+| P0 systems designed | **1/1** ✅ |
+| P1 systems designed | 0/3 |
+
+---
+
+## Next Steps
+
+- [ ] Design [16] GLM Service Integration — `/design-system GLM Service Integration`
+- [ ] Plan Sprint 1 around P0 + P1 systems — `/sprint-plan new`
+- [ ] Research GLM API documentation before design
+- [ ] Design [4] AI Tour Guide adaptation after GLM design
+- [ ] Design [5] AI NPC System adaptation after GLM design
+- [ ] Run `/gate-check` when P0-P1 systems are designed and implemented

--- a/docs/engine-reference/unity/VERSION.md
+++ b/docs/engine-reference/unity/VERSION.md
@@ -2,56 +2,44 @@
 
 | Field | Value |
 |-------|-------|
-| **Engine Version** | Unity 6.3 LTS |
-| **Release Date** | December 2025 |
-| **Project Pinned** | 2026-02-13 |
-| **Last Docs Verified** | 2026-02-13 |
+| **Engine Version** | Unity 2021.3.11f1 (LTS) |
+| **Project Pinned** | 2026-03-30 |
+| **Last Docs Verified** | 2026-03-30 |
 | **LLM Knowledge Cutoff** | May 2025 |
+| **Risk Level** | LOW — version is within LLM training data |
 
-## Knowledge Gap Warning
+## Note
 
-The LLM's training data likely covers Unity up to ~2022 LTS (2022.3). The entire
-Unity 6 release series (formerly Unity 2023 Tech Stream) introduced significant
-changes that the model does NOT know about. Always cross-reference this directory
-before suggesting Unity API calls.
+This engine version (2021.3 LTS) is well within the LLM's training data.
+No knowledge gap concerns. Engine reference docs are minimal.
 
-## Post-Cutoff Version Timeline
+## Key Packages
 
-| Version | Release | Risk Level | Key Theme |
-|---------|---------|------------|-----------|
-| 6.0 | Oct 2024 | HIGH | Unity 6 rebrand, new rendering features, Entities 1.3, DOTS improvements |
-| 6.1 | Nov 2024 | MEDIUM | Bug fixes, stability improvements |
-| 6.2 | Dec 2024 | MEDIUM | Performance optimizations, new input system improvements |
-| 6.3 LTS | Dec 2025 | HIGH | First LTS since 6.0, production-ready DOTS, enhanced graphics features |
+| Package | Version | Purpose |
+|---------|---------|---------|
+| URP | 17.0.3 | Rendering pipeline |
+| XR Interaction Toolkit | 3.0.7 | VR interactions |
+| Netcode for GameObjects | 2.1.1 | Multiplayer networking |
+| Input System | 1.11.2 | Input handling |
+| Addressables | 1.22.6 | Asset management |
+| ML Agents | 3.0.0 | AI behavior |
+| Barracuda | 3.0.0 | Neural network inference |
+| TextMeshPro | 3.0.7 | Text rendering |
 
-## Major Changes from 2022 LTS to Unity 6.3 LTS
+## Target Platform
 
-### Breaking Changes
-- **Entities/DOTS**: Major API overhaul in Entities 1.0+, complete redesign of ECS patterns
-- **Input System**: Legacy Input Manager deprecated, new Input System is default
-- **Rendering**: URP/HDRP significant upgrades, SRP Batcher improvements
-- **Addressables**: Asset management workflow changes
-- **Scripting**: C# 9 support, new API patterns
+- **Primary**: Android (PICO VR headsets)
+- **Development**: Windows (Editor)
 
-### New Features (Post-Cutoff)
-- **DOTS**: Production-ready Entity Component System (Entities 1.3+)
-- **Graphics**: Enhanced URP/HDRP pipelines, GPU Resident Drawer
-- **Multiplayer**: Netcode for GameObjects improvements
-- **UI Toolkit**: Production-ready for runtime UI (replaces UGUI for new projects)
-- **Async Asset Loading**: Improved Addressables performance
-- **Web**: WebGPU support
+## Performance Targets
 
-### Deprecated Systems
-- **Legacy Input Manager**: Use new Input System package
-- **Legacy Particle System**: Use Visual Effect Graph
-- **UGUI**: Still supported, but UI Toolkit recommended for new projects
-- **Old ECS (GameObjectEntity)**: Replaced by modern DOTS/Entities
+- **Frame Rate**: 90 FPS (PICO 4 requirement)
+- **Latency**: <20ms motion-to-photon
+- **Draw Calls**: <100 per frame
+- **Memory**: <4GB total budget
 
 ## Verified Sources
 
-- Official docs: https://docs.unity3d.com/6000.0/Documentation/Manual/index.html
-- Unity 6 release: https://unity.com/releases/unity-6
-- Unity 6.3 LTS announcement: https://unity.com/blog/unity-6-3-lts-is-now-available
-- Migration guide: https://docs.unity3d.com/6000.0/Documentation/Manual/upgrade-guides.html
-- Unity 6 support: https://unity.com/releases/unity-6/support
-- C# API reference: https://docs.unity3d.com/6000.0/Documentation/ScriptReference/index.html
+- Official docs: https://docs.unity3d.com/2021.3/Documentation/Manual/
+- C# API reference: https://docs.unity3d.com/2021.3/Documentation/ScriptReference/
+- Release notes: https://unity.com/releases/editor/whats-new/2021.3.11

--- a/docs/superpowers/specs/2026-03-31-spatial-memory-network-design.md
+++ b/docs/superpowers/specs/2026-03-31-spatial-memory-network-design.md
@@ -1,0 +1,447 @@
+# Spatial Memory Network — Product Design Spec
+
+**Date**: 2026-03-31
+**Status**: Draft — Pending Implementation Plan
+**Author**: Brainstorming session
+
+---
+
+## 1. Product Positioning & Core Experience
+
+### One-Line Positioning
+
+**"Pin memories to the real world. Discover them in person."**
+
+**中文**："把记忆钉在真实世界里，让亲友和陌生人亲自到场才能发现。"
+
+**对标**：空间版小红书 / Pinterest for the physical world
+
+### Problem Statement
+
+现有社交平台的内容在任何地方都能看到，与物理世界脱节。没有产品能同时做到：
+1. 地理位置锚定的 AR 渲染（不是地图标记，是真正的空间 AR）
+2. 持久化的个人多媒体记忆
+3. 面向亲友和公众的授权分享机制
+
+### Core Experience Loop
+
+```
+发现 → 感动 → 想留下自己的 → 创作 → 被别人发现 → 循环
+```
+
+**发现是核心驱动力**。用户必须先体验到"在真实世界某个位置看到别人的记忆"这个 magic moment，才会主动留下自己的记忆。留下记忆的创作行为可以通过其他平台导入内容完成——我们不需要成为用户最喜欢的"记录"工具，但要成为唯一的"空间发现"工具。
+
+### Experience Principles
+
+1. **到场即解锁** — 用户必须物理到达记忆所在位置（~50m 开始可见，15m 内完整查看）。这是核心差异化，永远不要妥协。
+2. **渐进式呈现** — 远处看到光点/轮廓提示 → 走近逐渐清晰 → 到达位置完整展开。像游戏里的"战争迷雾"。
+3. **不打扰，但引人好奇** — 不推送"你附近有记忆"。用户主动打开 app/戴上眼镜时，记忆自然浮现。
+4. **情感优先于信息** — 这不是大众点评，而是个人情感和故事的载体。
+
+### Content Visibility Model — Progressive Disclosure
+
+| Layer | Visibility | Unlock Condition | Example |
+|-------|-----------|-----------------|---------|
+| **Private** | Creator only | Creator present at location | Personal diary-style memory |
+| **Circle** | Authorized friends/family | Present + holds authorization token | "Dad, I watched the sunrise here last year" |
+| **Public** | All users | Present at location | Landmarks, city stories, check-ins |
+| **Featured** | All users (recommended) | Present at location | Editor's picks, high-engagement content |
+
+### MVP Content Types
+
+| Type | Priority | Notes |
+|------|----------|-------|
+| Photo + text caption | P0 | Lowest creation barrier |
+| Short video (≤30s) | P0 | High immersion for memory scenes |
+| Voice memo | P1 | Highest emotional warmth |
+| Text-only | P1 | Poems, stories, messages |
+| 3D model | P2 | AR-native but high creation barrier |
+| AR graffiti | P2 | Fun but complex |
+
+---
+
+## 2. Technical Architecture
+
+### System Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                   Client Layer                   │
+│  ┌──────────┐  ┌──────────┐  ┌───────────────┐  │
+│  │ Phone AR │  │Glasses AR│  │  Web Map View  │  │
+│  │ (Phase1) │  │ (Phase2) │  │  (Phase1.5)   │  │
+│  └────┬─────┘  └────┬─────┘  └──────┬────────┘  │
+├───────┴──────────────┴───────────────┴───────────┤
+│               AR Abstraction Layer               │
+│  Unified spatial anchor interface                │
+│  Shields ARCore/ARKit/MetaXR/Niantic differences │
+├──────────────────────────────────────────────────┤
+│                   API Gateway                    │
+├──────┬──────────┬──────────┬────────┬────────────┤
+│Spatial│ Content  │ Social   │Discover│ Moderation │
+│Service│ Service  │ Service  │ Engine │  Service   │
+├──────┴──────────┴──────────┴────────┴────────────┤
+│                  Data Layer                       │
+│  PostGIS │ Object Store (R2) │ Redis │ Vector DB  │
+└──────────────────────────────────────────────────┘
+```
+
+### Core Services
+
+**1. Spatial Service — "Where"**
+- Stores geo-coordinates (lat/lng/alt) + orientation (yaw/pitch/roll) per memory
+- PostGIS for spatial queries ("memories within 500m of me")
+- Does NOT rely on AR platform Cloud Anchors for persistence — own coordinate data + dynamic local anchor reconstruction
+- Outdoor: ARCore Geospatial API (Google Street View VPS)
+- Indoor: Wi-Fi fingerprinting + BLE beacons (Phase 2)
+
+**2. Content Service — "What"**
+- Media storage: Cloudflare R2 (zero egress cost)
+- Images: compressed original + thumbnail, CDN delivery
+- Video: transcode to HLS adaptive streaming, ≤30s
+- E2E encryption: private/circle memories encrypted client-side, server stores ciphertext
+- Content hash deduplication
+
+**3. Social Service — "Who can see"**
+- User relationship graph (follow, friend circles, auth chains)
+- Per-memory visibility settings
+- Auth tokens: shareable encrypted tokens for circle memories, works without friend relationship
+
+**4. Discovery Engine — "How to find"**
+- Geo-fence trigger: mark memories as "discoverable" when user enters radius
+- Heatmap ranking: when multiple memories at one location, sort by quality/recency/relationship closeness
+- Vector similarity: interest-based recommendation of nearby public memories (Phase 2)
+
+**5. Moderation Service — Safety**
+- Public memories require review (AI screening + human review)
+- Private/circle memories exempt but have report channel
+- GLM-4V (ZhipuAI) for Chinese content understanding and moderation
+
+### AR Abstraction Layer (Key Differentiator)
+
+```
+interface ISpatialAnchorProvider {
+    createAnchor(lat, lng, alt, orientation) → AnchorHandle
+    getLocalizationStatus() → { accuracy, source }
+    getDevicePose() → { position, rotation }
+    destroyAnchor(handle)
+}
+
+// Phase 1
+class ARCoreGeospatialProvider implements ISpatialAnchorProvider
+class ARKitLocationProvider implements ISpatialAnchorProvider
+
+// Phase 2
+class MetaXRProvider implements ISpatialAnchorProvider
+class NianticVPSProvider implements ISpatialAnchorProvider
+```
+
+This abstraction decouples from any single AR platform and enables future migration to glasses SDKs.
+
+### Phase 1 Technology Choices
+
+| Layer | Choice | Rationale |
+|-------|--------|-----------|
+| Mobile framework | Flutter + native AR bridge | Cross-platform efficiency, AR via native code for performance |
+| AR positioning | ARCore Geospatial API (Android) + ARKit Location Anchors (iOS) | Global outdoor coverage, sufficient precision |
+| Backend language | Go or Node.js | High-concurrency geo-query scenarios |
+| Database | PostgreSQL + PostGIS | Spatial queries are core; PostGIS is industry standard |
+| Object storage | Cloudflare R2 | Zero egress fees — critical for media-heavy app |
+| CDN | Cloudflare | Seamless R2 integration |
+| Cache | Redis + GeoHash | Fast hot-zone memory lookups |
+| AI moderation | GLM-4V (ZhipuAI) | Strong Chinese content understanding, low cost |
+| Real-time sync | WebSocket | Multi-user presence at same location (Phase 2) |
+
+### Key Technical Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| GPS drift causes memory misplacement | High | Dual-layer positioning: GPS coarse → VPS visual fine. Allow user manual adjustment. "Fuzzy mode" shows area instead of precise pin when accuracy is low |
+| GPS fails indoors | High | Phase 1 focuses on outdoor scenes (tourist spots, streets, parks). Indoor as Phase 2 |
+| Too many memories at hotspots cause visual clutter | Medium | Spatial clustering + LOD (far: aggregate into one glow point, near: expand individuals) |
+| E2E encryption vs content moderation conflict | Medium | Only public memories are moderated (plaintext). Private memories are E2E encrypted, exempt from moderation but have report channel |
+| Multi-user sync at same location | Low | Phase 1 single-user only. Phase 2 adds shared sessions |
+
+---
+
+## 3. Business Model & Funding Story
+
+### Revenue Phases
+
+**Phase 1 (Month 0-12) — Free Growth**
+- Zero revenue. All features free.
+- Goal: 100K+ registered users, 1M+ geo-anchored memories
+
+**Phase 2 (Month 12-24) — Payment Validation**
+
+| Source | Model | Details |
+|--------|-------|---------|
+| Pro subscription | ¥18/month or ¥168/year | Free: 50 memory limit, 720p video. Pro: unlimited, 4K, 3D models, AR graffiti, advanced privacy |
+| Brand memories | B2B partnerships | Venues/brands place branded content at locations. Per-location/time pricing |
+| Memory gifts | Virtual goods | Special "memory containers" (time capsule, drift bottle, birthday cake shape). ¥6-30 each |
+
+**Phase 3 (Month 24+) — Platform Ecosystem**
+
+| Source | Model |
+|--------|-------|
+| Spatial ads | Location-based AR ads in commercial areas. CPM model |
+| Open API | Third-party apps connect to spatial memory network. Usage-based pricing |
+| Data licensing | Anonymized spatial behavior data to city planning, tourism boards |
+| Glasses premium | AR glasses premium experience subscription when hardware arrives |
+
+### Unit Economics Target (Phase 2)
+
+```
+Per-user monthly cost:
+  Storage (avg 200MB/user)     ≈ ¥0.03
+  CDN egress (R2 zero egress)  ≈ ¥0.00
+  Compute (API calls)          ≈ ¥0.15
+  AI moderation (public)       ≈ ¥0.05
+  ─────────────────────────────
+  Total                        ≈ ¥0.23/user/month
+
+5% paid conversion × ¥18/month = ¥0.90 ARPU
+Gross margin ≈ ¥0.67/user/month ✅ Positive
+```
+
+### Funding Pitch
+
+**One-liner**: "We are the spatial memory network — users pin photos, videos, and sounds to physical locations in the real world. Others must visit in person to discover them. Phone AR first, AR glasses infrastructure when hardware arrives."
+
+**Why now**:
+1. ARCore Geospatial API matured in 2024 — global coverage, tech inflection point
+2. Gen Z location-sharing behavior validated by Snapchat/Find My — user habits ready
+3. AR glasses consumer launch imminent (2027) — accumulate spatial data now = own the future entry point
+4. 18-24 month window before big tech moves in
+
+**Competitive moats**:
+
+| Moat | Description |
+|------|-------------|
+| Spatial data network effect | More memories per location → better discovery → more users → more memories. First mover wins |
+| Emotional social graph | Not "follow" relationships but "I trust you with my most private memories." Extremely high switching cost |
+| Presence verification | Patentable "must be physically present to unlock" core mechanic |
+| Cross-platform spatial index | World's largest "what human memories exist at which physical locations" database |
+
+**Comparable framing**:
+- "空间版小红书 — Xiaohongshu lets you search for good content; we make you walk up to it"
+- "Pinterest for the physical world — Pinterest pins inspiration to digital boards; we pin memories to the real world"
+
+### Funding Cadence
+
+| Round | Timing | Amount | Milestone |
+|-------|--------|--------|-----------|
+| Angel/Seed | 2026 Q3 | ¥3-5M | MVP live, seed city with 10K users, 100K memories |
+| Pre-A | 2027 Q2 | ¥15-30M | 100K DAU, 1M+ memories, brand partnership validation, AR glasses demo |
+| Series A | 2028 Q1 | ¥50-100M | AR glasses version live, 500K DAU, payment model validated |
+
+---
+
+## 4. Cold Start Strategy & MVP Roadmap
+
+### The Triple Cold Start Problem
+
+Spatial content platforms face three simultaneous requirements:
+- Need content
+- Need users
+- Need content AND users at the SAME physical location
+
+### Solution: "City Seed" Strategy
+
+Focus on one city first, achieve critical content density, then expand.
+
+```
+Month 1:  Select seed city (recommend: Hangzhou — tourism + tech + founder familiarity)
+
+Month 2:  Official team + 50 recruited "Memory Seed Officers" pre-plant content
+          Cover 200 core locations (West Lake, Lingyin Temple, Hefang Street, malls...)
+          5-10 curated memories per location = ~1,000 seed memories
+
+Month 3:  Invite-only launch — "Hangzhou Memory Map"
+          Target: local university students, travel bloggers, photography enthusiasts
+          Hook: "Discover 1,000 memory easter eggs hidden across Hangzhou"
+
+Month 4-6: User organic growth + expand to second city
+```
+
+**Why it works**: 200 locations × 5 memories = 1,000 memories. Users encounter one memory approximately every 500m in urban areas → sufficient discovery density.
+
+### Viral Mechanisms
+
+| Mechanism | Description |
+|-----------|-------------|
+| **Memory Invitation** | "I left you a memory at [location], come open it in person" → Share to WeChat. Recipient must visit to see → creates curiosity + physical action |
+| **Memory Footprint Map** | Profile shows world map of "places I've left memories." Shareable to Moments. Like travel check-in maps but with emotional depth |
+| **Crossed Memories** | Two people each leave a memory at the same location → system generates "You and XX have a crossed memory here" → social interaction trigger |
+| **Memory Drift Bottle** | Random public memory pushed to nearby user: "Someone left a memory 300m from you. Want to go see?" |
+
+### MVP Development Roadmap
+
+```
+Month 1-2: Infrastructure
+├── Backend: PostGIS + R2 + API framework
+├── Auth: phone number / WeChat login
+└── Content pipeline: photo upload + storage + CDN
+
+Month 3-4: Core Experience
+├── AR positioning: ARCore Geospatial API integration
+├── Spatial discovery: open camera → see nearby memory glow points
+├── Memory viewing: approach → expand photo/video/text
+└── Memory creation: capture → anchor to current location
+
+Month 5: Social Layer
+├── User relationships: follow, friend circles
+├── Permissions: private/circle/public three-tier
+├── Memory invitations: share to WeChat
+└── Interactions: like, comment, bookmark
+
+Month 6: Launch
+├── Seed content pre-planting (200 locations)
+├── TestFlight / internal beta
+├── Seed city (Hangzhou) invite-only launch
+└── Analytics instrumentation + core metric monitoring
+```
+
+### North Star Metrics
+
+| Metric | Definition | 6-Month Target |
+|--------|-----------|----------------|
+| **Memory Discoveries** (North Star) | Times a user successfully arrives at location and views a memory | 50K/month |
+| Memory Density | Memories per km² in seed city | Core area >20/km² |
+| Creation Conversion | % of users who discovered a memory and then created one | >15% |
+| Invitation Conversion | Received memory invitation → actually visited and opened | >8% |
+| D7 Retention | New users still active after 7 days | >25% |
+
+---
+
+## 5. Team & Risk Management
+
+### Minimum Founding Team (Phase 1)
+
+| Role | Count | Core Responsibility | Key Skills |
+|------|-------|-------------------|------------|
+| Product/CEO | 1 | Product definition, fundraising, cold start ops | Product sense, fundraising, Unity/AR background |
+| AR Engineer | 1 | ARCore/ARKit integration, spatial anchors, AR rendering | ARCore Geospatial API expert, 3D rendering |
+| Backend Engineer | 1 | PostGIS spatial service, API, content pipeline | Go/Node + PostgreSQL + distributed systems |
+| Mobile Engineer | 1 | Flutter/native app, camera, UX | Cross-platform + native AR bridging |
+| Content Ops (part-time) | 1 | Seed content production, seed officer recruitment | Photography, community operations |
+
+### AR Engineer Hiring — Critical Path
+
+Most difficult and most important hire. Look for candidates from:
+- Niantic alumni (Pokemon GO AR team)
+- ByteDance/Kuaishou AR effects teams
+- University researchers in SLAM/VPS
+
+### Risk Matrix
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Cold start failure — users find no memories | High | Fatal | City seed strategy + 20/km² density hard target. If unmet in 3 months, narrow to single commercial district |
+| Poor AR positioning — memory drift | High | Severe | Dual-layer positioning + manual adjustment + "fuzzy mode" for low-accuracy areas |
+| Big tech enters (Google/Apple/Snap) | Medium | Severe | Moat is data, not technology. Speed > perfection. Big tech builds general tools; we build emotional vertical |
+| AR glasses delayed to 2029+ | Medium | Moderate | Phone experience must stand alone. Glasses are bonus, not requirement |
+| Privacy compliance (GDPR/PIPL) | Medium | Severe | Privacy-by-design from Day 1: minimal data collection, E2E encryption, local processing. Hire legal counsel |
+| Content safety (inappropriate content at public locations) | Medium | Severe | Mandatory moderation for public memories + geo-fencing (restrict public content near schools/government buildings) + rapid takedown |
+| Business model doesn't work — users won't pay | Medium | Moderate | Phase 1 doesn't depend on revenue. If Pro conversion <2%, pivot to brand partnerships and spatial ads |
+| Can't hire AR engineer | Medium | Severe | Founder builds prototype with ARCore first (has Unity/AR background), prove viability, then recruit |
+
+### Biggest Non-Technical Risk: User Habit Formation
+
+Current user mental model: "I arrive at a place → open Dianping/Xiaohongshu to search what's here"
+
+Target mental model: "I arrive at a place → open [our app] to see what memories are here"
+
+**Key insight**: Don't compete with search-intent products. Our trigger scenarios are:
+
+| Trigger | User Motivation | Competition |
+|---------|----------------|-------------|
+| "My friend says she left something here for me" | Social curiosity | **None** |
+| "Saw someone discover an amazing memory at West Lake on WeChat Moments" | FOMO + curiosity | **None** |
+| "I want to surprise my boyfriend at the place we first met" | Emotional expression | **None** |
+| "What interesting stories exist at this tourist spot" | Exploration | Xiaohongshu (weak overlap) |
+
+The first three — socially-driven, emotionally-driven — are our exclusive territory.
+
+---
+
+## 6. Platform Strategy — Phone First, Glasses Upgrade
+
+### Phase 1: Phone AR (2026 Q3 — 2027)
+- ARCore Geospatial API (Android) + ARKit Location Anchors (iOS)
+- Flutter app with native AR bridges
+- Full feature set on phone
+
+### Phase 1.5: Web Map View (2027 Q1)
+- Browse memories on a map (no AR, just map pins)
+- Low friction "window shopping" for non-app users
+- Drives app installs ("download the app to see this memory in AR")
+
+### Phase 2: AR Glasses (2027 — 2028)
+- Meta Orion / future consumer AR glasses via Meta XR SDK
+- Niantic VPS integration on Meta hardware
+- Ambient discovery layer — glasses auto-highlight nearby memories
+- Phone app remains for detailed viewing and creation
+
+### Phase 3: Spatial Infrastructure (2028+)
+- Open API for third-party apps
+- "Spatial memory layer" as platform primitive
+- Cross-device, cross-platform memory network
+
+### AR Abstraction Layer ensures each phase addition is an implementation swap, not an architecture rewrite.
+
+---
+
+## 7. Market Context (Research Summary)
+
+### Competitive Landscape
+
+| Product | What It Does | Gap vs. Our Concept |
+|---------|-------------|-------------------|
+| ReplayAR | GPS-pins photos to locations | Single-user only, social sharing never shipped, appears stagnant |
+| Snapchat Memories | Pins past Snaps to map locations | Private only, not true AR rendering, map overlay |
+| Google Photos + Maps | Photo timeline + location | Pure 2D, no sharing of timelines |
+| Apple Spatial Photos | 3D photo capture and viewing | $3,500 headset, no geo-anchoring |
+| Niantic Lightship | Global VPS platform | SDK/platform, not consumer memory app |
+
+**No product combines: geo-anchored AR + persistent personal memories + authorized social sharing.**
+
+### Market Size
+
+- Location-based services: $70.4B (2024) → $235B (2034), CAGR 12.6%
+- AR market: $78.3B (2025) → $828.5B (2033), CAGR 34.3%
+- Spatial computing: $168.6B (2025) → $897.5B (2035), CAGR 18.2%
+
+### Smart Glasses Landscape (as of 2026)
+
+No current consumer smart glasses simultaneously deliver: lightweight + spatial AR + available to buy.
+
+- **Meta Orion** (prototype, ~98g): Best spatial AR demo in glasses form, consumer version expected 2027
+- **Snap Spectacles 5** (226g, 45min battery): Best current spatial AR in glasses, dev kit only
+- **Meta Ray-Ban** (49g): Travel-friendly but no AR display
+
+Timeline: mainstream AR glasses expected 2027-2028 (Meta Orion derivative or Apple).
+
+### Meta AR Ecosystem Status
+
+- Meta shut down Spark AR (mobile) in Jan 2025, pivoting fully to headset/glasses
+- Orion developer access: invitation-only, broader availability targeted 2026
+- Consumer Orion: 2027 estimated
+- **Meta has no public VPS/geospatial service** — use Niantic Lightship VPS or Google ARCore Geospatial API
+- Niantic Spatial SDK v3.15 supports Meta Quest 3 including VPS
+- Current best development path: Quest 3 passthrough MR (Unity 6 + Meta XR SDK), skills transfer to Orion
+
+---
+
+## Appendix: Key Decisions Log
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Relationship to TripMeta | Independent project | VR headsets too bulky for travel; smart glasses form factor needed |
+| Core experience priority | Discovery > Creation | Users need to see magic first; creation can import from other platforms |
+| Content model | Fully open UGC | Low creation barrier, maximum expression space |
+| Visibility model | Progressive disclosure (default private, publishable to public, proximity unlock) | Privacy safety + growth potential + "must be present" ritual |
+| Target platform | Meta AR glasses ecosystem | Betting on Meta Orion as 2027 consumer AR glasses winner |
+| Product approach | Phone first, glasses upgrade | Phone AR is mature now; build user base and data moat before glasses arrive |
+| Project goal | Startup venture | Full product planning + business model + fundraising story needed |
+| Seed city | Hangzhou (recommended) | Tourism city + tech ecosystem + founder familiarity |

--- a/docs/superpowers/specs/2026-03-31-spatial-memory-network-design.md
+++ b/docs/superpowers/specs/2026-03-31-spatial-memory-network-design.md
@@ -115,7 +115,7 @@
 **5. Moderation Service — Safety**
 - Public memories require review (AI screening + human review)
 - Private/circle memories exempt but have report channel
-- GLM-4V (ZhipuAI) for Chinese content understanding and moderation
+- Ark vision-capable model (`ARK_VISION_MODEL`) for Chinese content understanding and moderation
 
 ### AR Abstraction Layer (Key Differentiator)
 
@@ -149,7 +149,7 @@ This abstraction decouples from any single AR platform and enables future migrat
 | Object storage | Cloudflare R2 | Zero egress fees — critical for media-heavy app |
 | CDN | Cloudflare | Seamless R2 integration |
 | Cache | Redis + GeoHash | Fast hot-zone memory lookups |
-| AI moderation | GLM-4V (ZhipuAI) | Strong Chinese content understanding, low cost |
+| AI moderation | Ark vision-capable model (`ARK_VISION_MODEL`) | Strong Chinese content understanding, provider managed through Ark env |
 | Real-time sync | WebSocket | Multi-user presence at same location (Phase 2) |
 
 ### Key Technical Risks

--- a/production/project-stage-report.md
+++ b/production/project-stage-report.md
@@ -18,7 +18,7 @@
 
 ## Key Decisions (2026-03-30)
 
-1. **AI Model**: GLM series (ZhipuAI) — replaces GPT-4o entirely
+1. **AI Model**: Volcengine Ark CodingPlan / Doubao — replaces GPT-4o entirely
 2. **Multiplayer**: Deferred — single-player VR experience first
 3. **Sprint Planning**: Managed within this project via /sprint-plan
 4. **Testing Strategy**: Full test suite after feature development
@@ -43,8 +43,8 @@
 
 | Priority | Task | Status |
 |----------|------|--------|
-| P0 | GLM model integration (replace GPT-4o) | Pending |
+| P0 | Ark model integration (replace GPT-4o) | Pending |
 | P1 | Map systems + create systems index | Pending |
-| P2 | Sprint plan for GLM integration | Pending |
+| P2 | Sprint plan for Ark integration | Pending |
 | P3 | Test coverage for AI service layer | Pending |
 | P4 | Multiplayer VR sessions | Deferred |

--- a/production/project-stage-report.md
+++ b/production/project-stage-report.md
@@ -1,0 +1,50 @@
+# Project Stage Analysis — TripMeta
+
+**Date**: 2026-03-30
+**Stage**: Production (Alpha)
+**Engine**: Unity 2021.3.11f1 (LTS) + URP 17.0.3
+**Platform**: PICO 4 VR (Android)
+
+## Completeness Overview
+
+| Domain | Pct | Details |
+|--------|-----|---------|
+| Source Code | 80% | 80 C# files, 6,817 LOC, 11 subsystems |
+| Documentation | 85% | 36 markdown docs covering architecture/API/deployment/security |
+| Testing | 25% | 5 test files, framework + integration only |
+| CI/CD | 70% | GitHub Actions (3-platform build matrix) |
+| Production Mgmt | 10% | No sprint plans or milestones |
+| Design Docs (GDD) | 0% | No Game Studios format GDDs yet |
+
+## Key Decisions (2026-03-30)
+
+1. **AI Model**: GLM series (ZhipuAI) — replaces GPT-4o entirely
+2. **Multiplayer**: Deferred — single-player VR experience first
+3. **Sprint Planning**: Managed within this project via /sprint-plan
+4. **Testing Strategy**: Full test suite after feature development
+5. **Design Docs**: Will reverse-document from existing code
+
+## Systems Inventory
+
+| System | Files | LOC | Maturity |
+|--------|-------|-----|----------|
+| Core (DI/Config/Error/Perf) | 24 | 7,248 | High |
+| AI (Guide/NPC/Dialogue/Services) | 15 | 6,285 | High |
+| Editor (Build/Analysis/Recording) | 11 | 4,477 | Medium |
+| VR (Interaction/Gesture/Perf) | 4 | 1,848 | Medium |
+| Tests | 5 | 1,741 | Low |
+| Demo | 5 | 1,612 | Medium |
+| Presentation/UI | 4 | 700 | Low |
+| Video | 4 | 693 | Medium |
+| Features (TourGuide/SceneGen) | 4 | 539 | Low |
+| Infrastructure (Cache/Network) | 3 | 240 | Low (interfaces) |
+
+## Priority Roadmap
+
+| Priority | Task | Status |
+|----------|------|--------|
+| P0 | GLM model integration (replace GPT-4o) | Pending |
+| P1 | Map systems + create systems index | Pending |
+| P2 | Sprint plan for GLM integration | Pending |
+| P3 | Test coverage for AI service layer | Pending |
+| P4 | Multiplayer VR sessions | Deferred |

--- a/production/sprints/sprint-1.md
+++ b/production/sprints/sprint-1.md
@@ -1,0 +1,67 @@
+# Sprint 1 — 2026-03-30 to 2026-04-13
+
+## Sprint Goal
+
+用 GLM 替换 Mock AI 服务，让 AI 导游和 NPC 能真实对话。
+
+## Capacity
+
+- Total days: 14 (2 weeks)
+- Buffer (20%): 3 days reserved for unplanned work
+- Available: 11 days
+
+## Tasks
+
+### Must Have (Critical Path)
+
+| ID | Task | Agent/Owner | Est. Days | Dependencies | Acceptance Criteria |
+|----|------|-------------|-----------|-------------|-------------------|
+| S1-01 | 创建 `GLMConfig` ScriptableObject | gameplay-programmer | 0.5 | — | 包含 apiKey, model, endpoint, temperature, maxTokens, fallback 开关 |
+| S1-02 | 实现 `GLMService.cs`（实现 `IGPTService`） | ai-programmer | 2 | S1-01 | SendChatAsync + SendStreamChatAsync + GenerateContentAsync 通过测试 |
+| S1-03 | 实现 SSE 流式解析 | ai-programmer | 1 | S1-02 | 逐 chunk 回调正确，`[DONE]` 后不再解析 |
+| S1-04 | 实现三级 Fallback（GLM → Ollama → Mock） | ai-programmer | 1 | S1-02 | GLM 断开后 5s 内自动切换 Ollama |
+| S1-05 | 修改 `AIServiceManager.InitializeLLMService()` | gameplay-programmer | 0.5 | S1-02 | Manager 启动后 `services[LLM]` 为 GLMService 实例 |
+| S1-06 | AI Tour Guide 适配 GLM | ai-programmer | 1 | S1-05 | 导游对话使用 GLM 返回真实回复，多轮上下文连贯 |
+| S1-07 | AI NPC System 适配 GLM | ai-programmer | 1 | S1-05 | NPC 对话流式输出，行为树正常触发 |
+
+### Should Have
+
+| ID | Task | Agent/Owner | Est. Days | Dependencies | Acceptance Criteria |
+|----|------|-------------|-----------|-------------|-------------------|
+| S1-08 | 速率限制 + 指数退避重试 | ai-programmer | 0.5 | S1-02 | 429 响应后退避重试，不超过 3 次 |
+| S1-09 | 对话历史上下文窗口截断 | ai-programmer | 0.5 | S1-02 | 超 maxConversationLength 时截断旧消息，保留 system prompt |
+| S1-10 | GLM 配置文档 + API Key 获取指南 | — | 0.5 | S1-01 | docs/GLM_SETUP.md 完成 |
+
+### Nice to Have
+
+| ID | Task | Agent/Owner | Est. Days | Dependencies | Acceptance Criteria |
+|----|------|-------------|-----------|-------------|-------------------|
+| S1-11 | GLM 健康检查 + 自动恢复 | ai-programmer | 0.5 | S1-04 | Degraded 状态定期探测，恢复后自动切回 GLM |
+| S1-12 | Token 用量统计日志 | ai-programmer | 0.5 | S1-02 | 每次请求记录 input/output token 数 |
+
+## Carryover from Previous Sprint
+
+N/A — First sprint.
+
+## Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| GLM API 响应延迟超标 (>2s 首 token) | Medium | High | 先用免费 Flash 模型测试延迟基线 |
+| 智谱 AI 平台注册/API Key 获取受阻 | Low | High | 备选：通过阿里云百炼调用 GLM |
+| SSE 流式解析在 Unity WebRequest 中兼容性 | Medium | Medium | 参考现有 OpenAI SSE 解析逻辑，已验证可行 |
+
+## Dependencies on External Factors
+
+- 智谱 AI 开放平台账号 + API Key
+- 网络环境可访问 `open.bigmodel.cn`
+
+## Definition of Done for this Sprint
+
+- [ ] All Must Have tasks (S1-01 ~ S1-07) completed
+- [ ] AI 导游在 Editor Play Mode 下产生真实 GLM 回复
+- [ ] NPC 流式对话正常工作
+- [ ] Fallback 到 Ollama/Mock 验证通过
+- [ ] 代码中无硬编码 API Key
+- [ ] GDD Acceptance Criteria 全部通过
+- [ ] design/gdd/glm-service-integration.md 状态更新为 Implemented

--- a/production/sprints/sprint-1.md
+++ b/production/sprints/sprint-1.md
@@ -2,7 +2,7 @@
 
 ## Sprint Goal
 
-用 GLM 替换 Mock AI 服务，让 AI 导游和 NPC 能真实对话。
+用火山方舟 Ark 替换 Mock AI 服务，让 AI 导游和 NPC 能真实对话。
 
 ## Capacity
 
@@ -16,13 +16,13 @@
 
 | ID | Task | Agent/Owner | Est. Days | Dependencies | Acceptance Criteria |
 |----|------|-------------|-----------|-------------|-------------------|
-| S1-01 | 创建 `GLMConfig` ScriptableObject | gameplay-programmer | 0.5 | — | 包含 apiKey, model, endpoint, temperature, maxTokens, fallback 开关 |
-| S1-02 | 实现 `GLMService.cs`（实现 `IGPTService`） | ai-programmer | 2 | S1-01 | SendChatAsync + SendStreamChatAsync + GenerateContentAsync 通过测试 |
+| S1-01 | 创建 `ArkConfig` ScriptableObject | gameplay-programmer | 0.5 | — | 包含 apiKey, model, endpoint, temperature, maxTokens, fallback 开关 |
+| S1-02 | 实现 `ArkService.cs`（实现 `IGPTService`） | ai-programmer | 2 | S1-01 | SendChatAsync + SendStreamChatAsync + GenerateContentAsync 通过测试 |
 | S1-03 | 实现 SSE 流式解析 | ai-programmer | 1 | S1-02 | 逐 chunk 回调正确，`[DONE]` 后不再解析 |
-| S1-04 | 实现三级 Fallback（GLM → Ollama → Mock） | ai-programmer | 1 | S1-02 | GLM 断开后 5s 内自动切换 Ollama |
-| S1-05 | 修改 `AIServiceManager.InitializeLLMService()` | gameplay-programmer | 0.5 | S1-02 | Manager 启动后 `services[LLM]` 为 GLMService 实例 |
-| S1-06 | AI Tour Guide 适配 GLM | ai-programmer | 1 | S1-05 | 导游对话使用 GLM 返回真实回复，多轮上下文连贯 |
-| S1-07 | AI NPC System 适配 GLM | ai-programmer | 1 | S1-05 | NPC 对话流式输出，行为树正常触发 |
+| S1-04 | 实现三级 Fallback（Ark → Ollama → Mock） | ai-programmer | 1 | S1-02 | Ark 断开后 5s 内自动切换 Ollama |
+| S1-05 | 修改 `AIServiceManager.InitializeLLMService()` | gameplay-programmer | 0.5 | S1-02 | Manager 启动后 `services[LLM]` 为 ArkService 实例 |
+| S1-06 | AI Tour Guide 适配 Ark | ai-programmer | 1 | S1-05 | 导游对话使用 Ark 返回真实回复，多轮上下文连贯 |
+| S1-07 | AI NPC System 适配 Ark | ai-programmer | 1 | S1-05 | NPC 对话流式输出，行为树正常触发 |
 
 ### Should Have
 
@@ -30,13 +30,13 @@
 |----|------|-------------|-----------|-------------|-------------------|
 | S1-08 | 速率限制 + 指数退避重试 | ai-programmer | 0.5 | S1-02 | 429 响应后退避重试，不超过 3 次 |
 | S1-09 | 对话历史上下文窗口截断 | ai-programmer | 0.5 | S1-02 | 超 maxConversationLength 时截断旧消息，保留 system prompt |
-| S1-10 | GLM 配置文档 + API Key 获取指南 | — | 0.5 | S1-01 | docs/GLM_SETUP.md 完成 |
+| S1-10 | Ark 配置文档 + API Key 获取指南 | — | 0.5 | S1-01 | docs/ARK_SETUP.md 完成 |
 
 ### Nice to Have
 
 | ID | Task | Agent/Owner | Est. Days | Dependencies | Acceptance Criteria |
 |----|------|-------------|-----------|-------------|-------------------|
-| S1-11 | GLM 健康检查 + 自动恢复 | ai-programmer | 0.5 | S1-04 | Degraded 状态定期探测，恢复后自动切回 GLM |
+| S1-11 | Ark 健康检查 + 自动恢复 | ai-programmer | 0.5 | S1-04 | Degraded 状态定期探测，恢复后自动切回 Ark |
 | S1-12 | Token 用量统计日志 | ai-programmer | 0.5 | S1-02 | 每次请求记录 input/output token 数 |
 
 ## Carryover from Previous Sprint
@@ -47,21 +47,21 @@ N/A — First sprint.
 
 | Risk | Probability | Impact | Mitigation |
 |------|------------|--------|------------|
-| GLM API 响应延迟超标 (>2s 首 token) | Medium | High | 先用免费 Flash 模型测试延迟基线 |
-| 智谱 AI 平台注册/API Key 获取受阻 | Low | High | 备选：通过阿里云百炼调用 GLM |
+| Ark API 响应延迟超标 (>2s 首 token) | Medium | High | 先用 CodingPlan 模型测试延迟基线 |
+| 火山方舟控制台/API Key 获取受阻 | Low | High | 备选：保留 Ollama/Mock fallback，不在客户端硬编码密钥 |
 | SSE 流式解析在 Unity WebRequest 中兼容性 | Medium | Medium | 参考现有 OpenAI SSE 解析逻辑，已验证可行 |
 
 ## Dependencies on External Factors
 
-- 智谱 AI 开放平台账号 + API Key
-- 网络环境可访问 `open.bigmodel.cn`
+- 火山方舟 Ark API Key，通过 `ARK_API_KEY` 注入
+- 网络环境可访问 `ark.cn-beijing.volces.com`
 
 ## Definition of Done for this Sprint
 
 - [ ] All Must Have tasks (S1-01 ~ S1-07) completed
-- [ ] AI 导游在 Editor Play Mode 下产生真实 GLM 回复
+- [ ] AI 导游在 Editor Play Mode 下产生真实 Ark 回复
 - [ ] NPC 流式对话正常工作
 - [ ] Fallback 到 Ollama/Mock 验证通过
 - [ ] 代码中无硬编码 API Key
 - [ ] GDD Acceptance Criteria 全部通过
-- [ ] design/gdd/glm-service-integration.md 状态更新为 Implemented
+- [ ] design/gdd/ark-service-integration.md 状态更新为 Implemented


### PR DESCRIPTION
## Summary
- Rename the TripMeta LLM integration design from GLM to Ark
- Update GDD, systems index, sprint plan, stage report, and Spatial Memory moderation docs to Ark/CodingPlan wording
- Remove old GLM/Zhipu/BigModel markers from tracked project docs

## Validation
- /Users/zhengmin/.codex/skills/volcengine-ark-migration/scripts/scan_project.sh .
- rg -n "GLM|glm|Zhipu|zhipu|智谱|BigModel|bigmodel|open\.bigmodel" -S --glob '!node_modules/**' --glob '!.git/**'
- git diff --check