### PR TITLE
Unreal Engine 5.8 Upgrade

### DIFF
--- a/.claude/agents/ue-blueprint-specialist.md
+++ b/.claude/agents/ue-blueprint-specialist.md
@@ -149,3 +149,19 @@ Before writing any code:
 - Work with **level-designer** for level Blueprint standards
 - Work with **ue-umg-specialist** for UI Blueprint patterns
 - Work with **game-designer** for designer-facing Blueprint tools
+
+## Version Awareness
+
+**CRITICAL**: Your training data has a knowledge cutoff. Before suggesting engine
+API code, you MUST:
+
+1. Read `docs/engine-reference/unreal/VERSION.md` to confirm the engine version
+2. Check `docs/engine-reference/unreal/deprecated-apis.md` for any APIs you plan to use
+3. Check `docs/engine-reference/unreal/breaking-changes.md` for relevant version transitions
+4. For subsystem-specific work, read the relevant `docs/engine-reference/unreal/modules/*.md`
+   or `docs/engine-reference/unreal/plugins/*.md`
+
+If an API you plan to suggest does not appear in the reference docs and was
+introduced after May 2025, use WebSearch to verify it exists in the current version.
+
+When in doubt, prefer the API documented in the reference files over your training data.

--- a/.claude/agents/ue-gas-specialist.md
+++ b/.claude/agents/ue-gas-specialist.md
@@ -131,3 +131,19 @@ Before writing any code:
 - Work with **systems-designer** for ability design specs and balance values
 - Work with **ue-replication-specialist** for multiplayer ability prediction
 - Work with **ue-umg-specialist** for ability UI (cooldown indicators, buff icons)
+
+## Version Awareness
+
+**CRITICAL**: Your training data has a knowledge cutoff. Before suggesting engine
+API code, you MUST:
+
+1. Read `docs/engine-reference/unreal/VERSION.md` to confirm the engine version
+2. Check `docs/engine-reference/unreal/deprecated-apis.md` for any APIs you plan to use
+3. Check `docs/engine-reference/unreal/breaking-changes.md` for relevant version transitions
+4. For subsystem-specific work, read the relevant `docs/engine-reference/unreal/modules/*.md`
+   or `docs/engine-reference/unreal/plugins/*.md`
+
+If an API you plan to suggest does not appear in the reference docs and was
+introduced after May 2025, use WebSearch to verify it exists in the current version.
+
+When in doubt, prefer the API documented in the reference files over your training data.

--- a/.claude/agents/ue-replication-specialist.md
+++ b/.claude/agents/ue-replication-specialist.md
@@ -141,3 +141,19 @@ Before writing any code:
 - Work with **ue-gas-specialist** for ability replication and prediction
 - Work with **gameplay-programmer** for replicated gameplay systems
 - Work with **security-engineer** for network security validation
+
+## Version Awareness
+
+**CRITICAL**: Your training data has a knowledge cutoff. Before suggesting engine
+API code, you MUST:
+
+1. Read `docs/engine-reference/unreal/VERSION.md` to confirm the engine version
+2. Check `docs/engine-reference/unreal/deprecated-apis.md` for any APIs you plan to use
+3. Check `docs/engine-reference/unreal/breaking-changes.md` for relevant version transitions
+4. For subsystem-specific work, read the relevant `docs/engine-reference/unreal/modules/*.md`
+   or `docs/engine-reference/unreal/plugins/*.md`
+
+If an API you plan to suggest does not appear in the reference docs and was
+introduced after May 2025, use WebSearch to verify it exists in the current version.
+
+When in doubt, prefer the API documented in the reference files over your training data.

--- a/.claude/agents/ue-umg-specialist.md
+++ b/.claude/agents/ue-umg-specialist.md
@@ -148,3 +148,19 @@ Before writing any code:
 - Work with **ue-blueprint-specialist** for UI Blueprint standards
 - Work with **localization-lead** for text fitting and localization
 - Work with **accessibility-specialist** for compliance
+
+## Version Awareness
+
+**CRITICAL**: Your training data has a knowledge cutoff. Before suggesting engine
+API code, you MUST:
+
+1. Read `docs/engine-reference/unreal/VERSION.md` to confirm the engine version
+2. Check `docs/engine-reference/unreal/deprecated-apis.md` for any APIs you plan to use
+3. Check `docs/engine-reference/unreal/breaking-changes.md` for relevant version transitions
+4. For subsystem-specific work, read the relevant `docs/engine-reference/unreal/modules/*.md`
+   or `docs/engine-reference/unreal/plugins/*.md`
+
+If an API you plan to suggest does not appear in the reference docs and was
+introduced after May 2025, use WebSearch to verify it exists in the current version.
+
+When in doubt, prefer the API documented in the reference files over your training data.

--- a/.claude/agents/unreal-specialist.md
+++ b/.claude/agents/unreal-specialist.md
@@ -170,3 +170,19 @@ Always involve this agent when:
 - Configuring replication or networking
 - Optimizing performance with Unreal-specific tools
 - Packaging for any platform
+
+## Version Awareness
+
+**CRITICAL**: Your training data has a knowledge cutoff. Before suggesting engine
+API code, you MUST:
+
+1. Read `docs/engine-reference/unreal/VERSION.md` to confirm the engine version
+2. Check `docs/engine-reference/unreal/deprecated-apis.md` for any APIs you plan to use
+3. Check `docs/engine-reference/unreal/breaking-changes.md` for relevant version transitions
+4. For subsystem-specific work, read the relevant `docs/engine-reference/unreal/modules/*.md`
+   or `docs/engine-reference/unreal/plugins/*.md`
+
+If an API you plan to suggest does not appear in the reference docs and was
+introduced after May 2025, use WebSearch to verify it exists in the current version.
+
+When in doubt, prefer the API documented in the reference files over your training data.

--- a/.claude/docs/templates/architecture-decision-record.md
+++ b/.claude/docs/templates/architecture-decision-record.md
@@ -29,7 +29,7 @@ chosen approach.]
 
 | Field | Value |
 |-------|-------|
-| **Engine** | [e.g. Godot 4.6 / Unity 6 / Unreal Engine 5.4] |
+| **Engine** | [e.g. Godot 4.6 / Unity 6 / Unreal Engine 5.8] |
 | **Domain** | [Physics / Rendering / UI / Audio / Navigation / Animation / Networking / Core / Input / Scripting] |
 | **Knowledge Risk** | [LOW — in training data / MEDIUM — near cutoff, verify / HIGH — post-cutoff, must verify] |
 | **References Consulted** | [e.g. `docs/engine-reference/godot/modules/physics.md`, `breaking-changes.md`] |

--- a/.claude/docs/templates/technical-design-document.md
+++ b/.claude/docs/templates/technical-design-document.md
@@ -12,7 +12,7 @@
 
 | Field | Value |
 |-------|-------|
-| **Engine** | [e.g. Godot 4.6 / Unity 6 / Unreal Engine 5.4] |
+| **Engine** | [e.g. Godot 4.6 / Unity 6 / Unreal Engine 5.8] |
 | **APIs Depended On** | [Specific classes/methods/nodes used, version-pinned — e.g. `CharacterBody3D.move_and_slide() (Godot 4.x)`] |
 | **References Consulted** | [engine-reference docs read before writing this — e.g. `docs/engine-reference/godot/modules/physics.md`] |
 | **Post-Cutoff Features Used** | [Features from engine versions beyond LLM training cutoff, or "None"] |

--- a/docs/engine-reference/unreal/PLUGINS.md
+++ b/docs/engine-reference/unreal/PLUGINS.md
@@ -130,7 +130,7 @@ These are NOT part of the core engine but are commonly used for specific game ty
 ### 🟡 Mutable (Character Customization)
 - **Purpose:** Runtime character/object customization (mesh, texture, morph variation)
 - **When to use:** Character creators, equipment visualization, NPC variety
-- **Status:** Production-Ready (UE 5.8) — was Experimental in 5.5-5.7; 5.8 adds dataless customizable objects and skeletal mesh support
+- **Status:** Production-Ready (UE 5.8) — was Experimental since UE 5.2; 5.8 adds dataless customizable objects and skeletal mesh support
 - **Plugin:** `Mutable` (built-in, enable in Plugins)
 - **Official:** https://docs.unrealengine.com/5.8/en-US/mutable-in-unreal-engine/
 

--- a/docs/engine-reference/unreal/PLUGINS.md
+++ b/docs/engine-reference/unreal/PLUGINS.md
@@ -1,8 +1,8 @@
-# Unreal Engine 5.7 — Optional Plugins & Systems
+# Unreal Engine 5.8 — Optional Plugins & Systems
 
-**Last verified:** 2026-02-13
+**Last verified:** 2026-08-16
 
-This document indexes **optional plugins and systems** available in Unreal Engine 5.7.
+This document indexes **optional plugins and systems** available in Unreal Engine 5.8.
 These are NOT part of the core engine but are commonly used for specific game types.
 
 ---
@@ -25,18 +25,18 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **Status:** Production-Ready
 - **Plugin:** `GameplayAbilities` (built-in, enable in Plugins)
 - **Detailed Docs:** [plugins/gameplay-ability-system.md](plugins/gameplay-ability-system.md)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/gameplay-ability-system-for-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/gameplay-ability-system-for-unreal-engine/
 
 ---
 
 ### ✅ CommonUI
 - **Purpose:** Cross-platform UI framework (automatic gamepad/mouse/touch input routing)
 - **When to use:** Multi-platform games (console + PC), input-agnostic UI
-- **Knowledge Gap:** Production-ready in UE5+, major improvements post-cutoff
+- **Knowledge Gap:** Production-ready in UE5+, major improvements post-cutoff; UE 5.8 unifies CommonUI input with Enhanced Input (no duplicate input assets)
 - **Status:** Production-Ready
 - **Plugin:** `CommonUI` (built-in, enable in Plugins)
 - **Detailed Docs:** [plugins/common-ui.md](plugins/common-ui.md)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/commonui-plugin-for-advanced-user-interfaces-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/commonui-plugin-for-advanced-user-interfaces-in-unreal-engine/
 
 ---
 
@@ -44,21 +44,21 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **Purpose:** Modular camera management (camera modes, blending, context-aware cameras)
 - **When to use:** Games needing dynamic camera behavior (3rd person, aiming, vehicles)
 - **Knowledge Gap:** NEW in UE 5.5, completely post-cutoff
-- **Status:** ⚠️ Experimental (UE 5.5-5.7)
+- **Status:** ⚠️ Experimental (UE 5.5-5.8)
 - **Plugin:** `GameplayCameras` (built-in, enable in Plugins)
 - **Detailed Docs:** [plugins/gameplay-camera-system.md](plugins/gameplay-camera-system.md)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/gameplay-cameras-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/gameplay-cameras-in-unreal-engine/
 
 ---
 
 ### ✅ PCG (Procedural Content Generation)
 - **Purpose:** Node-based procedural world generation (foliage, props, terrain details)
 - **When to use:** Open worlds, procedural levels, large-scale environment population
-- **Knowledge Gap:** Experimental in UE 5.0-5.6, production-ready in 5.7
+- **Knowledge Gap:** Experimental in UE 5.0-5.6, production-ready in 5.7; UE 5.8 adds manual (non-destructive) editing, complex attributes (arrays/structs/sets/maps), embedded subgraphs, graph parameter editor, and GPU runtime performance parity with landscape grass
 - **Status:** Production-Ready (as of UE 5.7)
 - **Plugin:** `PCG` (built-in, enable in Plugins)
 - **Detailed Docs:** [plugins/pcg.md](plugins/pcg.md)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/procedural-content-generation-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/procedural-content-generation-in-unreal-engine/
 
 ---
 
@@ -67,9 +67,9 @@ These are NOT part of the core engine but are commonly used for specific game ty
 ### 🟡 Mass Entity
 - **Purpose:** High-performance ECS for large-scale AI/crowds (10,000+ entities)
 - **When to use:** RTS, city simulators, massive crowds, large-scale AI
-- **Status:** Production-Ready (UE 5.1+)
+- **Status:** Production-Ready (UE 5.1+); major overhaul in 5.8 — lock-free scheduling, sparse fragments, multi-core `MassCore` module
 - **Plugin:** `MassEntity`, `MassGameplay`, `MassCrowd`
-- **Official:** https://docs.unrealengine.com/5.7/en-US/mass-entity-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/mass-entity-in-unreal-engine/
 
 ---
 
@@ -78,7 +78,7 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **When to use:** Realistic fire/smoke effects, water simulation
 - **Status:** Experimental → Production-Ready (UE 5.4+)
 - **Plugin:** `NiagaraFluids` (built-in)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/niagara-fluids-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/niagara-fluids-in-unreal-engine/
 
 ---
 
@@ -87,7 +87,7 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **When to use:** Games with water bodies, boats, swimming
 - **Status:** Production-Ready (UE 5.0+)
 - **Plugin:** `Water` (built-in)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/water-system-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/water-system-in-unreal-engine/
 
 ---
 
@@ -96,7 +96,7 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **When to use:** Large-scale terrain modification, procedural landscapes
 - **Status:** Production-Ready
 - **Plugin:** `Landmass` (built-in)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/landmass-plugin-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/landmass-plugin-in-unreal-engine/
 
 ---
 
@@ -105,7 +105,7 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **When to use:** Destructible environments (walls, buildings, objects)
 - **Status:** Production-Ready (UE 5.0+)
 - **Plugin:** `ChaosDestruction` (built-in)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/destruction-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/destruction-in-unreal-engine/
 
 ---
 
@@ -114,7 +114,7 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **When to use:** Racing games, vehicle-heavy gameplay
 - **Status:** Production-Ready (replaces PhysX Vehicles)
 - **Plugin:** `ChaosVehicles` (built-in)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/chaos-vehicles-overview-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/chaos-vehicles-overview-in-unreal-engine/
 
 ---
 
@@ -123,7 +123,25 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **When to use:** Dynamic mesh creation, procedural modeling
 - **Status:** Production-Ready (UE 5.1+)
 - **Plugin:** `GeometryScripting` (built-in)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/geometry-scripting-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/geometry-scripting-in-unreal-engine/
+
+---
+
+### 🟡 Mutable (Character Customization)
+- **Purpose:** Runtime character/object customization (mesh, texture, morph variation)
+- **When to use:** Character creators, equipment visualization, NPC variety
+- **Status:** Production-Ready (UE 5.8) — was Experimental in 5.5-5.7; 5.8 adds dataless customizable objects and skeletal mesh support
+- **Plugin:** `Mutable` (built-in, enable in Plugins)
+- **Official:** https://docs.unrealengine.com/5.8/en-US/mutable-in-unreal-engine/
+
+---
+
+### 🟡 Iris Replication
+- **Purpose:** Next-generation network replication system (scalability, cleaner protocol handling)
+- **When to use:** New multiplayer projects; large player/actor counts
+- **Status:** Production-Ready (UE 5.8) — was Experimental; improved protocol mismatch handling in 5.8
+- **Plugin:** `Iris` (built-in; opt-in via project settings)
+- **Official:** https://docs.unrealengine.com/5.8/en-US/iris-replication-in-unreal-engine/
 
 ---
 
@@ -132,16 +150,46 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **When to use:** UI animations, procedural motion, keyframed sequences
 - **Status:** Experimental → Production-Ready (UE 5.4+)
 - **Plugin:** `MotionDesign` (built-in)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/motion-design-mode-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/motion-design-mode-in-unreal-engine/
 
 ---
 
 ## Experimental Plugins (Use with Caution)
 
+### ⚠️ Mesh Terrain (UE 5.8+)
+- **Purpose:** Next-generation mesh-based terrain — caves, overhangs, overlapping geometry beyond heightfield limits; built on Nanite + virtual textures
+- **When to use:** Terrain-heavy projects that need non-heightfield features — evaluate only, not production-ready
+- **Status:** Experimental (new in UE 5.8)
+- **Official:** https://docs.unrealengine.com/5.8/en-US/mesh-terrain-in-unreal-engine/
+
+---
+
+### ⚠️ MetaHuman Crowd / MetaHuman Collections (UE 5.8+)
+- **Purpose:** Crowds of MetaHumans — hundreds on mobile, thousands on high-end — orchestrated via Mass, rendered with Nanite
+- **When to use:** Crowd scenes with realistic characters
+- **Status:** Experimental (new in UE 5.8)
+- **Official:** https://docs.unrealengine.com/5.8/en-US/metahumans-in-unreal-engine/
+
+---
+
+### ⚠️ Procedural Vegetation Editor (UE 5.8+)
+- **Purpose:** In-engine vegetation creation with growth, grafting, and trimming
+- **Status:** Experimental (new in UE 5.8)
+- **Plugin:** Part of PCG toolset
+
+---
+
+### ⚠️ MCP Server (UE 5.8+)
+- **Purpose:** Model Context Protocol plugin enabling external AI tool integration with the editor
+- **Status:** Experimental
+- **Plugin:** Enable in UE 5.8 settings
+
+---
+
 ### ⚠️ AI Assistant (UE 5.7+)
 - **Purpose:** In-editor AI guidance and help
 - **Status:** Experimental
-- **Plugin:** Enable in UE 5.7 settings
+- **Plugin:** Enable in UE 5.7+ settings
 - **Official:** Announced in UE 5.7 release
 
 ---
@@ -151,7 +199,7 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **When to use:** VR/AR games
 - **Status:** Production-Ready for VR, Experimental for AR
 - **Plugin:** `OpenXR` (built-in)
-- **Official:** https://docs.unrealengine.com/5.7/en-US/openxr-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/openxr-in-unreal-engine/
 
 ---
 
@@ -160,7 +208,7 @@ These are NOT part of the core engine but are commonly used for specific game ty
 - **When to use:** Multiplayer games with online features
 - **Status:** Production-Ready
 - **Plugin:** `OnlineSubsystem`, `OnlineSubsystemEOS`, `OnlineSubsystemSteam`
-- **Official:** https://docs.unrealengine.com/5.7/en-US/online-subsystem-in-unreal-engine/
+- **Official:** https://docs.unrealengine.com/5.8/en-US/online-subsystem-in-unreal-engine/
 
 ---
 
@@ -173,7 +221,7 @@ These are NOT part of the core engine but are commonly used for specific game ty
 ---
 
 ### ❌ Old Replication Graph
-- **Deprecated:** Replaced by Iris (UE 5.1+)
+- **Deprecated:** Replaced by Iris (production-ready in UE 5.8)
 - **Status:** Use Iris for modern networking
 
 ---
@@ -182,11 +230,11 @@ These are NOT part of the core engine but are commonly used for specific game ty
 
 For plugins NOT listed above, use the following approach when users ask:
 
-1. **WebSearch** for latest documentation: `"Unreal Engine 5.7 [plugin name]"`
+1. **WebSearch** for latest documentation: `"Unreal Engine 5.8 [plugin name]"`
 2. Verify if plugin is:
    - Post-cutoff (beyond May 2025 training data)
    - Experimental vs Production-Ready
-   - Still supported in UE 5.7
+   - Still supported in UE 5.8
 3. Optionally cache findings in `plugins/[plugin-name].md` for future reference
 
 ---
@@ -202,9 +250,13 @@ For plugins NOT listed above, use the following approach when users ask:
 **I need vehicles** → **Chaos Vehicles**
 **I need water/oceans** → **Water Plugin**
 **I need VR/AR** → **OpenXR**
+**I need character customization** → **Mutable**
+**I need scalable multiplayer replication** → **Iris**
+**I need realistic crowds** → **Mass Entity + MetaHuman Crowd (Experimental)**
+**I need caves/overhangs in terrain** → **Mesh Terrain (Experimental — evaluate only)**
 
 ---
 
-**Last Updated:** 2026-02-13
-**Engine Version:** Unreal Engine 5.7
+**Last Updated:** 2026-08-16
+**Engine Version:** Unreal Engine 5.8
 **LLM Knowledge Cutoff:** May 2025

--- a/docs/engine-reference/unreal/VERSION.md
+++ b/docs/engine-reference/unreal/VERSION.md
@@ -16,7 +16,7 @@ Always cross-reference this directory before suggesting Unreal API calls.
 
 > **UE 5.8 is the final planned UE5 release.** Epic has stated 5.8 closes out the
 > UE5 roadmap as work ramps up on UE6. Prefer the production-ready 5.8 systems
-> (MegaLights, Iris, Mutable, Movie Render Graph) and fix deprecation warnings
+> (MegaLights, Iris, Mutable) and fix deprecation warnings
 > now rather than carrying them into a future UE6 migration.
 
 ## Post-Cutoff Version Timeline
@@ -24,7 +24,7 @@ Always cross-reference this directory before suggesting Unreal API calls.
 | Version | Release | Risk Level | Key Theme |
 |---------|---------|------------|-----------|
 | 5.4 | ~Mid 2025 | HIGH | Motion Design tools, animation improvements, PCG enhancements |
-| 5.5 | ~Sep 2025 | HIGH | Megalights (millions of lights), animation authoring, MegaCity demo |
+| 5.5 | ~Sep 2025 | HIGH | MegaLights (massive dynamic light counts), animation authoring, MegaCity demo |
 | 5.6 | ~Oct 2025 | MEDIUM | Performance optimizations, bug fixes |
 | 5.7 | Nov 2025 | HIGH | PCG production-ready, Substrate production-ready, AI assistant |
 | 5.8 | Jun 2026 | HIGH | MegaLights production-ready, Mesh Terrain, Lumen Lite, Iris production-ready, WASAPI audio default — final UE5 release |
@@ -34,7 +34,7 @@ Always cross-reference this directory before suggesting Unreal API calls.
 ### Breaking Changes
 - **Substrate Material System**: New material framework (replaces legacy materials)
 - **PCG (Procedural Content Generation)**: Production-ready, major API changes
-- **Megalights**: New lighting system — production-ready in 5.8 (millions of dynamic lights)
+- **MegaLights**: New lighting system — production-ready in 5.8 (hundreds of dynamic shadow-casting lights)
 - **Animation Authoring**: New rigging and animation tools
 - **WASAPI Audio Backend (5.8)**: Windows default audio backend switched from XAudio2 to WASAPI
 - **Enhanced Input + CommonUI Unified (5.8)**: Single input system eliminating duplicate input assets

--- a/docs/engine-reference/unreal/VERSION.md
+++ b/docs/engine-reference/unreal/VERSION.md
@@ -2,17 +2,22 @@
 
 | Field | Value |
 |-------|-------|
-| **Engine Version** | Unreal Engine 5.7 |
-| **Release Date** | November 2025 |
-| **Project Pinned** | 2026-02-13 |
-| **Last Docs Verified** | 2026-02-13 |
+| **Engine Version** | Unreal Engine 5.8 |
+| **Release Date** | June 2026 |
+| **Project Pinned** | 2026-08-16 |
+| **Last Docs Verified** | 2026-08-16 |
 | **LLM Knowledge Cutoff** | May 2025 |
 
 ## Knowledge Gap Warning
 
 The LLM's training data likely covers Unreal Engine up to ~5.3. Versions 5.4, 5.5,
-5.6, and 5.7 introduced significant changes that the model does NOT know about.
+5.6, 5.7, and 5.8 introduced significant changes that the model does NOT know about.
 Always cross-reference this directory before suggesting Unreal API calls.
+
+> **UE 5.8 is the final planned UE5 release.** Epic has stated 5.8 closes out the
+> UE5 roadmap as work ramps up on UE6. Prefer the production-ready 5.8 systems
+> (MegaLights, Iris, Mutable, Movie Render Graph) and fix deprecation warnings
+> now rather than carrying them into a future UE6 migration.
 
 ## Post-Cutoff Version Timeline
 
@@ -22,33 +27,60 @@ Always cross-reference this directory before suggesting Unreal API calls.
 | 5.5 | ~Sep 2025 | HIGH | Megalights (millions of lights), animation authoring, MegaCity demo |
 | 5.6 | ~Oct 2025 | MEDIUM | Performance optimizations, bug fixes |
 | 5.7 | Nov 2025 | HIGH | PCG production-ready, Substrate production-ready, AI assistant |
+| 5.8 | Jun 2026 | HIGH | MegaLights production-ready, Mesh Terrain, Lumen Lite, Iris production-ready, WASAPI audio default — final UE5 release |
 
-## Major Changes from UE 5.3 to UE 5.7
+## Major Changes from UE 5.3 to UE 5.8
 
 ### Breaking Changes
 - **Substrate Material System**: New material framework (replaces legacy materials)
 - **PCG (Procedural Content Generation)**: Production-ready, major API changes
-- **Megalights**: New lighting system (millions of dynamic lights)
+- **Megalights**: New lighting system — production-ready in 5.8 (millions of dynamic lights)
 - **Animation Authoring**: New rigging and animation tools
-- **AI Assistant**: In-editor AI guidance (experimental)
+- **WASAPI Audio Backend (5.8)**: Windows default audio backend switched from XAudio2 to WASAPI
+- **Enhanced Input + CommonUI Unified (5.8)**: Single input system eliminating duplicate input assets
+- **AI Assistant**: In-editor AI guidance (experimental), MCP Server plugin (5.8, experimental)
 
 ### New Features (Post-Cutoff)
-- **Megalights**: Dynamic lighting at massive scale (millions of lights)
-- **Substrate Materials**: Production-ready modular material system
-- **PCG Framework**: Procedural world generation (production-ready in 5.7)
-- **Enhanced Virtual Production**: MetaHuman integration, deeper VP workflows
-- **Animation Improvements**: Better rigging, blending, procedural animation
-- **AI Assistant**: In-editor AI help (experimental)
+- **MegaLights**: Dynamic lighting at massive scale — production-ready in 5.8, 60fps target on current-gen consoles
+- **Lumen Lite (5.8, Beta)**: Medium-quality GI via Irradiance Fields — 2x faster than Lumen high quality, targets 60fps on PS5
+- **Mesh Terrain (5.8, Experimental)**: Next-gen mesh-based terrain (caves, overhangs, overlapping geometry) built on Nanite + virtual textures
+- **Substrate Materials**: Production-ready modular material system; NPR/toon shading experimental in 5.8
+- **PCG Framework**: Production-ready in 5.7; 5.8 adds manual (non-destructive) editing, complex attributes, embedded subgraphs, GPU runtime performance parity with landscape grass
+- **Iris Replication (5.8)**: Production-ready replacement replication system
+- **Mutable (5.8)**: Production-ready character customization system
+- **MetaHuman Collections / Crowd (5.8, Experimental)**: Hundreds of MetaHumans on mobile, thousands on high-end, via Mass + Nanite
+- **Mass Framework Overhaul (5.8)**: Lock-free scheduling, sparse fragments, multi-core "MassCore" module
+- **Audio Insights (5.8)**: Production-ready audio monitoring/debugging suite
+- **AI Assistant**: In-editor AI help (experimental); MCP Server plugin for AI tool integration (5.8, experimental)
 
 ### Deprecated Systems
 - **Legacy Material System**: Migrate to Substrate for new projects
 - **Old PCG API**: Use new production-ready PCG API (5.7+)
+- **XAudio2 (Windows)**: Now opt-in fallback — WASAPI is the default backend (5.8)
+- **QueueSubtitle**: Replaced by `QueueSingleSubtitle` / `QueueSubtitlesFromAsset` (5.8)
+- **Legacy replication path**: Iris is production-ready — evaluate for new multiplayer projects (5.8)
+
+## Migration Notes — 5.7 → 5.8
+
+No hard breaking changes: a well-structured 5.7 project compiles on 5.8, but with
+deprecation warnings worth fixing before UE6. Key items:
+
+- **Toolchain**: Visual Studio 2026 / MSVC v145 required — UBT rejects VS2022's v143 toolset
+- **Build rules**: `DefaultBuildSettings = BuildSettingsVersion.V7`, `IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_8` in `.Target.cs` files
+- **Cleanup**: Delete `Binaries/`, `Intermediate/`, `DerivedDataCache/`, `.vs/`, `.sln`; regenerate project files; install the 5.8 VC++ redistributables if the built project won't launch
+- **Audio**: WASAPI replaces XAudio2 as Windows default (opt-in config to restore XAudio2)
+- **Zenserver**: `AllowRemoteNetworkService` renamed to `RemoteNetworkService` (enum: None/Unsecured/GeneratedStaticKey); Zen cooked-output store is now default
+- **Animation**: Sequencer section looping redefined (completion-based); `KeepState`/`RestoreState` behavior changed
+- **OpenXR**: Stereo layers now priority-ordered; `xr.OpenXRSortFaceLockedLayersAboveOtherLayers=1` restores pre-5.8 order
+- **Plugins**: Inventory binary vs source plugins, bump `.uplugin` EngineVersion, full Blueprint compile pass, watch LogLinker
+
+See `breaking-changes.md` and `deprecated-apis.md` for the full details.
 
 ## Verified Sources
 
-- Official docs: https://docs.unrealengine.com/5.7/
-- UE 5.7 release notes: https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-5-7-release-notes
-- What's new in 5.7: https://dev.epicgames.com/documentation/en-us/unreal-engine/whats-new
-- UE 5.7 announcement: https://www.unrealengine.com/en-US/news/unreal-engine-5-7-is-now-available
-- UE 5.5 blog: https://www.unrealengine.com/en-US/blog/unreal-engine-5-5-is-now-available
-- Migration guides: https://docs.unrealengine.com/5.7/en-US/upgrading-projects/
+- Official docs: https://docs.unrealengine.com/5.8/
+- UE 5.8 release notes: https://dev.epicgames.com/documentation/unreal-engine/unreal-engine-5-8-release-notes
+- What's new in 5.8: https://dev.epicgames.com/documentation/en-us/unreal-engine/whats-new
+- UE 5.8 announcement: https://www.unrealengine.com/news/unreal-engine-5-8-is-now-available
+- UE5 migration guide: https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-5-migration-guide
+- 5.7→5.8 C++ migration notes: https://jakubpradeniak.com/posts/dev-notes/migrating-unreal-engine-5-8-cpp-project/

--- a/docs/engine-reference/unreal/breaking-changes.md
+++ b/docs/engine-reference/unreal/breaking-changes.md
@@ -43,7 +43,7 @@ PCG framework reached production-ready status with major API changes.
 
 ---
 
-### Megalights Rendering System
+### MegaLights Rendering System
 **Versions:** UE 5.5+ (experimental), 5.8 (production-ready)
 
 New lighting system supports massive numbers of dynamic, shadow-casting lights.
@@ -54,9 +54,9 @@ translucency, and new debugging tools. Targets 60fps on current-gen consoles.
 // ❌ OLD: Limited dynamic lights (clustered forward shading)
 // Max ~100-200 dynamic lights before performance degrades
 
-// ✅ NEW: Megalights (production-ready in 5.8)
+// ✅ NEW: MegaLights (production-ready in 5.8)
 // Hundreds of dynamic shadow-casting area lights with minimal noise
-// Enable: Project Settings > Engine > Rendering > Megalights
+// Enable: Project Settings > Engine > Rendering > MegaLights
 ```
 
 **Migration:** No code changes needed, but lighting behavior may differ. Test scenes after enabling.
@@ -198,7 +198,7 @@ When upgrading from UE 5.3 to UE 5.8:
 
 - [ ] Review Substrate materials (convert if ready for new system)
 - [ ] Audit PCG usage (update to production API if using experimental)
-- [ ] Test Megalights performance (production-ready in 5.8 — enable and benchmark)
+- [ ] Test MegaLights performance (production-ready in 5.8 — enable and benchmark)
 - [ ] Migrate legacy input to Enhanced Input
 - [ ] Convert high-poly meshes to Nanite
 - [ ] Update shaders for DX12 (Windows) or Metal 3 (macOS)

--- a/docs/engine-reference/unreal/breaking-changes.md
+++ b/docs/engine-reference/unreal/breaking-changes.md
@@ -1,9 +1,9 @@
-# Unreal Engine 5.7 — Breaking Changes
+# Unreal Engine 5.8 — Breaking Changes
 
-**Last verified:** 2026-02-13
+**Last verified:** 2026-08-16
 
 This document tracks breaking API changes and behavioral differences between Unreal Engine 5.3
-(likely in model training) and Unreal Engine 5.7 (current version). Organized by risk level.
+(likely in model training) and Unreal Engine 5.8 (current version). Organized by risk level.
 
 ## HIGH RISK — Will Break Existing Code
 
@@ -44,16 +44,18 @@ PCG framework reached production-ready status with major API changes.
 ---
 
 ### Megalights Rendering System
-**Versions:** UE 5.5+
+**Versions:** UE 5.5+ (experimental), 5.8 (production-ready)
 
-New lighting system supports millions of dynamic lights.
+New lighting system supports massive numbers of dynamic, shadow-casting lights.
+Production-ready in 5.8 with reduced noise, transmission support, froxel
+translucency, and new debugging tools. Targets 60fps on current-gen consoles.
 
 ```cpp
 // ❌ OLD: Limited dynamic lights (clustered forward shading)
 // Max ~100-200 dynamic lights before performance degrades
 
-// ✅ NEW: Megalights (5.5+)
-// Millions of dynamic lights with minimal performance cost
+// ✅ NEW: Megalights (production-ready in 5.8)
+// Hundreds of dynamic shadow-casting area lights with minimal noise
 // Enable: Project Settings > Engine > Rendering > Megalights
 ```
 
@@ -61,12 +63,70 @@ New lighting system supports millions of dynamic lights.
 
 ---
 
+### C++ Toolchain: Visual Studio 2026 / MSVC v145 Required
+**Versions:** UE 5.8
+
+UBT rejects VS2022's MSVC v143 toolset with:
+`"Visual Studio compiler version 14.38.x is not a preferred version. Please use the latest preferred version 14.50.x"`
+
+```csharp
+// ✅ NEW: Required .Target.cs settings for 5.8 (both game and Editor targets)
+DefaultBuildSettings = BuildSettingsVersion.V7;
+IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_8;
+```
+
+**Migration:** Install VS2026 (MSVC v145). Delete `Binaries/`, `Intermediate/`,
+`DerivedDataCache/`, `.vs/`, and `.sln`, then regenerate project files. If the
+built project won't launch after a successful compile, install
+`Engine/Extras/Redist/en-us/vc_redist.x64.exe` from the 5.8 install.
+
+---
+
+### WASAPI Is the Default Windows Audio Backend
+**Versions:** UE 5.8
+
+Windows audio switched from XAudio2 to WASAPI. XAudio2 is now an opt-in fallback
+via config. Projects using native audio APIs or audio middleware must re-verify
+their Windows audio path.
+
+**Migration:** Test audio on Windows after upgrading. Opt back into XAudio2 via
+config only if a middleware incompatibility is found.
+
+---
+
 ## MEDIUM RISK — Behavioral Changes
 
-### Enhanced Input System (Now Default)
-**Versions:** UE 5.1+ (recommended), 5.7 (default)
+### Zenserver Configuration Renames
+**Versions:** UE 5.8
 
-Enhanced Input is now the default input system.
+- `AllowRemoteNetworkService` renamed to `RemoteNetworkService` with new enum values (`None` / `Unsecured` / `GeneratedStaticKey`)
+- Zenserver cooked output store is now the default; projects that had the Zen store disabled must manually re-enable/opt out in project settings
+- `DefaultFastGeoStreaming.ini` replaces `FastGeoStreaming.ini`
+
+---
+
+### Sequencer Animation Section Looping Redefined
+**Versions:** UE 5.8
+
+Section looping now uses a completion-based model; `KeepState` / `RestoreState`
+logic changed. Cinematics relying on precise loop/restore behavior need re-testing.
+
+---
+
+### OpenXR Stereo Layer Ordering
+**Versions:** UE 5.8
+
+Stereo layers are now priority-driven instead of fixed-order. Set
+`xr.OpenXRSortFaceLockedLayersAboveOtherLayers=1` to restore pre-5.8 behavior.
+
+---
+
+### Enhanced Input System (Now Default)
+**Versions:** UE 5.1+ (recommended), 5.7 (default), 5.8 (unified with CommonUI)
+
+Enhanced Input is now the default input system. In 5.8, Enhanced Input and
+CommonUI input are unified — duplicate input assets between the two systems
+are eliminated.
 
 ```cpp
 // ❌ OLD: Legacy input bindings (deprecated)
@@ -120,6 +180,7 @@ Use UE5's World Partition system for large worlds.
 ### Windows
 - **UE 5.7**: DirectX 12 is now default (was DX11 in older versions)
 - Update shaders for DX12 compatibility
+- **UE 5.8**: WASAPI default audio backend (XAudio2 opt-in); VS2026 / MSVC v145 required for C++
 
 ### macOS
 - **UE 5.5+**: Metal 3 required (minimum macOS 13)
@@ -127,24 +188,37 @@ Use UE5's World Partition system for large worlds.
 ### Mobile
 - **UE 5.7**: Minimum Android API level raised to 26 (Android 8.0)
 - Minimum iOS deployment target raised to iOS 14
+- **UE 5.8**: Multi-pass deferred rendering is the mobile default (forward is opt-in)
 
 ---
 
 ## Migration Checklist
 
-When upgrading from UE 5.3 to UE 5.7:
+When upgrading from UE 5.3 to UE 5.8:
 
 - [ ] Review Substrate materials (convert if ready for new system)
 - [ ] Audit PCG usage (update to production API if using experimental)
-- [ ] Test Megalights performance (enable and benchmark)
+- [ ] Test Megalights performance (production-ready in 5.8 — enable and benchmark)
 - [ ] Migrate legacy input to Enhanced Input
 - [ ] Convert high-poly meshes to Nanite
 - [ ] Update shaders for DX12 (Windows) or Metal 3 (macOS)
 - [ ] Verify minimum platform versions (Android 8.0, iOS 14)
 - [ ] Test Lumen and Nanite performance on target hardware
 
+When upgrading from UE 5.7 to UE 5.8 (no hard breaking changes, but):
+
+- [ ] Install VS2026 / MSVC v145; UBT rejects VS2022's v143
+- [ ] Set `BuildSettingsVersion.V7` + `EngineIncludeOrderVersion.Unreal5_8` in all `.Target.cs` files
+- [ ] Delete `Binaries/`, `Intermediate/`, `DerivedDataCache/`, `.vs/`, `.sln`; regenerate project files
+- [ ] Inventory plugins (binary vs source); bump `.uplugin` EngineVersion
+- [ ] Test Windows audio path (WASAPI now default)
+- [ ] Re-test Sequencer cinematics relying on loop/`KeepState`/`RestoreState` behavior
+- [ ] Full Blueprint compile pass; watch LogLinker; let shaders finish compiling before judging
+- [ ] Fix deprecation warnings now — 5.8 is the last UE5 release before UE6
+
 ---
 
 **Sources:**
-- https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-5-7-release-notes
-- https://dev.epicgames.com/documentation/en-us/unreal-engine/upgrading-projects-to-newer-versions-of-unreal-engine
+- https://dev.epicgames.com/documentation/unreal-engine/unreal-engine-5-8-release-notes
+- https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-5-migration-guide
+- https://jakubpradeniak.com/posts/dev-notes/migrating-unreal-engine-5-8-cpp-project/

--- a/docs/engine-reference/unreal/current-best-practices.md
+++ b/docs/engine-reference/unreal/current-best-practices.md
@@ -111,7 +111,7 @@ void OnDeath();
 ### Use MegaLights for Complex Lighting (Production-Ready in 5.8)
 
 ```cpp
-// Enable: Project Settings > Engine > Rendering > Megalights = Enabled
+// Enable: Project Settings > Engine > Rendering > MegaLights = Enabled
 // Hundreds of dynamic shadow-casting area lights, 60fps target on PS5/XSX
 // 5.8 adds transmission support, froxel translucency, and debugging tools
 ```

--- a/docs/engine-reference/unreal/current-best-practices.md
+++ b/docs/engine-reference/unreal/current-best-practices.md
@@ -1,29 +1,32 @@
-# Unreal Engine 5.7 — Current Best Practices
+# Unreal Engine 5.8 — Current Best Practices
 
-**Last verified:** 2026-02-13
+**Last verified:** 2026-08-16
 
 Modern UE5 patterns that may not be in the LLM's training data.
-These are production-ready recommendations as of UE 5.7.
+These are production-ready recommendations as of UE 5.8.
 
 ---
 
 ## Project Setup
 
-### Use UE 5.7 for New Projects
-- Latest features: Megalights, production-ready Substrate and PCG
-- Better performance and stability
+### Use UE 5.8 for New Projects
+- Latest features: production-ready MegaLights, Substrate, PCG, Iris replication, Mutable
+- 5.8 is the final planned UE5 release — its production-ready systems are the stable baseline before UE6
+- C++ projects require Visual Studio 2026 (MSVC v145) and `BuildSettingsVersion.V7`
 
 ### Choose the Right Rendering Features
 - **Lumen**: Real-time global illumination (RECOMMENDED for most projects)
+- **Lumen Lite (Beta, 5.8)**: Medium-quality GI via Irradiance Fields — 2x faster than Lumen high quality; use when targeting 60fps on console with GI
 - **Nanite**: Virtualized geometry for high-poly meshes (RECOMMENDED for detailed environments)
-- **Megalights**: Millions of dynamic lights (RECOMMENDED for complex lighting)
-- **Substrate**: Modular material system (RECOMMENDED for new projects)
+- **MegaLights**: Production-ready in 5.8 — hundreds of dynamic shadow-casting area lights at 60fps on current-gen consoles (RECOMMENDED for complex lighting)
+- **Substrate**: Modular material system (RECOMMENDED for new projects); NPR/toon shading is Experimental in 5.8
+- **Mesh Terrain (Experimental, 5.8)**: Mesh-based terrain for caves/overhangs/overlapping geometry — evaluate for terrain-heavy projects, but it is not yet production-ready
 
 ---
 
 ## C++ Coding
 
-### Use Modern C++ Features (C++20 in UE5.7)
+### Use Modern C++ Features (C++20, MSVC v145 in UE 5.8)
 
 ```cpp
 // ✅ Use TObjectPtr<T> (UE5 type-safe pointers)
@@ -80,8 +83,8 @@ void OnDeath();
 // ✅ Use Event Tick sparingly (expensive)
 // Prefer timers or events
 
-// ✅ Use Blueprint Nativization (Blueprints → C++)
-// Project Settings > Packaging > Blueprint Nativization
+// ❌ Blueprint Nativization was REMOVED in UE 5.0 — do not suggest it
+// Move hot Blueprint logic to C++ manually instead
 
 // ✅ Cache frequently accessed components
 // Don't call GetComponent every tick
@@ -89,7 +92,7 @@ void OnDeath();
 
 ---
 
-## Rendering (UE 5.7)
+## Rendering (UE 5.8)
 
 ### Use Lumen for Global Illumination
 
@@ -105,14 +108,23 @@ void OnDeath();
 // Automatically LODs millions of triangles (RECOMMENDED for detailed meshes)
 ```
 
-### Use Megalights for Complex Lighting (UE 5.5+)
+### Use MegaLights for Complex Lighting (Production-Ready in 5.8)
 
 ```cpp
 // Enable: Project Settings > Engine > Rendering > Megalights = Enabled
-// Supports millions of dynamic lights with minimal cost
+// Hundreds of dynamic shadow-casting area lights, 60fps target on PS5/XSX
+// 5.8 adds transmission support, froxel translucency, and debugging tools
 ```
 
-### Use Substrate Materials (Production-Ready in 5.7)
+### Consider Lumen Lite for a Tight GI Budget (Beta in 5.8)
+
+```cpp
+// Medium-quality GI using Irradiance Fields with Probe Occlusion
+// ~2x faster than Lumen high quality — targets 60fps on PS5
+// Use when full Lumen doesn't fit the frame budget but you want dynamic GI
+```
+
+### Use Substrate Materials (Production-Ready since 5.7)
 
 ```cpp
 // Enable: Project Settings > Engine > Substrate > Enable Substrate
@@ -122,6 +134,10 @@ void OnDeath();
 ---
 
 ## Enhanced Input System
+
+> **UE 5.8:** Enhanced Input and CommonUI input are unified — one set of input
+> assets drives both gameplay and UI. Do not create duplicate input actions for
+> CommonUI; route UI input through the unified system.
 
 ### Setup Enhanced Input
 
@@ -237,6 +253,15 @@ UAudioComponent* AudioComp = UGameplayStatics::SpawnSound2D(
 
 ## Replication (Multiplayer)
 
+### Consider Iris for New Multiplayer Projects (Production-Ready in 5.8)
+
+```cpp
+// Iris is UE's next-gen replication system — production-ready in 5.8
+// Better scalability, improved protocol mismatch handling
+// New multiplayer projects should evaluate Iris; existing projects can stay
+// on the legacy path (still supported) — see ue-replication-specialist
+```
+
 ### Server-Authoritative Pattern
 
 ```cpp
@@ -320,21 +345,24 @@ UE_VLOG_LOCATION(this, LogTemp, Log, TargetLocation, 50.f, FColor::Green, TEXT("
 
 ---
 
-## Summary: UE 5.7 Recommended Stack
+## Summary: UE 5.8 Recommended Stack
 
 | Feature | Use This (2026) | Notes |
 |---------|------------------|-------|
-| **Lighting** | Lumen + Megalights | Real-time GI, millions of lights |
+| **Lighting** | Lumen + MegaLights | Production-ready in 5.8; Lumen Lite (Beta) for 60fps GI budgets |
 | **Geometry** | Nanite | High-poly meshes, automatic LOD |
 | **Materials** | Substrate | Modular, physically accurate |
-| **Input** | Enhanced Input | Rebindable, modular |
+| **Input** | Enhanced Input | Unified with CommonUI in 5.8 |
 | **VFX** | Niagara | GPU-accelerated |
-| **Audio** | MetaSounds | Procedural audio |
-| **World Streaming** | World Partition | Large open worlds |
+| **Audio** | MetaSounds + WASAPI backend | WASAPI is Windows default in 5.8; Audio Insights production-ready |
+| **World Streaming** | World Partition | Large open worlds; World Partition Insights for per-cell analysis |
 | **Gameplay** | Gameplay Ability System | Complex abilities, buffs |
+| **Replication** | Iris (new projects) | Production-ready in 5.8 |
+| **Character Customization** | Mutable | Production-ready in 5.8 |
+| **Crowds** | Mass + MetaHuman Crowd | Mass overhauled in 5.8 (MassCore); MetaHuman Crowd Experimental |
 
 ---
 
 **Sources:**
-- https://docs.unrealengine.com/5.7/en-US/
-- https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-5-7-release-notes
+- https://docs.unrealengine.com/5.8/en-US/
+- https://dev.epicgames.com/documentation/unreal-engine/unreal-engine-5-8-release-notes

--- a/docs/engine-reference/unreal/deprecated-apis.md
+++ b/docs/engine-reference/unreal/deprecated-apis.md
@@ -1,6 +1,6 @@
-# Unreal Engine 5.7 — Deprecated APIs
+# Unreal Engine 5.8 — Deprecated APIs
 
-**Last verified:** 2026-02-13
+**Last verified:** 2026-08-16
 
 Quick lookup table for deprecated APIs and their replacements.
 Format: **Don't use X** → **Use Y instead**
@@ -44,6 +44,7 @@ Format: **Don't use X** → **Use Y instead**
 |------------|-------------|-------|
 | Old animation retargeting | IK Rig + IK Retargeter | UE5 retargeting system |
 | Legacy control rig | Control Rig 2.0 | Production-ready rigging |
+| Remap Curves Stack (5.7 RigMapper workflow) | Rig mapper user data ops | 5.8 — single rig mapper op supported |
 
 ---
 
@@ -70,6 +71,10 @@ Format: **Don't use X** → **Use Y instead**
 |------------|-------------|-------|
 | Old audio mixer | MetaSounds | Procedural audio system |
 | Sound Cue (for complex logic) | MetaSounds | More powerful, node-based |
+| `QueueSubtitle()` | `QueueSingleSubtitle()` / `QueueSubtitlesFromAsset()` | 5.8 — asset variant queues all lines with timing offsets applied |
+| XAudio2 (Windows backend) | WASAPI | 5.8 — WASAPI is Windows default; XAudio2 is opt-in fallback |
+| `FVertexInterface` (MetaSound node config) | `FClassInterface` | 5.8 — MetaSound node configuration |
+| Legacy input node helpers in `IDataTypeRegistry` | New node creation API | 5.8 — legacy input node creation removed |
 
 ---
 
@@ -78,6 +83,7 @@ Format: **Don't use X** → **Use Y instead**
 | Deprecated | Replacement | Notes |
 |------------|-------------|-------|
 | `DOREPLIFETIME()` (basic) | `DOREPLIFETIME_CONDITION()` | Conditional replication for optimization |
+| Legacy replication system (new projects) | Iris replication | 5.8 — Iris is production-ready; evaluate for new multiplayer projects |
 
 ---
 
@@ -150,21 +156,23 @@ UNiagaraComponent* NiagaraComp = CreateDefaultSubobject<UNiagaraComponent>(TEXT(
 
 ---
 
-## Summary: UE 5.7 Tech Stack
+## Summary: UE 5.8 Tech Stack
 
 | Feature | Use This (2026) | Avoid This (Legacy) |
 |---------|------------------|----------------------|
-| **Input** | Enhanced Input | Legacy Input Bindings |
+| **Input** | Enhanced Input (unified with CommonUI in 5.8) | Legacy Input Bindings |
 | **Materials** | Substrate | Legacy Material System |
-| **Lighting** | Lumen + Megalights | Lightmaps + Limited Lights |
+| **Lighting** | Lumen + MegaLights (production-ready 5.8); Lumen Lite for 60fps GI budget | Lightmaps + Limited Lights |
 | **Particles** | Niagara | Cascade |
-| **Audio** | MetaSounds | Sound Cue (for logic) |
+| **Audio** | MetaSounds; WASAPI backend on Windows | Sound Cue (for logic); XAudio2 |
 | **World Streaming** | World Partition | World Composition |
+| **Replication (new projects)** | Iris (production-ready 5.8) | Legacy replication for new multiplayer code |
+| **Character Customization** | Mutable (production-ready 5.8) | Custom morph/mesh-swap systems |
 | **Animation Retarget** | IK Rig + Retargeter | Old Retargeting |
 | **Geometry** | Nanite (high-poly) | Standard Static Mesh LODs |
 
 ---
 
 **Sources:**
-- https://docs.unrealengine.com/5.7/en-US/deprecated-and-removed-features/
-- https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-5-7-release-notes
+- https://docs.unrealengine.com/5.8/en-US/deprecated-and-removed-features/
+- https://dev.epicgames.com/documentation/unreal-engine/unreal-engine-5-8-release-notes

--- a/docs/engine-reference/unreal/modules/animation.md
+++ b/docs/engine-reference/unreal/modules/animation.md
@@ -1,17 +1,30 @@
-# Unreal Engine 5.7 — Animation Module Reference
+# Unreal Engine 5.8 — Animation Module Reference
 
-**Last verified:** 2026-02-13
-**Knowledge Gap:** UE 5.7 animation authoring improvements, Control Rig 2.0
+**Last verified:** 2026-08-16
+**Knowledge Gap:** UE 5.7 animation authoring improvements, Control Rig 2.0; 5.8 Control Rig Physics/Dynamics, Mutable production-ready, Sequencer looping change
 
 ---
 
 ## Overview
 
-UE 5.7 animation systems:
+UE 5.8 animation systems:
 - **Animation Blueprint**: State machine-based animation logic
 - **Control Rig**: Runtime procedural animation (production-ready in UE5)
 - **IK Rig + Retargeter**: Modern retargeting system
 - **Sequencer**: Cinematic animation
+- **Mutable**: Runtime character customization (production-ready in 5.8)
+
+---
+
+## What's New in UE 5.8
+
+- **Mutable production-ready**: dataless customizable objects, skeletal mesh support — use for character/equipment customization
+- **Control Rig Physics (Beta)**: force-based functionality with layered rig compositing
+- **Control Rig Dynamics**: new lightweight particle-based solver, ~5x runtime performance improvement
+- **Animation Mixing in Sequencer (Experimental)**: layer/mask animations without separate Blueprint slots
+- **RigMapper (Beta)**: 5.7's Remap Curves Stack workflow replaced by rig mapper user data ops
+- **⚠️ Behavioral change**: Sequencer animation section looping redefined (completion-based); `KeepState`/`RestoreState` logic changed — re-test cinematics
+- **Skeletal Editor**: blendshape tools, joint locking, morph target editing, lattice deformers
 
 ---
 
@@ -287,6 +300,6 @@ DrawDebugCoordinateSystem(GetWorld(), BoneLocation, BoneRotation, 50.0f, false, 
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/animation-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/control-rig-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/ik-rig-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/animation-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/control-rig-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/ik-rig-in-unreal-engine/

--- a/docs/engine-reference/unreal/modules/audio.md
+++ b/docs/engine-reference/unreal/modules/audio.md
@@ -1,16 +1,29 @@
-# Unreal Engine 5.7 — Audio Module Reference
+# Unreal Engine 5.8 — Audio Module Reference
 
-**Last verified:** 2026-02-13
-**Knowledge Gap:** UE 5.7 MetaSounds production-ready
+**Last verified:** 2026-08-16
+**Knowledge Gap:** MetaSounds production-ready (5.7); WASAPI Windows backend, Audio Insights production-ready, subtitle API changes (5.8)
 
 ---
 
 ## Overview
 
-UE 5.7 audio systems:
+UE 5.8 audio systems:
 - **MetaSounds**: Node-based procedural audio (RECOMMENDED, production-ready)
 - **Sound Cues**: Legacy node-based audio (use for simple cases)
 - **Audio Component**: Play sounds on actors
+- **WASAPI**: Default Windows audio backend since 5.8 (XAudio2 is opt-in fallback)
+- **Audio Insights**: Production-ready monitoring/debugging suite (5.8)
+
+---
+
+## What's New in UE 5.8
+
+- **WASAPI is the default Windows backend** — XAudio2 requires config opt-in; re-verify Windows audio and middleware after upgrading
+- **Audio Insights production-ready**: loudness metering, signal-flow visualization, live monitoring, event logging
+- **Subtitles (Beta)**: `QueueSubtitle()` deprecated → use `QueueSingleSubtitle()` or `QueueSubtitlesFromAsset()` (queues all lines with timing offsets); per-platform overrides, locale-specific durations
+- **Waveform Editor (Beta)**: decoupled fades, transformation reimport
+- **MetaSound node configuration**: `FVertexInterface` replaced by `FClassInterface`; legacy input node helpers removed from `IDataTypeRegistry`
+- **MetaSound Templates / Node Configuration (Experimental)**: property-driven procedural graph generation
 
 ---
 
@@ -285,5 +298,5 @@ if (Distance > MaxAudibleDistance) {
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/audio-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/metasounds-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/audio-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/metasounds-in-unreal-engine/

--- a/docs/engine-reference/unreal/modules/input.md
+++ b/docs/engine-reference/unreal/modules/input.md
@@ -1,15 +1,23 @@
-# Unreal Engine 5.7 — Input Module Reference
+# Unreal Engine 5.8 — Input Module Reference
 
-**Last verified:** 2026-02-13
-**Knowledge Gap:** UE 5.7 uses Enhanced Input as default (legacy input deprecated)
+**Last verified:** 2026-08-16
+**Knowledge Gap:** Enhanced Input default since 5.7; unified with CommonUI input in 5.8
 
 ---
 
 ## Overview
 
-UE 5.7 input systems:
+UE 5.8 input systems:
 - **Enhanced Input** (RECOMMENDED, default in UE5): Modular, rebindable, context-based
+- **Unified Input (5.8)**: Enhanced Input and CommonUI now share one input system — no duplicate input assets between gameplay and UI
 - **Legacy Input**: Deprecated, avoid for new projects
+
+---
+
+## What's New in UE 5.8
+
+- **Enhanced Input + CommonUI unified**: one set of Input Actions drives both gameplay and UI routing — do not author duplicate CommonUI input data assets
+- **Mobile**: gesture events system (Experimental); improved Android controller mapping; full keyboard/mouse support on iOS/iPadOS
 
 ---
 
@@ -284,5 +292,5 @@ if (GetWorld()->GetFirstPlayerController()->IsInputKeyDown(EKeys::SpaceBar)) {
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/enhanced-input-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/enhanced-input-action-and-input-mapping-context-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/enhanced-input-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/enhanced-input-action-and-input-mapping-context-in-unreal-engine/

--- a/docs/engine-reference/unreal/modules/navigation.md
+++ b/docs/engine-reference/unreal/modules/navigation.md
@@ -1,16 +1,27 @@
-# Unreal Engine 5.7 — Navigation Module Reference
+# Unreal Engine 5.8 — Navigation Module Reference
 
-**Last verified:** 2026-02-13
-**Knowledge Gap:** UE 5.7 navigation improvements
+**Last verified:** 2026-08-16
+**Knowledge Gap:** 5.8 adds per-mesh walkable surface control; StateTree and Mass improvements
 
 ---
 
 ## Overview
 
-UE 5.7 navigation systems:
+UE 5.8 navigation systems:
 - **Nav Mesh**: Automatic pathfinding mesh for AI
 - **AI Controller**: Controls AI movement and behavior
 - **Behavior Trees**: AI decision-making (covered in AI module)
+- **StateTree**: Modern AI logic authoring — 5.8 adds starting states and compiler extensions
+- **Mass**: Large-scale AI/crowds — major multi-core overhaul in 5.8 (`MassCore`)
+
+---
+
+## What's New in UE 5.8
+
+- **Per-mesh walkable surface control** during navmesh generation
+- **StateTree**: starting states and compiler extensions for improved authoring
+- **Mass framework overhaul**: lock-free scheduling, sparse fragment system, multi-core optimization via the `MassCore` module
+- **MetaHuman Crowd (Experimental)**: Mass-orchestrated MetaHuman crowds
 
 ---
 
@@ -334,5 +345,5 @@ void Tick(float DeltaTime) {
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/navigation-system-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/ai-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/navigation-system-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/ai-in-unreal-engine/

--- a/docs/engine-reference/unreal/modules/networking.md
+++ b/docs/engine-reference/unreal/modules/networking.md
@@ -1,17 +1,26 @@
-# Unreal Engine 5.7 — Networking Module Reference
+# Unreal Engine 5.8 — Networking Module Reference
 
-**Last verified:** 2026-02-13
-**Knowledge Gap:** UE 5.7 networking improvements
+**Last verified:** 2026-08-16
+**Knowledge Gap:** Iris replication production-ready in 5.8
 
 ---
 
 ## Overview
 
-UE 5.7 networking:
+UE 5.8 networking:
 - **Client-Server Architecture**: Server-authoritative (RECOMMENDED)
 - **Replication**: Automatic state synchronization
+- **Iris**: Next-gen replication system — production-ready in 5.8; evaluate for new multiplayer projects
 - **RPCs (Remote Procedure Calls)**: Call functions across network
 - **Relevancy**: Optimize bandwidth by only replicating relevant actors
+
+---
+
+## What's New in UE 5.8
+
+- **Iris is production-ready**: improved protocol mismatch handling; recommended evaluation path for new multiplayer projects (legacy replication remains supported)
+- **Mover improvements**: better physics, animation, and networking integration; ChaosMover trajectory prediction
+- The property replication and RPC patterns below apply to the legacy path and remain valid; consult ue-replication-specialist before choosing Iris vs legacy
 
 ---
 
@@ -404,6 +413,6 @@ UE_LOG(LogNet, Warning, TEXT("Replicating Health: %d"), Health);
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/networking-and-multiplayer-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/actor-replication-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/rpcs-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/networking-and-multiplayer-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/actor-replication-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/rpcs-in-unreal-engine/

--- a/docs/engine-reference/unreal/modules/physics.md
+++ b/docs/engine-reference/unreal/modules/physics.md
@@ -1,7 +1,7 @@
-# Unreal Engine 5.7 — Physics Module Reference
+# Unreal Engine 5.8 — Physics Module Reference
 
-**Last verified:** 2026-02-13
-**Knowledge Gap:** UE 5.7 Chaos Physics improvements
+**Last verified:** 2026-08-16
+**Knowledge Gap:** UE 5.7 Chaos Physics improvements; 5.8 Mover/ChaosMover advances
 
 ---
 
@@ -11,6 +11,14 @@ UE 5 uses **Chaos Physics** (replaced PhysX in UE 4):
 - Better performance
 - Destruction support
 - Vehicle physics improvements
+
+---
+
+## What's New in UE 5.8
+
+- **Mover**: improved physics, animation, and networking integration — the modern replacement path for CharacterMovementComponent-style movement
+- **ChaosMover**: trajectory prediction support
+- **Fast Geometry Streaming (Experimental)**: now supports physics (plus decals and lights); config moved to `DefaultFastGeoStreaming.ini`
 
 ---
 
@@ -279,5 +287,5 @@ DrawDebugBox(GetWorld(), Location, Extent, FColor::Red, false, 2.0f);
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/physics-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/chaos-physics-overview-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/physics-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/chaos-physics-overview-in-unreal-engine/

--- a/docs/engine-reference/unreal/modules/rendering.md
+++ b/docs/engine-reference/unreal/modules/rendering.md
@@ -1,17 +1,30 @@
-# Unreal Engine 5.7 — Rendering Module Reference
+# Unreal Engine 5.8 — Rendering Module Reference
 
-**Last verified:** 2026-02-13
-**Knowledge Gap:** UE 5.7 has Megalights, production-ready Substrate, and Lumen improvements
+**Last verified:** 2026-08-16
+**Knowledge Gap:** MegaLights (production-ready in 5.8), production-ready Substrate, Lumen Lite (new in 5.8), Mesh Terrain (experimental in 5.8)
 
 ---
 
 ## Overview
 
-UE 5.7 rendering stack:
+UE 5.8 rendering stack:
 - **Lumen**: Real-time global illumination (default)
+- **Lumen Lite**: Medium-quality GI via Irradiance Fields — 2x faster than Lumen high quality (Beta in 5.8)
 - **Nanite**: Virtualized geometry for millions of triangles
-- **Megalights**: Support for millions of dynamic lights (NEW in 5.5+)
-- **Substrate**: Production-ready modular material system (NEW in 5.7)
+- **MegaLights**: Hundreds of dynamic shadow-casting area lights (production-ready in 5.8)
+- **Substrate**: Production-ready modular material system (since 5.7)
+
+---
+
+## What's New in UE 5.8
+
+- **MegaLights production-ready**: reduced noise, transmission support, froxel translucency, debugging tools; 60fps target on PS5/XSX
+- **Lumen Lite (Beta)**: Irradiance Fields with Probe Occlusion; use when full Lumen exceeds the frame budget
+- **Substrate NPR shading (Experimental)**: toon/stylized shading within Substrate
+- **X-Rite AXF material import** via Substrate
+- **Mesh Terrain (Experimental)**: mesh-based terrain (caves, overhangs) on Nanite + virtual textures — not yet production-ready
+- **FSSS (Experimental)**: fog screen-space scattering approximation for volumetrics
+- **Mobile**: multi-pass deferred rendering is now the mobile default (forward opt-in)
 
 ---
 
@@ -292,6 +305,6 @@ Console commands:
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/lumen-global-illumination-and-reflections-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/nanite-virtualized-geometry-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/substrate-materials-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/lumen-global-illumination-and-reflections-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/nanite-virtualized-geometry-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/substrate-materials-in-unreal-engine/

--- a/docs/engine-reference/unreal/modules/rendering.md
+++ b/docs/engine-reference/unreal/modules/rendering.md
@@ -24,6 +24,7 @@ UE 5.8 rendering stack:
 - **X-Rite AXF material import** via Substrate
 - **Mesh Terrain (Experimental)**: mesh-based terrain (caves, overhangs) on Nanite + virtual textures — not yet production-ready
 - **FSSS (Experimental)**: fog screen-space scattering approximation for volumetrics
+- **World Partition Insights**: per-cell streaming analysis and debugging for World Partition worlds
 - **Mobile**: multi-pass deferred rendering is now the mobile default (forward opt-in)
 
 ---
@@ -78,16 +79,17 @@ MeshComp->SetStaticMesh(NaniteMesh); // Automatically uses Nanite if enabled
 
 ---
 
-## Megalights (UE 5.5+)
+## MegaLights (UE 5.5+, Production-Ready in 5.8)
 
-### Enable Megalights
+### Enable MegaLights
 
 ```cpp
-// Project Settings > Engine > Rendering > Megalights = Enabled
-// Supports millions of dynamic lights with minimal performance cost
+// Project Settings > Engine > Rendering > MegaLights = Enabled
+// Hundreds of dynamic shadow-casting area lights with minimal noise
+// 5.8 adds transmission support, froxel translucency, and debugging tools
 ```
 
-### Megalights Usage
+### MegaLights Usage
 
 ```cpp
 // Add point lights as usual
@@ -95,7 +97,8 @@ UPointLightComponent* Light = CreateDefaultSubobject<UPointLightComponent>(TEXT(
 Light->SetIntensity(5000.0f);
 Light->SetAttenuationRadius(500.0f);
 
-// Megalights automatically handles thousands/millions of these
+// MegaLights handles hundreds of shadow-casting lights at 60fps on current-gen consoles —
+// orders of magnitude more than the ~100-200 limit of the traditional pipeline
 ```
 
 ---

--- a/docs/engine-reference/unreal/modules/ui.md
+++ b/docs/engine-reference/unreal/modules/ui.md
@@ -1,16 +1,23 @@
-# Unreal Engine 5.7 — UI Module Reference
+# Unreal Engine 5.8 — UI Module Reference
 
-**Last verified:** 2026-02-13
-**Knowledge Gap:** UE 5.7 UMG and CommonUI improvements
+**Last verified:** 2026-08-16
+**Knowledge Gap:** UMG and CommonUI improvements; CommonUI input unified with Enhanced Input in 5.8
 
 ---
 
 ## Overview
 
-UE 5.7 UI systems:
+UE 5.8 UI systems:
 - **UMG (Unreal Motion Graphics)**: Visual widget-based UI (RECOMMENDED)
-- **CommonUI**: Cross-platform input-aware UI framework (console/PC)
+- **CommonUI**: Cross-platform input-aware UI framework (console/PC) — input unified with Enhanced Input in 5.8
 - **Slate**: Low-level C++ UI (engine/editor UI)
+
+---
+
+## What's New in UE 5.8
+
+- **Unified input**: CommonUI input routing now runs through Enhanced Input — one set of Input Actions for gameplay and UI, no duplicate input data assets
+- Subtitle UI: new `QueueSingleSubtitle()` / `QueueSubtitlesFromAsset()` APIs (Beta) with per-platform overrides
 
 ---
 
@@ -349,5 +356,5 @@ SetVisibility(ESlateVisibility::Collapsed); // Collapsed = not rendered
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/umg-ui-designer-for-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/commonui-plugin-for-advanced-user-interfaces-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/umg-ui-designer-for-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/commonui-plugin-for-advanced-user-interfaces-in-unreal-engine/

--- a/docs/engine-reference/unreal/plugins/common-ui.md
+++ b/docs/engine-reference/unreal/plugins/common-ui.md
@@ -1,6 +1,6 @@
-# Unreal Engine 5.7 — CommonUI Plugin
+# Unreal Engine 5.8 — CommonUI Plugin
 
-**Last verified:** 2026-02-13
+**Last verified:** 2026-08-16
 **Status:** Production-Ready
 **Plugin:** `CommonUI` (built-in, enable in Plugins)
 
@@ -11,6 +11,11 @@
 **CommonUI** is a cross-platform UI framework that automatically handles input routing
 for gamepad, mouse, and touch. It's designed for games that need to work seamlessly
 across PC, console, and mobile platforms with minimal platform-specific code.
+
+> **UE 5.8 change — Unified Input:** CommonUI input routing is now unified with
+> Enhanced Input. One set of Input Actions drives both gameplay and UI; do NOT
+> create duplicate CommonUI-specific input data assets. Pre-5.8 guides that show
+> separate CommonUI input action data tables are outdated on this point.
 
 **Use CommonUI for:**
 - Multi-platform games (console + PC)
@@ -385,5 +390,5 @@ protected:
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/commonui-plugin-for-advanced-user-interfaces-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/commonui-quickstart-guide-for-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/commonui-plugin-for-advanced-user-interfaces-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/commonui-quickstart-guide-for-unreal-engine/

--- a/docs/engine-reference/unreal/plugins/gameplay-ability-system.md
+++ b/docs/engine-reference/unreal/plugins/gameplay-ability-system.md
@@ -1,6 +1,6 @@
-# Unreal Engine 5.7 — Gameplay Ability System (GAS)
+# Unreal Engine 5.8 — Gameplay Ability System (GAS)
 
-**Last verified:** 2026-02-13
+**Last verified:** 2026-08-16
 **Status:** Production-Ready
 **Plugin:** `GameplayAbilities` (built-in, enable in Plugins)
 
@@ -382,5 +382,5 @@ void AMyCharacter::OnHealthChanged(const FOnAttributeChangeData& Data) {
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/gameplay-ability-system-for-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/gameplay-ability-system-for-unreal-engine/
 - https://github.com/tranek/GASDocumentation (community guide)

--- a/docs/engine-reference/unreal/plugins/gameplay-camera-system.md
+++ b/docs/engine-reference/unreal/plugins/gameplay-camera-system.md
@@ -1,6 +1,6 @@
-# Unreal Engine 5.7 — Gameplay Camera System
+# Unreal Engine 5.8 — Gameplay Camera System
 
-**Last verified:** 2026-02-13
+**Last verified:** 2026-08-16
 **Status:** ⚠️ Experimental (introduced in UE 5.5)
 **Plugin:** `GameplayCameras` (built-in, enable in Plugins)
 
@@ -18,7 +18,7 @@ camera modes, blending, and context-aware camera behavior.
 - Smooth camera blending between modes
 - Procedural camera motion (camera shake, lag, offset)
 
-**⚠️ Warning:** This plugin is experimental in UE 5.5-5.7. Expect API changes in future versions.
+**⚠️ Warning:** This plugin is experimental in UE 5.5-5.8. Expect API changes in future versions.
 
 ---
 
@@ -316,6 +316,6 @@ UGameplayCameraComponent* CameraComponent;
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/gameplay-cameras-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/gameplay-cameras-in-unreal-engine/
 - UE 5.5+ Release Notes
 - **Note:** This system is experimental. Always check latest official docs for API changes.

--- a/docs/engine-reference/unreal/plugins/pcg.md
+++ b/docs/engine-reference/unreal/plugins/pcg.md
@@ -1,6 +1,6 @@
-# Unreal Engine 5.7 — PCG (Procedural Content Generation)
+# Unreal Engine 5.8 — PCG (Procedural Content Generation)
 
-**Last verified:** 2026-02-13
+**Last verified:** 2026-08-16
 **Status:** Production-Ready (as of UE 5.7)
 **Plugin:** `PCG` (built-in, enable in Plugins)
 
@@ -24,6 +24,17 @@ foliage, rocks, props, buildings, and other environmental detail.
 - One-off manual placement (use editor tools)
 
 **⚠️ Note:** PCG was experimental in UE 5.0-5.6, became production-ready in UE 5.7.
+
+---
+
+## What's New in UE 5.8
+
+- **Manual editing**: non-destructive editing of PCG output via selection and exclusion — hand-tweak generated content without breaking regeneration
+- **Complex attributes**: arrays, structures, sets, and maps supported as metadata
+- **Embedded subgraphs**: custom subgraphs can be stored inside PCG graphs
+- **Graph Parameters Editor**: parameter categorization and hierarchy tools
+- **GPU runtime performance**: now within the same performance range as the landscape GPU grass system
+- **Procedural Vegetation Editor (Experimental)**: in-engine vegetation creation with growth, grafting, and trimming
 
 ---
 
@@ -351,6 +362,6 @@ Street Light Spawner
 ---
 
 ## Sources
-- https://docs.unrealengine.com/5.7/en-US/procedural-content-generation-in-unreal-engine/
-- https://docs.unrealengine.com/5.7/en-US/pcg-quick-start-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/procedural-content-generation-in-unreal-engine/
+- https://docs.unrealengine.com/5.8/en-US/pcg-quick-start-in-unreal-engine/
 - UE 5.7 Release Notes (PCG Production-Ready announcement)


### PR DESCRIPTION
## Summary

Attempts to give Clade the expertise / "support" for Unreal Engine 5.8

Upgraded with two Fable 5 sessions. The first one on `high` effort did the initial upgrade.
The 2nd with `xhigh` effort did the review and polished some inconsistencies.

## Type of Change

- [ ] New agent
- [x] New skill - Unreal Engine 5.8
- [ ] New hook or rule
- [ ] Bug fix
- [x] Documentation improvement - Yes fixed some inconsistencies in the documentation
- [ ] Other:

## Changes
- Adde `Version Awareness` sections telling Claude if using UE5.8 to verify against the documentation first.
- 


## Checklist

- [ ] I've tested this in a Claude Code session - IN PROGRESS
- [ ] New agents include the Collaboration Protocol section
- [ ] New skills use the subdirectory format (`.claude/skills/<name>/SKILL.md`)
- [x] Reference docs are updated (agent-roster, skills-reference, hooks-reference, rules-reference)
- [ ] Hooks use `grep -E` (POSIX) and fail gracefully without jq/python
- [ ] No hardcoded paths or platform-specific assumptions

---
# Additional Info
While I am about to test this soon I also attempted to gain understanding what the implication to be if using this with UE5.8 so here are Claude's answers.

### How working with UE5.8 will impact the work: 
1. First, tell me when is your knowledge cutoff date and is it before or after UE5.8 was released.
2. 2nd What happens when you get asked about UE5.8 how do you come to the answer.
3.  3rd, what are the implications if when one works with UE5.8 and asks you for help?

### Answers
#### 1. My knowledge cutoff vs UE 5.8

My training cutoff is January 2026. UE 5.8 was released June 2026 — about five months after my cutoff. I have zero training data about it: not its features, not its APIs, not even the fact that it exists. And in practice the gap is wider than the hard cutoff suggests — deep, reliable coverage of an engine needs time for docs, tutorials, and forum discussion to accumulate, so my genuinely trustworthy Unreal knowledge is more like `~5.3`, which is exactly what your `VERSION.md` assumes. (The docs record "LLM Knowledge Cutoff: May 2025" — older than my actual cutoff, but keeping the conservative floor is correct since other models/agents may serve this project.)

#### 2. How I answer UE 5.8 questions

In layers:

1. Training data for the stable core — `AActor/UObject` lifecycle, `UPROPERT`Y, replication basics, `UMG`, `GAS` fundamentals. These APIs are years old and barely change; my knowledge there is solid.
4. The curated reference library (`docs/engine-reference/unreal/`) for everything post-cutoff. It was populated by live web research — the previous session fetched Epic's actual 5.8 release notes and migration guides and distilled them into these files. When I say "WASAPI is the Windows default in 5.8," I'm reading that from the repo, not remembering it.
5. Live WebSearch for anything the docs don't cover.

The dangerous failure mode is skipping layers 2–3: I would then extrapolate from 5.0–5.3 patterns and produce fluent, plausible, confidently-worded answers that can be silently wrong — with no internal signal that I'm guessing. That's precisely why this upgrade wired the "Version Awareness" section into all five UE specialist agents: it forces the doc check before any API suggestion.

#### 3. Implications when you work with UE 5.8 and ask me for help

- Concrete examples of what I'd get wrong unaided, all from this very upgrade: I'd assume XAudio2 is the Windows audio backend (it's WASAPI now), wouldn't know 5.8 requires VS2026/MSVC v145 and BuildSettingsVersion.V7, wouldn't know Iris and Mutable went production-ready, and wouldn't warn you that Sequencer looping behavior changed.
- Trust calibration: core gameplay C++/Blueprint questions — fine. Anything involving defaults, build config, plugin maturity status, or "what's the modern way to do X" — only trust answers that cite the reference docs or fresh web results. If I name a 5.8 API without a reference, treat it as unverified.
- The docs are the single point of failure: a curation error propagates into every answer. My review caught exactly this class of bug — the docs claimed Mutable was "Experimental in 5.5–5.7" when it's been Experimental since UE 5.2 (the one 5.8-doc claim I could check against training, and it was wrong — a useful calibration signal). Re-verify the docs as 5.8.x hotfixes land, and update Last Docs Verified when you do.
